### PR TITLE
feat: Odinエディタ拡張 + エディタ便利メソッド追加

### DIFF
--- a/Assets/MyAsset/Core/Common/Structs.cs
+++ b/Assets/MyAsset/Core/Common/Structs.cs
@@ -1,4 +1,5 @@
 using System;
+using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace Game.Core
@@ -7,18 +8,35 @@ namespace Game.Core
     /// 7属性（斬撃/打撃/刺突/炎/雷/聖/闇）のステータス値。
     /// 攻撃力・防御力・ダメージの各チャネルで使用する。
     /// </summary>
-    [Serializable]
+    [Serializable, InlineProperty]
     public struct ElementalStatus
     {
+        [HorizontalGroup("Physical", LabelWidth = 40)]
+        [LabelText("斬")]
         public int slash;
+        [HorizontalGroup("Physical", LabelWidth = 40)]
+        [LabelText("打")]
         public int strike;
+        [HorizontalGroup("Physical", LabelWidth = 40)]
+        [LabelText("突")]
         public int pierce;
+
+        [HorizontalGroup("Magical", LabelWidth = 40)]
+        [LabelText("炎")]
         public int fire;
+        [HorizontalGroup("Magical", LabelWidth = 40)]
+        [LabelText("雷")]
         public int thunder;
+        [HorizontalGroup("Magical", LabelWidth = 40)]
+        [LabelText("聖")]
         public int light;
+        [HorizontalGroup("Magical", LabelWidth = 40)]
+        [LabelText("闇")]
         public int dark;
 
+        [ShowInInspector, ReadOnly, LabelText("合計")]
         public int Total => slash + strike + pierce + fire + thunder + light + dark;
+
         public int PhysicalTotal => slash + strike + pierce;
 
         public int Get(Element element)
@@ -40,18 +58,27 @@ namespace Game.Core
     /// <summary>
     /// 7属性別のガードカット率。
     /// </summary>
-    [Serializable]
+    [Serializable, InlineProperty]
     public struct GuardStats
     {
-        public float slashCut;
-        public float strikeCut;
-        public float pierceCut;
-        public float fireCut;
-        public float thunderCut;
-        public float lightCut;
-        public float darkCut;
-        public float guardStrength;
-        public float statusCut;
+        [HorizontalGroup("Cuts", LabelWidth = 40)]
+        [LabelText("斬"), Range(0f, 1f)] public float slashCut;
+        [HorizontalGroup("Cuts", LabelWidth = 40)]
+        [LabelText("打"), Range(0f, 1f)] public float strikeCut;
+        [HorizontalGroup("Cuts", LabelWidth = 40)]
+        [LabelText("突"), Range(0f, 1f)] public float pierceCut;
+
+        [HorizontalGroup("MagicCuts", LabelWidth = 40)]
+        [LabelText("炎"), Range(0f, 1f)] public float fireCut;
+        [HorizontalGroup("MagicCuts", LabelWidth = 40)]
+        [LabelText("雷"), Range(0f, 1f)] public float thunderCut;
+        [HorizontalGroup("MagicCuts", LabelWidth = 40)]
+        [LabelText("聖"), Range(0f, 1f)] public float lightCut;
+        [HorizontalGroup("MagicCuts", LabelWidth = 40)]
+        [LabelText("闇"), Range(0f, 1f)] public float darkCut;
+
+        [MinValue(0)] public float guardStrength;
+        [Range(0f, 1f)] public float statusCut;
     }
 
     [Serializable]
@@ -73,23 +100,27 @@ namespace Game.Core
     public struct StatusEffectInfo
     {
         public StatusEffectId effect;
-        public float accumulateValue;   // 1ヒット蓄積量
-        public float duration;          // 発症持続時間(秒)
-        public float tickDamage;        // tick毎ダメージ(DoT)
-        public float tickInterval;      // tick間隔(秒)
-        public float modifier;          // 効果量(速度低下率等)
-        public byte maxStack;           // 最大スタック数(0=スタック不可)
+        [MinValue(0)] public float accumulateValue;
+        [MinValue(0)] public float duration;
+        [MinValue(0)] public float tickDamage;
+        [MinValue(0)] public float tickInterval;
+        [Range(0f, 1f)] public float modifier;
+        [Tooltip("0=スタック不可")]
+        public byte maxStack;
     }
 
     /// <summary>
     /// 物理タイプ別耐性（斬撃/打撃/刺突）。
     /// </summary>
-    [Serializable]
+    [Serializable, InlineProperty]
     public struct PhysicalResistance
     {
-        public float slashResist;
-        public float strikeResist;
-        public float pierceResist;
+        [HorizontalGroup("Resist", LabelWidth = 40)]
+        [LabelText("斬"), Range(0f, 1f)] public float slashResist;
+        [HorizontalGroup("Resist", LabelWidth = 40)]
+        [LabelText("打"), Range(0f, 1f)] public float strikeResist;
+        [HorizontalGroup("Resist", LabelWidth = 40)]
+        [LabelText("突"), Range(0f, 1f)] public float pierceResist;
     }
 
     public struct MovementInfo
@@ -118,8 +149,8 @@ namespace Game.Core
         public int defenderHash;
         public ElementalStatus damage;
         public float motionValue;
-        public Vector2 knockbackForce;          // XY軸別の吹き飛ばし強度
-        public Element attackElement;           // 主属性
+        public Vector2 knockbackForce;
+        public Element attackElement;
         public StatusEffectInfo statusEffectInfo;
         public AttackFeature feature;
         public float armorBreakValue;
@@ -140,36 +171,44 @@ namespace Game.Core
     [Serializable]
     public struct AttackMotionData
     {
-        [Header("基本")]
-        public float motionValue;
-        public Element attackElement;
+        [FoldoutGroup("基本")]
+        [MinValue(0)] public float motionValue;
+        [FoldoutGroup("基本")]
+        [EnumToggleButtons] public Element attackElement;
+        [FoldoutGroup("基本")]
         public AttackFeature feature;
 
-        [Header("コスト")]
-        public float staminaCost;
-        public float mpCost;
+        [FoldoutGroup("コスト")]
+        [MinValue(0)] public float staminaCost;
+        [FoldoutGroup("コスト")]
+        [MinValue(0)] public float mpCost;
 
-        [Header("ヒット")]
-        public int maxHitCount;
-        public float armorBreakValue;
+        [FoldoutGroup("ヒット")]
+        [MinValue(1)] public int maxHitCount;
+        [FoldoutGroup("ヒット")]
+        [MinValue(0)] public float armorBreakValue;
 
-        [Header("ノックバック")]
+        [FoldoutGroup("ノックバック")]
         public Vector2 knockbackForce;
 
-        [Header("状態異常")]
-        public StatusEffectInfo statusEffect;
+        [FoldoutGroup("状態異常")]
+        [InlineProperty] public StatusEffectInfo statusEffect;
 
-        [Header("移動")]
-        public float attackMoveDistance;
-        public float attackMoveDuration;
+        [FoldoutGroup("移動")]
+        [MinValue(0)] public float attackMoveDistance;
+        [FoldoutGroup("移動")]
+        [MinValue(0)] public float attackMoveDuration;
+        [FoldoutGroup("移動")]
         public AttackContactType contactType;
 
-        [Header("コンボ")]
+        [FoldoutGroup("コンボ")]
         public bool isAutoChain;
+        [FoldoutGroup("コンボ")]
         public bool isChainEndPoint;
-        public float inputWindow;
+        [FoldoutGroup("コンボ")]
+        [MinValue(0)] public float inputWindow;
 
-        [Header("ガード関連")]
-        public float justGuardResistance;
+        [FoldoutGroup("ガード関連")]
+        [Range(0f, 100f)] public float justGuardResistance;
     }
 }

--- a/Assets/MyAsset/Core/ScriptableObjects/AIInfo.cs
+++ b/Assets/MyAsset/Core/ScriptableObjects/AIInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace Game.Core
@@ -10,16 +11,20 @@ namespace Game.Core
     [CreateAssetMenu(fileName = "NewAIInfo", menuName = "Game/AIInfo")]
     public class AIInfo : ScriptableObject
     {
-        [Header("モード設定")]
+        [TitleGroup("モード設定")]
+        [ListDrawerSettings(ShowFoldout = true, DraggableItems = true)]
         public CharacterModeData[] modes;
 
-        [Header("行動定義")]
+        [TitleGroup("行動定義")]
+        [ListDrawerSettings(ShowFoldout = true, DraggableItems = true)]
         public ActData[] actDataList;
 
-        [Header("クールタイム")]
+        [TitleGroup("クールタイム")]
+        [InlineProperty]
         public CoolTimeData coolTimeData;
 
-        [Header("仲間AI設定")]
+        [TitleGroup("仲間AI設定")]
+        [InlineProperty]
         public CompanionBehaviorSetting companionSetting;
     }
 
@@ -51,19 +56,35 @@ namespace Game.Core
     [Serializable]
     public struct CharacterModeData
     {
+        [EnumToggleButtons]
         public CharacterMode mode;
+
+        [FoldoutGroup("検知範囲")]
+        [MinValue(0)]
         public float detectionRange;
+
+        [FoldoutGroup("検知範囲")]
+        [MinValue(0)]
         public float combatRange;
+
+        [FoldoutGroup("検知範囲")]
+        [Range(0f, 1f)]
         public float retreatHpThreshold;
+
+        [Tooltip("actDataList のインデックス")]
         public int[] availableActIndices;
+
+        [ListDrawerSettings(ShowFoldout = true)]
         public TransitionCondition[] transitions;
     }
 
     [Serializable]
     public struct TransitionCondition
     {
+        [EnumToggleButtons]
         public CharacterMode targetMode;
         public TriggerType trigger;
+        [MinValue(0)]
         public float threshold;
     }
 
@@ -80,21 +101,49 @@ namespace Game.Core
     [Serializable]
     public struct ActData
     {
+        [LabelText("$actName")]
+        [FoldoutGroup("基本")]
         public string actName;
+
+        [FoldoutGroup("基本")]
+        [EnumToggleButtons]
         public ActType actType;
+
+        [FoldoutGroup("基本")]
+        [Tooltip("AttackInfo配列のインデックス")]
         public int attackInfoIndex;
-        public TriggerJudgeData triggerJudge;
-        public TargetJudgeData targetJudge;
-        public ActJudgeData actJudge;
+
+        [FoldoutGroup("基本")]
+        [Range(0f, 100f)]
         public float weight;
+
+        [FoldoutGroup("基本")]
+        [MinValue(0)]
         public float coolTime;
+
+        [FoldoutGroup("基本")]
+        [Tooltip("0=無制限")]
+        [MinValue(0)]
         public int maxUseCount;
+
+        [FoldoutGroup("判定条件")]
+        [InlineProperty]
+        public TriggerJudgeData triggerJudge;
+
+        [FoldoutGroup("判定条件")]
+        [InlineProperty]
+        public TargetJudgeData targetJudge;
+
+        [FoldoutGroup("判定条件")]
+        [InlineProperty]
+        public ActJudgeData actJudge;
     }
 
     [Serializable]
     public struct TriggerJudgeData
     {
         public TriggerConditionType condition;
+        [MinValue(0)]
         public float value;
         public ComparisonOperator comparison;
     }
@@ -123,8 +172,11 @@ namespace Game.Core
     public struct TargetJudgeData
     {
         public TargetSelectionType selectionType;
+        [MinValue(0)]
         public float maxRange;
+        [MinValue(0)]
         public float minRange;
+        [EnumToggleButtons]
         public CharacterBelong targetBelong;
         public TargetFilter targetFilter;
     }
@@ -143,9 +195,13 @@ namespace Game.Core
     [Serializable]
     public struct ActJudgeData
     {
+        [MinValue(0)]
         public float requiredMp;
+        [MinValue(0)]
         public float requiredStamina;
+        [Range(0f, 1f)]
         public float minHpRatio;
+        [Range(0f, 1f)]
         public float maxHpRatio;
         public bool requireLineOfSight;
         public bool requireGrounded;
@@ -154,20 +210,20 @@ namespace Game.Core
     [Serializable]
     public struct CoolTimeData
     {
-        public float globalCoolTime;
-        public float attackCoolTime;
-        public float skillCoolTime;
-        public float guardCoolTime;
-        public float dodgeCoolTime;
-        public float healCoolTime;
+        [MinValue(0)] public float globalCoolTime;
+        [MinValue(0)] public float attackCoolTime;
+        [MinValue(0)] public float skillCoolTime;
+        [MinValue(0)] public float guardCoolTime;
+        [MinValue(0)] public float dodgeCoolTime;
+        [MinValue(0)] public float healCoolTime;
     }
 
     [Serializable]
     public struct CompanionBehaviorSetting
     {
-        public float followDistance;
-        public float maxLeashDistance;
-        public float supportHpThreshold;
+        [MinValue(0)] public float followDistance;
+        [MinValue(0)] public float maxLeashDistance;
+        [Range(0f, 1f)] public float supportHpThreshold;
         public bool autoHeal;
         public bool prioritizePlayerTarget;
         public CompanionStance defaultStance;

--- a/Assets/MyAsset/Core/ScriptableObjects/AttackInfo.cs
+++ b/Assets/MyAsset/Core/ScriptableObjects/AttackInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace Game.Core
@@ -9,119 +10,192 @@ namespace Game.Core
     [CreateAssetMenu(fileName = "NewAttackInfo", menuName = "Game/AttackInfo")]
     public class AttackInfo : ScriptableObject
     {
-        [Header("基本情報")]
+        [TitleGroup("基本情報")]
         public string attackName;
+
+        [TitleGroup("基本情報")]
+        [EnumToggleButtons]
         public AttackCategory category;
 
-        [Header("モーション")]
+        [TitleGroup("モーション")]
+        [InlineProperty]
         public MotionInfo motionInfo;
 
-        [Header("ダメージ")]
+        [TitleGroup("ダメージ")]
         public ElementalStatus baseDamage;
+
+        [TitleGroup("ダメージ")]
+        [MinValue(0)]
         public float damageMultiplier;
 
-        [Header("エフェクト・サウンド")]
+        [TitleGroup("エフェクト・サウンド")]
+        [InlineProperty]
         public EffectSoundInfo effectSoundInfo;
 
-        [Header("飛翔体")]
+        [TitleGroup("飛翔体")]
+        [InlineProperty]
         public ProjectileInfo projectileInfo;
 
-        [Header("吹き飛ばし")]
+        [TitleGroup("吹き飛ばし")]
+        [InlineProperty]
         public KnockbackInfo knockbackInfo;
 
-        [Header("状態異常")]
+        [TitleGroup("状態異常")]
+        [InlineProperty]
         public StatusEffectInfo statusEffectInfo;
 
-        [Header("コスト")]
+        [TitleGroup("コスト")]
+        [MinValue(0)]
         public float mpCost;
+
+        [TitleGroup("コスト")]
+        [MinValue(0)]
         public float staminaCost;
 
-        [Header("AI認識用")]
+        [TitleGroup("AI認識用")]
+        [InlineProperty]
         public AIAttackEvaluation aiEvaluation;
 
-        [Header("攻撃移動")]
+        [TitleGroup("攻撃移動")]
+        [MinValue(0)]
         public float attackMoveDistance;
+
+        [TitleGroup("攻撃移動")]
+        [MinValue(0)]
         public float attackMoveDuration;
+
+        [TitleGroup("攻撃移動")]
         public AttackContactType contactType;
 
-        [Header("パリィ・ガード")]
+        [TitleGroup("パリィ・ガード")]
         public bool isParriable;
+
+        [TitleGroup("パリィ・ガード")]
+        [MinValue(0)]
         public float armorBreakValue;
 
-        [Header("属性")]
+        [TitleGroup("属性")]
+        [EnumToggleButtons]
         public Element attackElement;
 
-        [Header("コンボ")]
+        [TitleGroup("コンボ")]
         public bool isAutoChain;
+
+        [TitleGroup("コンボ")]
         public bool isChainEndPoint;
+
+        [TitleGroup("コンボ")]
+        [MinValue(0)]
         public float inputWindow;
+
+        [TitleGroup("コンボ")]
+        [Range(0f, 100f)]
         public float justGuardResistance;
     }
 
     [Serializable]
     public struct MotionInfo
     {
-        public float preMotionDuration;
-        public float activeMotionDuration;
-        public float recoveryDuration;
-        public float chargeTimeMin;
-        public float chargeTimeMax;
-        public float chargeDamageMultiplier;
+        [FoldoutGroup("タイミング")]
+        [MinValue(0)] public float preMotionDuration;
+        [FoldoutGroup("タイミング")]
+        [MinValue(0)] public float activeMotionDuration;
+        [FoldoutGroup("タイミング")]
+        [MinValue(0)] public float recoveryDuration;
+
+        [FoldoutGroup("チャージ")]
+        [MinValue(0)] public float chargeTimeMin;
+        [FoldoutGroup("チャージ")]
+        [MinValue(0)] public float chargeTimeMax;
+        [FoldoutGroup("チャージ")]
+        [MinValue(0)] public float chargeDamageMultiplier;
+
+        [FoldoutGroup("アニメーション")]
         public AnimationClip preMotionClip;
+        [FoldoutGroup("アニメーション")]
         public AnimationClip activeClip;
+        [FoldoutGroup("アニメーション")]
         public AnimationClip chargeLoopClip;
+        [FoldoutGroup("アニメーション")]
         public AnimationClip recoveryClip;
     }
 
     [Serializable]
     public struct EffectSoundInfo
     {
+        [FoldoutGroup("エフェクト")]
         public GameObject hitEffect;
+        [FoldoutGroup("エフェクト")]
         public GameObject castEffect;
+        [FoldoutGroup("エフェクト")]
         public GameObject chargeEffect;
+        [FoldoutGroup("エフェクト")]
         public GameObject trailEffect;
+
+        [FoldoutGroup("サウンド")]
         public AudioClip attackSound;
+        [FoldoutGroup("サウンド")]
         public AudioClip hitSound;
+        [FoldoutGroup("サウンド")]
         public AudioClip chargeSound;
+        [FoldoutGroup("サウンド")]
         public AudioClip chargeCompleteSound;
     }
 
     [Serializable]
     public struct ProjectileInfo
     {
+        [ToggleGroup("hasProjectile", "飛翔体設定")]
         public bool hasProjectile;
+
+        [ToggleGroup("hasProjectile")]
         public GameObject projectilePrefab;
+        [ToggleGroup("hasProjectile")]
         public BulletMoveType trajectory;
-        public float speed;
-        public float lifetime;
-        public float homingStrength;
-        public int pierceCount;
-        public float aoeRadius;
-        public int projectileCount;
-        public float spreadAngle;
+        [ToggleGroup("hasProjectile")]
+        [MinValue(0)] public float speed;
+        [ToggleGroup("hasProjectile")]
+        [MinValue(0)] public float lifetime;
+        [ToggleGroup("hasProjectile")]
+        [MinValue(0)] public float homingStrength;
+        [ToggleGroup("hasProjectile")]
+        [MinValue(0)] public int pierceCount;
+        [ToggleGroup("hasProjectile")]
+        [MinValue(0)] public float aoeRadius;
+        [ToggleGroup("hasProjectile")]
+        [MinValue(1)] public int projectileCount;
+        [ToggleGroup("hasProjectile")]
+        [Range(0f, 360f)] public float spreadAngle;
     }
 
     [Serializable]
     public struct KnockbackInfo
     {
+        [ToggleGroup("hasKnockback", "ノックバック設定")]
         public bool hasKnockback;
+
+        [ToggleGroup("hasKnockback")]
         public Vector2 force;
-        public float stunDuration;
+        [ToggleGroup("hasKnockback")]
+        [MinValue(0)] public float stunDuration;
+        [ToggleGroup("hasKnockback")]
         public bool groundBounce;
+        [ToggleGroup("hasKnockback")]
         public bool wallBounce;
-        public float gravityScale;
+        [ToggleGroup("hasKnockback")]
+        [MinValue(0)] public float gravityScale;
     }
 
     [Serializable]
     public struct AIAttackEvaluation
     {
-        public float effectiveRangeMin;
-        public float effectiveRangeMax;
-        public float threatLevel;
+        [MinValue(0)] public float effectiveRangeMin;
+        [MinValue(0)] public float effectiveRangeMax;
+        [Range(0f, 10f)] public float threatLevel;
         public bool isBlockable;
         public bool isParriable;
-        public float totalWindupTime;
-        public float preferredUseHpThreshold;
+        [MinValue(0)] public float totalWindupTime;
+        [Range(0f, 1f)] public float preferredUseHpThreshold;
         public byte priority;
     }
 }

--- a/Assets/MyAsset/Core/ScriptableObjects/CharacterInfo.cs
+++ b/Assets/MyAsset/Core/ScriptableObjects/CharacterInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace Game.Core
@@ -13,59 +14,104 @@ namespace Game.Core
         // ─────────────────────────────────────────────
         //  キャラクター識別
         // ─────────────────────────────────────────────
-        [Header("キャラクター識別")]
-        public CharacterFeature feature;      // Player / Boss / NPC / Minion 等
-        public CharacterBelong belong;        // 陣営（味方・敵・中立）
-        public CharacterRank rank;            // 強さランク（AI脅威度評価に使用）
-        public bool canFly;                   // 飛行可能か
-        public int targetingLimit;            // 同時にターゲットされる上限数
+        [TitleGroup("キャラクター識別")]
+        [EnumToggleButtons]
+        public CharacterFeature feature;
+
+        [TitleGroup("キャラクター識別")]
+        [EnumToggleButtons]
+        public CharacterBelong belong;
+
+        [TitleGroup("キャラクター識別")]
+        public CharacterRank rank;
+
+        [TitleGroup("キャラクター識別")]
+        public bool canFly;
+
+        [TitleGroup("キャラクター識別")]
+        [Tooltip("同時にターゲットされる上限数")]
+        [MinValue(0)]
+        public int targetingLimit;
 
         // ─────────────────────────────────────────────
         //  基礎ステータス
         // ─────────────────────────────────────────────
-        [Header("基礎ステータス")]
+        [TitleGroup("基礎ステータス")]
+        [MinValue(1)]
         public int maxHp;
+
+        [TitleGroup("基礎ステータス")]
+        [MinValue(0)]
         public int maxMp;
+
+        [TitleGroup("基礎ステータス")]
+        [MinValue(0)]
         public float maxStamina;
-        public float staminaRecoveryRate;     // スタミナ回復速度（/秒）
-        public float staminaRecoveryDelay;    // 消費後の回復開始までの遅延（秒）
+
+        [TitleGroup("基礎ステータス")]
+        [Tooltip("スタミナ回復速度（/秒）")]
+        [MinValue(0)]
+        public float staminaRecoveryRate;
+
+        [TitleGroup("基礎ステータス")]
+        [Tooltip("消費後の回復開始までの遅延（秒）")]
+        [MinValue(0)]
+        public float staminaRecoveryDelay;
 
         // ─────────────────────────────────────────────
         //  属性攻撃力・防御力（7属性）
         // ─────────────────────────────────────────────
-        [Header("属性攻撃力")]
-        public ElementalStatus baseAttack;    // 7属性の基礎攻撃力
+        [TitleGroup("属性攻撃力")]
+        public ElementalStatus baseAttack;
 
-        [Header("属性防御力")]
-        public ElementalStatus baseDefense;   // 7属性の基礎防御力
+        [TitleGroup("属性防御力")]
+        public ElementalStatus baseDefense;
 
         // ─────────────────────────────────────────────
         //  弱点・攻撃属性
         // ─────────────────────────────────────────────
-        [Header("弱点属性")]
-        public Element weakPoint;             // 弱点属性
-        public Element attackElement;         // メイン攻撃属性
+        [TitleGroup("弱点・属性")]
+        [EnumToggleButtons]
+        public Element weakPoint;
+
+        [TitleGroup("弱点・属性")]
+        [EnumToggleButtons]
+        public Element attackElement;
 
         // ─────────────────────────────────────────────
         //  アクション設定
         // ─────────────────────────────────────────────
-        [Header("アクション設定")]
+        [TitleGroup("アクション設定")]
+        [MinValue(0)]
         public float moveSpeed;
+
+        [TitleGroup("アクション設定")]
+        [MinValue(0)]
         public float walkSpeed;
+
+        [TitleGroup("アクション設定")]
+        [MinValue(0)]
         public float dashSpeed;
+
+        [TitleGroup("アクション設定")]
+        [MinValue(0)]
         public float jumpHeight;
 
         // ─────────────────────────────────────────────
         //  耐性
         // ─────────────────────────────────────────────
-        [Header("耐性")]
-        public float statusResistance;            // 基礎状態異常耐性（蓄積閾値のグローバル倍率）
-        public PhysicalResistance physicalResistance; // 物理タイプ別耐性（斬撃/打撃/刺突）
+        [TitleGroup("耐性")]
+        [Tooltip("基礎状態異常耐性（蓄積閾値のグローバル倍率）")]
+        [Range(0f, 1f)]
+        public float statusResistance;
+
+        [TitleGroup("耐性")]
+        public PhysicalResistance physicalResistance;
 
         // ─────────────────────────────────────────────
         //  初期状態
         // ─────────────────────────────────────────────
-        [Header("初期状態")]
-        public ActState initialActState;      // スポーン時の初期行動状態
+        [TitleGroup("初期状態")]
+        public ActState initialActState;
     }
 }

--- a/Assets/MyAsset/Core/World/Challenge/ChallengeDefinition.cs
+++ b/Assets/MyAsset/Core/World/Challenge/ChallengeDefinition.cs
@@ -1,3 +1,4 @@
+using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace Game.Core
@@ -10,30 +11,67 @@ namespace Game.Core
     [CreateAssetMenu(fileName = "NewChallenge", menuName = "Game/Challenge/ChallengeDefinition")]
     public class ChallengeDefinition : ScriptableObject
     {
-        [Header("基本情報")]
+        [TitleGroup("基本情報")]
         [SerializeField] private string challengeId;
+
+        [TitleGroup("基本情報")]
         [SerializeField] private string challengeName;
+
+        [TitleGroup("基本情報")]
+        [TextArea(2, 4)]
         [SerializeField] private string description;
+
+        [TitleGroup("基本情報")]
+        [EnumToggleButtons]
         [SerializeField] private ChallengeType challengeType;
 
-        [Header("制限")]
+        [TitleGroup("制限")]
+        [MinValue(0)]
         [SerializeField] private float timeLimit;
+
+        [TitleGroup("制限")]
+        [MinValue(0)]
         [SerializeField] private int maxDeathCount;
 
-        [Header("コンテンツ")]
+        [TitleGroup("コンテンツ")]
+        [ShowIf("@challengeType == ChallengeType.BossRush")]
         [SerializeField] private string[] bossIds;
+
+        [TitleGroup("コンテンツ")]
+        [ShowIf("@challengeType == ChallengeType.Survival")]
+        [MinValue(0)]
         [SerializeField] private int waveCount;
+
+        [TitleGroup("コンテンツ")]
+        [ShowIf("@challengeType == ChallengeType.Survival")]
+        [MinValue(0)]
         [SerializeField] private int enemiesPerWave;
+
+        [TitleGroup("コンテンツ")]
+        [MinValue(0)]
         [SerializeField] private int levelCap;
 
-        [Header("ランク閾値")]
+        [TitleGroup("ランク閾値")]
+        [MinValue(0)]
         [SerializeField] private float silverTimeThreshold;
+
+        [TitleGroup("ランク閾値")]
+        [MinValue(0)]
         [SerializeField] private float goldTimeThreshold;
+
+        [TitleGroup("ランク閾値")]
+        [MinValue(0)]
         [SerializeField] private int goldScoreThreshold;
+
+        [TitleGroup("ランク閾値")]
+        [MinValue(0)]
         [SerializeField] private int platinumScoreThreshold;
 
-        [Header("報酬")]
+        [TitleGroup("報酬")]
+        [MinValue(0)]
         [SerializeField] private int currencyReward;
+
+        [TitleGroup("報酬")]
         [SerializeField] private string itemRewardId;
 
         // === Properties ===

--- a/Assets/MyAsset/Editor/AIInfoEditor.cs
+++ b/Assets/MyAsset/Editor/AIInfoEditor.cs
@@ -1,0 +1,92 @@
+#if UNITY_EDITOR
+using Sirenix.OdinInspector.Editor;
+using UnityEditor;
+using UnityEngine;
+using Game.Core;
+
+namespace Game.Editor
+{
+    [CustomEditor(typeof(AIInfo))]
+    public class AIInfoEditor : OdinEditor
+    {
+        public override void OnInspectorGUI()
+        {
+            AIInfo info = (AIInfo)target;
+
+            // タイトル
+            GUIStyle titleStyle = new GUIStyle(EditorStyles.boldLabel)
+            {
+                fontSize = 14,
+                alignment = TextAnchor.MiddleCenter
+            };
+            EditorGUILayout.LabelField("AI行動データ設定", titleStyle);
+            EditorGUILayout.Space(4);
+
+            // サマリー
+            int modeCount = info.modes != null ? info.modes.Length : 0;
+            int actCount = info.actDataList != null ? info.actDataList.Length : 0;
+            EditorGUILayout.HelpBox(
+                $"モード数: {modeCount} / 行動数: {actCount}\n" +
+                $"グローバルCT: {info.coolTimeData.globalCoolTime}s\n" +
+                $"仲間設定: 追従距離{info.companionSetting.followDistance} / " +
+                $"リーシュ{info.companionSetting.maxLeashDistance}",
+                MessageType.Info);
+
+            EditorGUILayout.Space(4);
+            base.OnInspectorGUI();
+
+            // バリデーション
+            EditorGUILayout.Space(8);
+            ValidateAIInfo(info);
+        }
+
+        private void ValidateAIInfo(AIInfo info)
+        {
+            if (info.modes == null || info.modes.Length == 0)
+            {
+                EditorGUILayout.HelpBox("モードが未設定です。最低1つのモードが必要です。", MessageType.Error);
+                return;
+            }
+
+            for (int i = 0; i < info.modes.Length; i++)
+            {
+                CharacterModeData mode = info.modes[i];
+
+                if (mode.detectionRange <= 0)
+                {
+                    EditorGUILayout.HelpBox($"モード[{i}] {mode.mode}: detectionRange が0以下です。", MessageType.Warning);
+                }
+
+                if (mode.availableActIndices != null)
+                {
+                    foreach (int actIndex in mode.availableActIndices)
+                    {
+                        if (info.actDataList == null || actIndex < 0 || actIndex >= info.actDataList.Length)
+                        {
+                            EditorGUILayout.HelpBox(
+                                $"モード[{i}] {mode.mode}: actIndex {actIndex} が範囲外です（行動数: {(info.actDataList != null ? info.actDataList.Length : 0)}）。",
+                                MessageType.Error);
+                        }
+                    }
+                }
+            }
+
+            if (info.actDataList != null)
+            {
+                for (int i = 0; i < info.actDataList.Length; i++)
+                {
+                    ActData act = info.actDataList[i];
+                    if (string.IsNullOrEmpty(act.actName))
+                    {
+                        EditorGUILayout.HelpBox($"行動[{i}]: actName が未設定です。", MessageType.Warning);
+                    }
+                    if (act.weight <= 0)
+                    {
+                        EditorGUILayout.HelpBox($"行動[{i}] {act.actName}: weight が0以下です。", MessageType.Warning);
+                    }
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Assets/MyAsset/Editor/AttackInfoEditor.cs
+++ b/Assets/MyAsset/Editor/AttackInfoEditor.cs
@@ -1,0 +1,104 @@
+#if UNITY_EDITOR
+using Sirenix.OdinInspector.Editor;
+using UnityEditor;
+using UnityEngine;
+using Game.Core;
+
+namespace Game.Editor
+{
+    [CustomEditor(typeof(AttackInfo))]
+    public class AttackInfoEditor : OdinEditor
+    {
+        public override void OnInspectorGUI()
+        {
+            AttackInfo info = (AttackInfo)target;
+
+            // タイトル
+            GUIStyle titleStyle = new GUIStyle(EditorStyles.boldLabel)
+            {
+                fontSize = 14,
+                alignment = TextAnchor.MiddleCenter
+            };
+            EditorGUILayout.LabelField("攻撃データ設定", titleStyle);
+            EditorGUILayout.Space(4);
+
+            // サマリー
+            float totalDuration = info.motionInfo.preMotionDuration
+                + info.motionInfo.activeMotionDuration
+                + info.motionInfo.recoveryDuration;
+            string projText = info.projectileInfo.hasProjectile ? "あり" : "なし";
+            string knockText = info.knockbackInfo.hasKnockback ? "あり" : "なし";
+
+            EditorGUILayout.HelpBox(
+                $"【{info.attackName}】 カテゴリ: {info.category} / 属性: {info.attackElement}\n" +
+                $"ダメージ合計: {info.baseDamage.Total} × {info.damageMultiplier:F1}\n" +
+                $"モーション: {totalDuration:F2}s（予備{info.motionInfo.preMotionDuration:F2} + " +
+                $"攻撃{info.motionInfo.activeMotionDuration:F2} + 回復{info.motionInfo.recoveryDuration:F2}）\n" +
+                $"コスト: MP{info.mpCost} / スタミナ{info.staminaCost}\n" +
+                $"飛翔体: {projText} / ノックバック: {knockText}",
+                MessageType.Info);
+
+            EditorGUILayout.Space(4);
+            base.OnInspectorGUI();
+
+            // バリデーション
+            EditorGUILayout.Space(8);
+            ValidateAttackInfo(info);
+        }
+
+        private void ValidateAttackInfo(AttackInfo info)
+        {
+            if (string.IsNullOrEmpty(info.attackName))
+            {
+                EditorGUILayout.HelpBox("attackName が未設定です。", MessageType.Error);
+            }
+
+            if (info.baseDamage.Total <= 0 && info.category != AttackCategory.Support)
+            {
+                EditorGUILayout.HelpBox("baseDamage の合計が0です（Support以外では異常）。", MessageType.Warning);
+            }
+
+            if (info.damageMultiplier <= 0)
+            {
+                EditorGUILayout.HelpBox("damageMultiplier が0以下です。", MessageType.Error);
+            }
+
+            if (info.motionInfo.activeMotionDuration <= 0)
+            {
+                EditorGUILayout.HelpBox("activeMotionDuration が0以下です。", MessageType.Warning);
+            }
+
+            if (info.projectileInfo.hasProjectile)
+            {
+                if (info.projectileInfo.projectilePrefab == null)
+                {
+                    EditorGUILayout.HelpBox("飛翔体が有効ですが projectilePrefab が未設定です。", MessageType.Error);
+                }
+                if (info.projectileInfo.speed <= 0)
+                {
+                    EditorGUILayout.HelpBox("飛翔体の speed が0以下です。", MessageType.Warning);
+                }
+                if (info.projectileInfo.lifetime <= 0)
+                {
+                    EditorGUILayout.HelpBox("飛翔体の lifetime が0以下です。", MessageType.Warning);
+                }
+            }
+
+            if (info.knockbackInfo.hasKnockback && info.knockbackInfo.force == Vector2.zero)
+            {
+                EditorGUILayout.HelpBox("ノックバックが有効ですが force が(0,0)です。", MessageType.Warning);
+            }
+
+            if (info.isAutoChain && info.isChainEndPoint)
+            {
+                EditorGUILayout.HelpBox("isAutoChain と isChainEndPoint が両方trueです。矛盾している可能性があります。", MessageType.Warning);
+            }
+
+            if (info.inputWindow < 0)
+            {
+                EditorGUILayout.HelpBox("inputWindow が負の値です。", MessageType.Error);
+            }
+        }
+    }
+}
+#endif

--- a/Assets/MyAsset/Editor/ChallengeDefinitionEditor.cs
+++ b/Assets/MyAsset/Editor/ChallengeDefinitionEditor.cs
@@ -1,0 +1,100 @@
+#if UNITY_EDITOR
+using Sirenix.OdinInspector.Editor;
+using UnityEditor;
+using UnityEngine;
+using Game.Core;
+
+namespace Game.Editor
+{
+    [CustomEditor(typeof(ChallengeDefinition))]
+    public class ChallengeDefinitionEditor : OdinEditor
+    {
+        public override void OnInspectorGUI()
+        {
+            ChallengeDefinition def = (ChallengeDefinition)target;
+
+            // タイトル
+            GUIStyle titleStyle = new GUIStyle(EditorStyles.boldLabel)
+            {
+                fontSize = 14,
+                alignment = TextAnchor.MiddleCenter
+            };
+            EditorGUILayout.LabelField("チャレンジ定義", titleStyle);
+            EditorGUILayout.Space(4);
+
+            // サマリー
+            string typeName = def.ChallengeTypeValue.ToString();
+            int bossCount = def.BossIds != null ? def.BossIds.Length : 0;
+            EditorGUILayout.HelpBox(
+                $"【{def.ChallengeName}】 タイプ: {typeName}\n" +
+                $"制限時間: {def.TimeLimit}s / 最大デス: {def.MaxDeathCount}\n" +
+                $"ボス数: {bossCount} / ウェーブ: {def.WaveCount}（{def.EnemiesPerWave}体/wave）\n" +
+                $"報酬: {def.CurrencyReward}G" +
+                (string.IsNullOrEmpty(def.ItemRewardId) ? "" : $" + {def.ItemRewardId}"),
+                MessageType.Info);
+
+            EditorGUILayout.Space(4);
+            base.OnInspectorGUI();
+
+            // バリデーション
+            EditorGUILayout.Space(8);
+            ValidateChallengeDefinition(def);
+        }
+
+        private void ValidateChallengeDefinition(ChallengeDefinition def)
+        {
+            if (string.IsNullOrEmpty(def.ChallengeId))
+            {
+                EditorGUILayout.HelpBox("challengeId が未設定です。", MessageType.Error);
+            }
+
+            if (string.IsNullOrEmpty(def.ChallengeName))
+            {
+                EditorGUILayout.HelpBox("challengeName が未設定です。", MessageType.Error);
+            }
+
+            if (def.ChallengeTypeValue == ChallengeType.BossRush)
+            {
+                if (def.BossIds == null || def.BossIds.Length == 0)
+                {
+                    EditorGUILayout.HelpBox("BossRush ですが bossIds が空です。", MessageType.Error);
+                }
+            }
+
+            if (def.ChallengeTypeValue == ChallengeType.Survival)
+            {
+                if (def.WaveCount <= 0)
+                {
+                    EditorGUILayout.HelpBox("Survival ですが waveCount が0以下です。", MessageType.Error);
+                }
+                if (def.EnemiesPerWave <= 0)
+                {
+                    EditorGUILayout.HelpBox("Survival ですが enemiesPerWave が0以下です。", MessageType.Error);
+                }
+            }
+
+            if (def.TimeLimit <= 0 && def.ChallengeTypeValue == ChallengeType.TimeAttack)
+            {
+                EditorGUILayout.HelpBox("TimeAttack ですが timeLimit が0以下です。", MessageType.Error);
+            }
+
+            // ランク閾値の整合性
+            if (def.GoldTimeThreshold > 0 && def.SilverTimeThreshold > 0
+                && def.GoldTimeThreshold >= def.SilverTimeThreshold)
+            {
+                EditorGUILayout.HelpBox(
+                    "Gold タイム閾値が Silver 以上です（Gold < Silver であるべき）。",
+                    MessageType.Warning);
+            }
+
+            if (def.PlatinumScoreThreshold > 0 && def.GoldScoreThreshold > 0
+                && def.PlatinumScoreThreshold <= def.GoldScoreThreshold)
+            {
+                EditorGUILayout.HelpBox(
+                    "Platinum スコア閾値が Gold 以下です（Platinum > Gold であるべき）。",
+                    MessageType.Warning);
+            }
+        }
+    }
+}
+#endif

--- a/Assets/MyAsset/Editor/CharacterInfoEditor.cs
+++ b/Assets/MyAsset/Editor/CharacterInfoEditor.cs
@@ -1,0 +1,54 @@
+#if UNITY_EDITOR
+using Sirenix.OdinInspector.Editor;
+using UnityEditor;
+using UnityEngine;
+using Game.Core;
+
+namespace Game.Editor
+{
+    [CustomEditor(typeof(CharacterInfo))]
+    public class CharacterInfoEditor : OdinEditor
+    {
+        public override void OnInspectorGUI()
+        {
+            CharacterInfo info = (CharacterInfo)target;
+
+            // タイトル
+            GUIStyle titleStyle = new GUIStyle(EditorStyles.boldLabel)
+            {
+                fontSize = 14,
+                alignment = TextAnchor.MiddleCenter
+            };
+            EditorGUILayout.LabelField("キャラクター情報", titleStyle);
+            EditorGUILayout.Space(4);
+
+            // サマリー
+            string featureText = info.feature.ToString();
+            string belongText = info.belong.ToString();
+            EditorGUILayout.HelpBox(
+                $"【{featureText}】 陣営: {belongText} / ランク: {info.rank}\n" +
+                $"HP: {info.maxHp} / MP: {info.maxMp} / スタミナ: {info.maxStamina:F0}\n" +
+                $"攻撃力合計: {info.baseAttack.Total} / 防御力合計: {info.baseDefense.Total}",
+                MessageType.Info);
+
+            EditorGUILayout.Space(4);
+            base.OnInspectorGUI();
+
+            // バリデーション
+            EditorGUILayout.Space(8);
+            if (info.maxHp <= 0)
+            {
+                EditorGUILayout.HelpBox("maxHp が0以下です。", MessageType.Error);
+            }
+            if (info.moveSpeed <= 0)
+            {
+                EditorGUILayout.HelpBox("moveSpeed が0以下です。", MessageType.Warning);
+            }
+            if (info.staminaRecoveryRate <= 0 && info.maxStamina > 0)
+            {
+                EditorGUILayout.HelpBox("スタミナ回復速度が0です。", MessageType.Warning);
+            }
+        }
+    }
+}
+#endif

--- a/Assets/MyAsset/Editor/GameEditorTools.cs
+++ b/Assets/MyAsset/Editor/GameEditorTools.cs
@@ -1,0 +1,306 @@
+#if UNITY_EDITOR
+using System.Linq;
+using UnityEngine;
+using UnityEditor;
+using Game.Core;
+using Game.Runtime;
+using CharacterInfo = Game.Core.CharacterInfo;
+
+namespace Game.Editor
+{
+    /// <summary>
+    /// ゲーム開発用エディタユーティリティ。
+    /// メニューとコンテキストメニューから各種便利機能を提供する。
+    /// </summary>
+    public static class GameEditorTools
+    {
+        // ─────────────────────────────────────────────
+        //  ScriptableObject一括作成
+        // ─────────────────────────────────────────────
+
+        [MenuItem("Game/作成/CharacterInfo", priority = 100)]
+        public static void CreateCharacterInfo()
+        {
+            CreateAssetInSelectedFolder<CharacterInfo>("NewCharacterInfo");
+        }
+
+        [MenuItem("Game/作成/AIInfo", priority = 101)]
+        public static void CreateAIInfo()
+        {
+            CreateAssetInSelectedFolder<AIInfo>("NewAIInfo");
+        }
+
+        [MenuItem("Game/作成/AttackInfo", priority = 102)]
+        public static void CreateAttackInfo()
+        {
+            CreateAssetInSelectedFolder<AttackInfo>("NewAttackInfo");
+        }
+
+        [MenuItem("Game/作成/ChallengeDefinition", priority = 103)]
+        public static void CreateChallengeDefinition()
+        {
+            CreateAssetInSelectedFolder<ChallengeDefinition>("NewChallengeDefinition");
+        }
+
+        // ─────────────────────────────────────────────
+        //  バリデーション
+        // ─────────────────────────────────────────────
+
+        [MenuItem("Game/検証/全CharacterInfoを検証", priority = 200)]
+        public static void ValidateAllCharacterInfos()
+        {
+            string[] guids = AssetDatabase.FindAssets("t:CharacterInfo");
+            int errorCount = 0;
+
+            foreach (string guid in guids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                CharacterInfo info = AssetDatabase.LoadAssetAtPath<CharacterInfo>(path);
+
+                if (info.maxHp <= 0)
+                {
+                    Debug.LogError($"[検証エラー] {path}: maxHp が0以下", info);
+                    errorCount++;
+                }
+                if (info.moveSpeed <= 0)
+                {
+                    Debug.LogWarning($"[検証警告] {path}: moveSpeed が0以下", info);
+                }
+            }
+
+            Debug.Log($"CharacterInfo検証完了: {guids.Length}件中 {errorCount}件のエラー");
+        }
+
+        [MenuItem("Game/検証/全AIInfoを検証", priority = 201)]
+        public static void ValidateAllAIInfos()
+        {
+            string[] guids = AssetDatabase.FindAssets("t:AIInfo");
+            int errorCount = 0;
+
+            foreach (string guid in guids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                AIInfo info = AssetDatabase.LoadAssetAtPath<AIInfo>(path);
+
+                if (info.modes == null || info.modes.Length == 0)
+                {
+                    Debug.LogError($"[検証エラー] {path}: モード未設定", info);
+                    errorCount++;
+                }
+
+                if (info.actDataList != null)
+                {
+                    for (int i = 0; i < info.actDataList.Length; i++)
+                    {
+                        if (string.IsNullOrEmpty(info.actDataList[i].actName))
+                        {
+                            Debug.LogWarning($"[検証警告] {path}: actDataList[{i}] の名前が未設定", info);
+                        }
+                    }
+                }
+            }
+
+            Debug.Log($"AIInfo検証完了: {guids.Length}件中 {errorCount}件のエラー");
+        }
+
+        [MenuItem("Game/検証/全AttackInfoを検証", priority = 202)]
+        public static void ValidateAllAttackInfos()
+        {
+            string[] guids = AssetDatabase.FindAssets("t:AttackInfo");
+            int errorCount = 0;
+
+            foreach (string guid in guids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                AttackInfo info = AssetDatabase.LoadAssetAtPath<AttackInfo>(path);
+
+                if (string.IsNullOrEmpty(info.attackName))
+                {
+                    Debug.LogError($"[検証エラー] {path}: attackName が未設定", info);
+                    errorCount++;
+                }
+                if (info.damageMultiplier <= 0)
+                {
+                    Debug.LogError($"[検証エラー] {path}: damageMultiplier が0以下", info);
+                    errorCount++;
+                }
+                if (info.projectileInfo.hasProjectile && info.projectileInfo.projectilePrefab == null)
+                {
+                    Debug.LogError($"[検証エラー] {path}: 飛翔体有効だが prefab 未設定", info);
+                    errorCount++;
+                }
+            }
+
+            Debug.Log($"AttackInfo検証完了: {guids.Length}件中 {errorCount}件のエラー");
+        }
+
+        // ─────────────────────────────────────────────
+        //  シーンユーティリティ
+        // ─────────────────────────────────────────────
+
+        [MenuItem("Game/シーン/プレースホルダー一覧", priority = 300)]
+        public static void ListPlaceholders()
+        {
+            GameObject[] allObjects = Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None);
+            GameObject[] placeholders = allObjects
+                .Where(go => go.name.StartsWith("[PLACEHOLDER]"))
+                .ToArray();
+
+            if (placeholders.Length == 0)
+            {
+                Debug.Log("プレースホルダーはありません。");
+                return;
+            }
+
+            Debug.Log($"プレースホルダー: {placeholders.Length}件");
+            foreach (GameObject ph in placeholders)
+            {
+                Debug.Log($"  - {ph.name} ({GetHierarchyPath(ph)})", ph);
+            }
+        }
+
+        [MenuItem("Game/シーン/CharacterInfo未設定のキャラクター検出", priority = 301)]
+        public static void FindCharactersWithoutInfo()
+        {
+            BaseCharacter[] characters = Object.FindObjectsByType<BaseCharacter>(FindObjectsSortMode.None);
+            int missingCount = 0;
+
+            foreach (BaseCharacter character in characters)
+            {
+                SerializedObject so = new SerializedObject(character);
+                SerializedProperty infoProp = so.FindProperty("_characterInfo");
+                if (infoProp != null && infoProp.objectReferenceValue == null)
+                {
+                    Debug.LogWarning($"CharacterInfo未設定: {GetHierarchyPath(character.gameObject)}", character);
+                    missingCount++;
+                }
+            }
+
+            Debug.Log($"検出完了: {characters.Length}キャラ中 {missingCount}件がCharacterInfo未設定");
+        }
+
+        [MenuItem("Game/シーン/Missing参照を検出", priority = 302)]
+        public static void FindMissingReferences()
+        {
+            GameObject[] allObjects = Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None);
+            int missingCount = 0;
+
+            foreach (GameObject go in allObjects)
+            {
+                Component[] components = go.GetComponents<Component>();
+                for (int i = 0; i < components.Length; i++)
+                {
+                    if (components[i] == null)
+                    {
+                        Debug.LogError($"Missing Component: {GetHierarchyPath(go)} [index {i}]", go);
+                        missingCount++;
+                        continue;
+                    }
+
+                    SerializedObject so = new SerializedObject(components[i]);
+                    SerializedProperty prop = so.GetIterator();
+                    while (prop.NextVisible(true))
+                    {
+                        if (prop.propertyType == SerializedPropertyType.ObjectReference
+                            && prop.objectReferenceValue == null
+                            && prop.objectReferenceInstanceIDValue != 0)
+                        {
+                            Debug.LogWarning(
+                                $"Missing参照: {GetHierarchyPath(go)} → " +
+                                $"{components[i].GetType().Name}.{prop.name}", go);
+                            missingCount++;
+                        }
+                    }
+                }
+            }
+
+            Debug.Log($"Missing参照検出完了: {missingCount}件");
+        }
+
+        // ─────────────────────────────────────────────
+        //  選択オブジェクト操作
+        // ─────────────────────────────────────────────
+
+        [MenuItem("Game/選択/コンポーネント一覧をログ出力", priority = 400)]
+        public static void LogSelectedComponents()
+        {
+            if (Selection.activeGameObject == null)
+            {
+                Debug.LogWarning("GameObjectを選択してください。");
+                return;
+            }
+
+            GameObject go = Selection.activeGameObject;
+            Component[] components = go.GetComponents<Component>();
+            Debug.Log($"--- {go.name} のコンポーネント ({components.Length}個) ---");
+            for (int i = 0; i < components.Length; i++)
+            {
+                if (components[i] == null)
+                {
+                    Debug.LogWarning($"  [{i}] (Missing)");
+                }
+                else
+                {
+                    Debug.Log($"  [{i}] {components[i].GetType().FullName}");
+                }
+            }
+        }
+
+        [MenuItem("Game/選択/コンポーネント一覧をログ出力", true)]
+        public static bool LogSelectedComponentsValidation()
+        {
+            return Selection.activeGameObject != null;
+        }
+
+        // ─────────────────────────────────────────────
+        //  ヘルパー
+        // ─────────────────────────────────────────────
+
+        private static void CreateAssetInSelectedFolder<T>(string defaultName) where T : ScriptableObject
+        {
+            string folderPath = "Assets/MyAsset/Data";
+            if (Selection.activeObject != null)
+            {
+                string selectedPath = AssetDatabase.GetAssetPath(Selection.activeObject);
+                if (AssetDatabase.IsValidFolder(selectedPath))
+                {
+                    folderPath = selectedPath;
+                }
+                else if (!string.IsNullOrEmpty(selectedPath))
+                {
+                    folderPath = System.IO.Path.GetDirectoryName(selectedPath);
+                }
+            }
+
+            if (!AssetDatabase.IsValidFolder(folderPath))
+            {
+                folderPath = "Assets/MyAsset/Data";
+                if (!AssetDatabase.IsValidFolder(folderPath))
+                {
+                    AssetDatabase.CreateFolder("Assets/MyAsset", "Data");
+                }
+            }
+
+            T asset = ScriptableObject.CreateInstance<T>();
+            string assetPath = AssetDatabase.GenerateUniqueAssetPath($"{folderPath}/{defaultName}.asset");
+            AssetDatabase.CreateAsset(asset, assetPath);
+            AssetDatabase.SaveAssets();
+            EditorUtility.FocusProjectWindow();
+            Selection.activeObject = asset;
+            Debug.Log($"{typeof(T).Name} を作成: {assetPath}");
+        }
+
+        private static string GetHierarchyPath(GameObject go)
+        {
+            string path = go.name;
+            Transform parent = go.transform.parent;
+            while (parent != null)
+            {
+                path = parent.name + "/" + path;
+                parent = parent.parent;
+            }
+            return path;
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- CharacterInfo / AIInfo / AttackInfo / ChallengeDefinition に Odin Inspector 属性を追加し、Inspector のUXを大幅改善
- 4つのカスタムエディタ（OdinEditor継承）でサマリー表示 + バリデーション警告
- GameEditorTools でSO一括作成・全アセット検証・シーンユーティリティを提供
- ElementalStatus（7属性）を横並びコンパクト表示に改善

## 変更内容
- **Odin属性追加**: EnumToggleButtons, FoldoutGroup, InlineProperty, ToggleGroup, ShowIf, MinValue, Range等
- **カスタムエディタ**: CharacterInfoEditor, AIInfoEditor, AttackInfoEditor, ChallengeDefinitionEditor
- **エディタツール**: Game/作成/, Game/検証/, Game/シーン/ メニュー

## Test plan
- [ ] Unity Editorでコンパイルエラーなし確認
- [ ] CharacterInfo のInspectorでサマリー・バリデーション表示確認
- [ ] AIInfo のInspectorでモード・行動データの折りたたみ表示確認
- [ ] AttackInfo の飛翔体ToggleGroup表示確認
- [ ] ChallengeDefinition のShowIf（BossRush時bossIds表示等）確認
- [ ] Game/検証/ メニューから一括バリデーション実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)