### PR TITLE
feat(combat): 行動特殊効果システム + アーマー二層構造

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -148,6 +148,20 @@ paths:
 - **二重MPプール**: currentMP は reserveMP から自然補充。reserveMP はアイテム/チェックポイントのみ回復
 - **MP回復行動**: SustainedAction.MpRecover。停止してMP加速回復。怯みで中断、再開可
 
+### 行動特殊効果（ActionEffect）
+- 全行動（攻撃・回避・ガード・スキル・魔法）に「開始時間+持続時間」の特殊効果を複数設定可能
+- ActionEffectType: Armor / SuperArmor / Invincible / DamageReduction / GuardPoint
+- 設定箇所: AttackInfo.motionInfo.actionEffects, AttackMotionData.actionEffects, AbilityData
+- Armor は合算、DamageReduction は最大値、その他は OR
+- 旧 DashAbility の _invincibleStart/_invincibleEnd は ActionEffect に統合
+
+### アーマーシステム
+- 二層構造: ベースアーマー（CharacterInfo.maxArmor） + 行動アーマー（ActionEffect.Armor）
+- 被弾時は行動アーマーから優先消費 → 残りがベースアーマーへ
+- 両方 0 でアーマーブレイク（1.3倍ダメージボーナス）
+- ベースアーマー自然回復: armorRecoveryDelay 経過後に armorRecoveryRate/秒で回復
+- 行動アーマーは回復しない（ActionEffect の有効区間のみ存在）
+
 ### 連携ボタンスキル（CoopAction）
 - 連携 = 仲間への指示スキル。CoopActionBase継承で多様な連携を追加
 - コンボ対応: 連打で最大N回連続発動（MP消費は初回のみ）

--- a/Architect/04_ダメージ・被弾システム.md
+++ b/Architect/04_ダメージ・被弾システム.md
@@ -1692,3 +1692,120 @@ private void UpdateRecognitionOnHit(in DamageData data)
 | 認識データ | `GetRecognitionData(hash)` | ヘイト更新 |
 | BaseCharacter 参照 | `TryGetManaged(hash)` | 吹き飛ばし適用 |
 | DamageReceiver 参照 | `TryGetDamageReceiver(hash)` | ヒット時のダメージ送信 |
+
+---
+
+## 13. アーマーシステム
+
+### 13.1 二層アーマー構造
+
+キャラクターのアーマーは**ベースアーマー**と**行動アーマー**の二層で構成される。
+
+| 層 | 説明 | 設定箇所 |
+|---|---|---|
+| ベースアーマー | キャラクター固有の基礎アーマー値。プレイヤーは装備/コアで変動 | CharacterInfo.maxArmor |
+| 行動アーマー | 行動中に一時的に付与されるアーマー。ActionEffect で設定 | ActionEffect (type=Armor) |
+
+### 13.2 アーマー消費優先度
+
+```
+被弾時のアーマー削り処理:
+
+  1. 行動アーマーが有効か確認（ActionEffectProcessor.Evaluate）
+  2. 行動アーマー > 0 → 行動アーマーから優先消費
+  3. 行動アーマーで吸収しきれない分 → ベースアーマーから消費
+  4. 両方とも 0 以下 → アーマーブレイク（1.3倍ダメージボーナス）
+
+  ※ 行動アーマーが残っている限りベースアーマーは減らない
+```
+
+### 13.3 ベースアーマー回復
+
+```
+回復条件:
+  - 被弾後 armorRecoveryDelay 秒経過で回復開始
+  - 回復速度: armorRecoveryRate/秒
+  - maxArmor を超過しない
+
+  CharacterInfo:
+    maxArmor: float            // ベースアーマー最大値
+    armorRecoveryRate: float   // 回復速度（/秒）
+    armorRecoveryDelay: float  // 被弾後の回復開始遅延（秒）
+```
+
+### 13.4 行動アーマーは回復しない
+
+行動アーマーは ActionEffect の有効区間のみ存在する一時的な値。
+行動が終了すれば自動的に消滅し、回復処理は不要。
+
+---
+
+## 14. 行動特殊効果（ActionEffect）システム
+
+### 14.1 概要
+
+全行動（攻撃、回避、ガード、スキル、魔法など）に共通で「開始時間〜持続時間」の特殊効果を複数設定できる汎用システム。
+
+```csharp
+[Serializable]
+public struct ActionEffect
+{
+    public ActionEffectType type;   // 効果の種類
+    public float startTime;         // 発生タイミング（秒）
+    public float duration;          // 持続時間（秒）
+    public float value;             // 効果量
+}
+
+public enum ActionEffectType : byte
+{
+    Armor,            // 行動アーマー（value = アーマー量）
+    SuperArmor,       // スーパーアーマー（怯まない）
+    Invincible,       // 完全無敵
+    DamageReduction,  // ダメージ軽減（value = 軽減率 0-1）
+    GuardPoint,       // ガードポイント（特定フレームだけガード判定）
+}
+```
+
+### 14.2 設定箇所
+
+| データ | 用途 |
+|---|---|
+| AttackInfo.motionInfo.actionEffects | 攻撃全体の特殊効果 |
+| AttackMotionData.actionEffects | コンボステップごとの特殊効果 |
+| AbilityData（回避等） | Ability個別の特殊効果 |
+
+### 14.3 効果の複合ルール
+
+| 効果タイプ | 同時に複数ある場合 |
+|---|---|
+| Armor | **合算**（20 + 15 = 35） |
+| DamageReduction | **最大値**を採用 |
+| SuperArmor / Invincible / GuardPoint | **OR**（1つでもあればtrue） |
+
+### 14.4 使用例
+
+**大振り攻撃（予備動作中アーマー→攻撃中スーパーアーマー）**
+```
+actionEffects[0] = { Armor, start=0.0, dur=0.3, value=30 }
+actionEffects[1] = { SuperArmor, start=0.3, dur=0.5 }
+```
+
+**回避ロール（序盤に無敵フレーム）**
+```
+actionEffects[0] = { Invincible, start=0.05, dur=0.1 }
+```
+
+**ガードポイント付きカウンター**
+```
+actionEffects[0] = { GuardPoint, start=0.0, dur=0.2 }
+```
+
+**ボスのチャージ攻撃（チャージ中ダメージ軽減50%）**
+```
+actionEffects[0] = { DamageReduction, start=0.0, dur=1.5, value=0.5 }
+```
+
+### 14.5 処理クラス
+
+`ActionEffectProcessor`（static class）が ActionEffect[] と経過時間から `EffectState` を返す。
+DamageReceiver は被弾時にこの EffectState を参照して無敵判定・ダメージ軽減・アーマー優先消費を行う。

--- a/Assets/MyAsset/Core/Common/Enums.cs
+++ b/Assets/MyAsset/Core/Common/Enums.cs
@@ -97,6 +97,17 @@ namespace Game.Core
         Carry,
     }
 
+    // ===== 行動特殊効果 =====
+
+    public enum ActionEffectType : byte
+    {
+        Armor,            // 行動アーマー（value = アーマー量、ベースに加算）
+        SuperArmor,       // スーパーアーマー（怯まない）
+        Invincible,       // 完全無敵
+        DamageReduction,  // ダメージ軽減（value = 軽減率 0-1）
+        GuardPoint,       // ガードポイント（特定フレームだけガード判定）
+    }
+
     // ===== ガード =====
 
     public enum GuardType : byte

--- a/Assets/MyAsset/Core/Common/Structs.cs
+++ b/Assets/MyAsset/Core/Common/Structs.cs
@@ -35,9 +35,14 @@ namespace Game.Core
         public int dark;
 
         [ShowInInspector, ReadOnly, LabelText("合計")]
+        [Tooltip("物理: 斬+打+突 / 魔法: 炎+雷+聖+闇")]
         public int Total => slash + strike + pierce + fire + thunder + light + dark;
 
+        [ShowInInspector, ReadOnly, LabelText("物理計")]
         public int PhysicalTotal => slash + strike + pierce;
+
+        [ShowInInspector, ReadOnly, LabelText("魔法計")]
+        public int MagicalTotal => fire + thunder + light + dark;
 
         public int Get(Element element)
         {
@@ -168,9 +173,31 @@ namespace Game.Core
         public StatusEffectId appliedEffect;
     }
 
+    /// <summary>
+    /// 行動中に発生する特殊効果（アーマー、無敵、ダメージ軽減など）。
+    /// 開始時間と持続時間で発生区間を制御する。
+    /// </summary>
+    [Serializable, InlineProperty]
+    public struct ActionEffect
+    {
+        [EnumToggleButtons] public ActionEffectType type;
+        [MinValue(0), LabelText("開始(秒)")] public float startTime;
+        [MinValue(0), LabelText("持続(秒)")] public float duration;
+        [MinValue(0), LabelText("効果量")] public float value;
+
+        public float EndTime => startTime + duration;
+
+        public bool IsActive(float elapsedTime)
+        {
+            return elapsedTime >= startTime && elapsedTime < EndTime;
+        }
+    }
+
     [Serializable]
     public struct AttackMotionData
     {
+        [FoldoutGroup("基本")]
+        [LabelText("行動名")] public string actionName;
         [FoldoutGroup("基本")]
         [MinValue(0)] public float motionValue;
         [FoldoutGroup("基本")]
@@ -210,5 +237,9 @@ namespace Game.Core
 
         [FoldoutGroup("ガード関連")]
         [Range(0f, 100f)] public float justGuardResistance;
+
+        [FoldoutGroup("行動特殊効果")]
+        [ListDrawerSettings(ShowFoldout = true)]
+        public ActionEffect[] actionEffects;
     }
 }

--- a/Assets/MyAsset/Core/Damage/ActionEffectProcessor.cs
+++ b/Assets/MyAsset/Core/Damage/ActionEffectProcessor.cs
@@ -1,0 +1,116 @@
+namespace Game.Core
+{
+    /// <summary>
+    /// 行動中の特殊効果（アーマー、無敵、スーパーアーマーなど）を評価する。
+    /// ActionEffect配列と経過時間から現在有効な効果を判定するpureロジック。
+    /// </summary>
+    public static class ActionEffectProcessor
+    {
+        /// <summary>
+        /// 現在の行動特殊効果の状態。
+        /// </summary>
+        public struct EffectState
+        {
+            public bool isInvincible;
+            public bool hasSuperArmor;
+            public bool hasGuardPoint;
+            public float actionArmorValue;
+            public float damageReduction;
+        }
+
+        /// <summary>
+        /// 指定時間における有効な行動特殊効果を集計する。
+        /// 複数の同種効果が同時にアクティブな場合:
+        /// - Armor: 合算
+        /// - DamageReduction: 最大値
+        /// - SuperArmor/Invincible/GuardPoint: OR
+        /// </summary>
+        public static EffectState Evaluate(ActionEffect[] effects, float elapsedTime)
+        {
+            EffectState state = default;
+
+            if (effects == null)
+            {
+                return state;
+            }
+
+            for (int i = 0; i < effects.Length; i++)
+            {
+                if (!effects[i].IsActive(elapsedTime))
+                {
+                    continue;
+                }
+
+                switch (effects[i].type)
+                {
+                    case ActionEffectType.Armor:
+                        state.actionArmorValue += effects[i].value;
+                        break;
+                    case ActionEffectType.SuperArmor:
+                        state.hasSuperArmor = true;
+                        break;
+                    case ActionEffectType.Invincible:
+                        state.isInvincible = true;
+                        break;
+                    case ActionEffectType.DamageReduction:
+                        if (effects[i].value > state.damageReduction)
+                        {
+                            state.damageReduction = effects[i].value;
+                        }
+                        break;
+                    case ActionEffectType.GuardPoint:
+                        state.hasGuardPoint = true;
+                        break;
+                }
+            }
+
+            return state;
+        }
+
+        /// <summary>
+        /// 指定の効果タイプが現在アクティブかどうかを判定する。
+        /// </summary>
+        public static bool HasActiveEffect(ActionEffect[] effects, float elapsedTime,
+            ActionEffectType type)
+        {
+            if (effects == null)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < effects.Length; i++)
+            {
+                if (effects[i].type == type && effects[i].IsActive(elapsedTime))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// 指定の効果タイプの現在のvalue合計を取得する。
+        /// </summary>
+        public static float GetActiveValue(ActionEffect[] effects, float elapsedTime,
+            ActionEffectType type)
+        {
+            float total = 0f;
+
+            if (effects == null)
+            {
+                return total;
+            }
+
+            for (int i = 0; i < effects.Length; i++)
+            {
+                if (effects[i].type == type && effects[i].IsActive(elapsedTime))
+                {
+                    total += effects[i].value;
+                }
+            }
+
+            return total;
+        }
+    }
+}

--- a/Assets/MyAsset/Core/Damage/HpArmorLogic.cs
+++ b/Assets/MyAsset/Core/Damage/HpArmorLogic.cs
@@ -14,28 +14,45 @@ namespace Game.Core
         public const float k_ArmorBreakBonusMult = 1.3f;
 
         /// <summary>
-        /// Apply damage to a character. If armorBreakValue > 0, armor is reduced first.
-        /// When armor reaches 0, armorBroken is flagged and rawDamage receives a bonus multiplier.
+        /// Apply damage to a character with action armor priority.
+        /// Action armor is consumed first, then base armor.
+        /// When total armor (action + base) reaches 0, armorBroken bonus applies.
         /// HP is clamped to a minimum of 0.
         /// </summary>
         /// <param name="currentHp">Current HP (modified in place).</param>
-        /// <param name="currentArmor">Current armor (modified in place).</param>
+        /// <param name="currentArmor">Current base armor (modified in place).</param>
         /// <param name="rawDamage">Base damage before armor break bonus.</param>
         /// <param name="armorBreakValue">Amount of armor to destroy.</param>
+        /// <param name="actionArmor">Current action armor (modified in place). 0 if no action armor active.</param>
         /// <returns>(actualDamage, isKill, armorBroken)</returns>
         public static (int actualDamage, bool isKill, bool armorBroken) ApplyDamage(
-            ref int currentHp, ref float currentArmor, int rawDamage, float armorBreakValue)
+            ref int currentHp, ref float currentArmor, int rawDamage, float armorBreakValue,
+            ref float actionArmor)
         {
             bool armorBroken = false;
             int actualDamage = rawDamage;
 
-            // Step 1: Apply armor break
+            // Step 1: Apply armor break (action armor first, then base armor)
             if (armorBreakValue > 0f)
             {
-                currentArmor -= armorBreakValue;
+                float remaining = armorBreakValue;
 
-                // Step 2: Check if armor is broken
-                if (currentArmor <= 0f)
+                // Step 1a: Consume action armor first
+                if (actionArmor > 0f)
+                {
+                    float absorbed = Mathf.Min(actionArmor, remaining);
+                    actionArmor -= absorbed;
+                    remaining -= absorbed;
+                }
+
+                // Step 1b: Remaining break value goes to base armor
+                if (remaining > 0f)
+                {
+                    currentArmor -= remaining;
+                }
+
+                // Step 2: Check if all armor is broken
+                if (currentArmor <= 0f && actionArmor <= 0f)
                 {
                     armorBroken = true;
                     actualDamage = Mathf.FloorToInt(rawDamage * k_ArmorBreakBonusMult);
@@ -49,6 +66,24 @@ namespace Game.Core
             bool isKill = currentHp <= 0;
 
             return (actualDamage, isKill, armorBroken);
+        }
+
+        /// <summary>
+        /// Apply armor recovery over time. Recovery starts after delay has elapsed.
+        /// </summary>
+        /// <param name="currentArmor">Current armor (modified in place).</param>
+        /// <param name="maxArmor">Maximum armor value.</param>
+        /// <param name="recoveryRate">Recovery per second.</param>
+        /// <param name="deltaTime">Time elapsed this frame.</param>
+        public static void RecoverArmor(ref float currentArmor, float maxArmor,
+            float recoveryRate, float deltaTime)
+        {
+            if (currentArmor >= maxArmor || recoveryRate <= 0f)
+            {
+                return;
+            }
+
+            currentArmor = Mathf.Min(maxArmor, currentArmor + recoveryRate * deltaTime);
         }
 
         /// <summary>

--- a/Assets/MyAsset/Core/ScriptableObjects/AttackInfo.cs
+++ b/Assets/MyAsset/Core/ScriptableObjects/AttackInfo.cs
@@ -118,6 +118,10 @@ namespace Game.Core
         public AnimationClip chargeLoopClip;
         [FoldoutGroup("アニメーション")]
         public AnimationClip recoveryClip;
+
+        [FoldoutGroup("行動特殊効果")]
+        [ListDrawerSettings(ShowFoldout = true)]
+        public ActionEffect[] actionEffects;
     }
 
     [Serializable]

--- a/Assets/MyAsset/Core/ScriptableObjects/CharacterInfo.cs
+++ b/Assets/MyAsset/Core/ScriptableObjects/CharacterInfo.cs
@@ -98,6 +98,24 @@ namespace Game.Core
         public float jumpHeight;
 
         // ─────────────────────────────────────────────
+        //  アーマー
+        // ─────────────────────────────────────────────
+        [TitleGroup("アーマー")]
+        [Tooltip("ベースアーマー最大値")]
+        [MinValue(0)]
+        public float maxArmor;
+
+        [TitleGroup("アーマー")]
+        [Tooltip("アーマー自然回復速度（/秒）")]
+        [MinValue(0)]
+        public float armorRecoveryRate;
+
+        [TitleGroup("アーマー")]
+        [Tooltip("被弾後のアーマー回復開始までの遅延（秒）")]
+        [MinValue(0)]
+        public float armorRecoveryDelay;
+
+        // ─────────────────────────────────────────────
         //  耐性
         // ─────────────────────────────────────────────
         [TitleGroup("耐性")]

--- a/Assets/MyAsset/Editor/AIInfoEditor.cs
+++ b/Assets/MyAsset/Editor/AIInfoEditor.cs
@@ -35,9 +35,66 @@ namespace Game.Editor
             EditorGUILayout.Space(4);
             base.OnInspectorGUI();
 
+            // 行動インデックス→名前マッピング表示
+            if (info.modes != null && info.actDataList != null && info.actDataList.Length > 0)
+            {
+                EditorGUILayout.Space(8);
+                DrawActIndexNameMap(info);
+            }
+
             // バリデーション
             EditorGUILayout.Space(8);
             ValidateAIInfo(info);
+        }
+
+        private void DrawActIndexNameMap(AIInfo info)
+        {
+            EditorGUILayout.LabelField("行動インデックス → 名前対応", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
+
+            for (int i = 0; i < info.modes.Length; i++)
+            {
+                CharacterModeData mode = info.modes[i];
+                if (mode.availableActIndices == null || mode.availableActIndices.Length == 0)
+                {
+                    continue;
+                }
+
+                EditorGUILayout.LabelField($"モード[{i}] {mode.mode}:", EditorStyles.miniBoldLabel);
+
+                SerializedProperty modesProp = serializedObject.FindProperty("modes");
+                SerializedProperty modeProp = modesProp.GetArrayElementAtIndex(i);
+                SerializedProperty indicesProp = modeProp.FindPropertyRelative("availableActIndices");
+
+                for (int j = 0; j < indicesProp.arraySize; j++)
+                {
+                    SerializedProperty indexProp = indicesProp.GetArrayElementAtIndex(j);
+                    int currentIndex = indexProp.intValue;
+
+                    // ドロップダウン用のラベル配列を構築
+                    string[] actNames = new string[info.actDataList.Length];
+                    for (int k = 0; k < info.actDataList.Length; k++)
+                    {
+                        string name = info.actDataList[k].actName;
+                        actNames[k] = string.IsNullOrEmpty(name)
+                            ? $"[{k}] (名前なし)"
+                            : $"[{k}] {name}";
+                    }
+
+                    int validIndex = (currentIndex >= 0 && currentIndex < actNames.Length)
+                        ? currentIndex
+                        : 0;
+
+                    int newIndex = EditorGUILayout.Popup($"  行動[{j}]", validIndex, actNames);
+                    if (newIndex != currentIndex)
+                    {
+                        indexProp.intValue = newIndex;
+                        serializedObject.ApplyModifiedProperties();
+                    }
+                }
+            }
+
+            EditorGUI.indentLevel--;
         }
 
         private void ValidateAIInfo(AIInfo info)

--- a/Assets/MyAsset/Editor/GameEditorTools.cs
+++ b/Assets/MyAsset/Editor/GameEditorTools.cs
@@ -184,9 +184,20 @@ namespace Game.Editor
         {
             GameObject[] allObjects = Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None);
             int missingCount = 0;
+            int totalObjects = allObjects.Length;
 
-            foreach (GameObject go in allObjects)
+            for (int objIndex = 0; objIndex < totalObjects; objIndex++)
             {
+                GameObject go = allObjects[objIndex];
+
+                if (EditorUtility.DisplayCancelableProgressBar(
+                    "Missing参照を検出中",
+                    $"{objIndex + 1}/{totalObjects}: {go.name}",
+                    (float)(objIndex + 1) / totalObjects))
+                {
+                    break;
+                }
+
                 Component[] components = go.GetComponents<Component>();
                 for (int i = 0; i < components.Length; i++)
                 {
@@ -214,6 +225,7 @@ namespace Game.Editor
                 }
             }
 
+            EditorUtility.ClearProgressBar();
             Debug.Log($"Missing参照検出完了: {missingCount}件");
         }
 

--- a/Assets/Tests/EditMode/ActionEffectProcessorTests.cs
+++ b/Assets/Tests/EditMode/ActionEffectProcessorTests.cs
@@ -1,0 +1,274 @@
+using NUnit.Framework;
+using Game.Core;
+
+namespace Game.Tests.EditMode
+{
+    public class ActionEffectProcessorTests
+    {
+        // ===== ActionEffect.IsActive テスト =====
+
+        [Test]
+        public void ActionEffect_IsActive_WithinWindow_ReturnsTrue()
+        {
+            ActionEffect effect = new ActionEffect
+            {
+                type = ActionEffectType.Armor,
+                startTime = 0.1f,
+                duration = 0.3f,
+                value = 20f
+            };
+
+            Assert.IsTrue(effect.IsActive(0.1f), "Should be active at start time");
+            Assert.IsTrue(effect.IsActive(0.2f), "Should be active during window");
+            Assert.IsTrue(effect.IsActive(0.39f), "Should be active just before end");
+        }
+
+        [Test]
+        public void ActionEffect_IsActive_OutsideWindow_ReturnsFalse()
+        {
+            ActionEffect effect = new ActionEffect
+            {
+                type = ActionEffectType.Armor,
+                startTime = 0.1f,
+                duration = 0.3f,
+                value = 20f
+            };
+
+            Assert.IsFalse(effect.IsActive(0.0f), "Should not be active before start");
+            Assert.IsFalse(effect.IsActive(0.09f), "Should not be active just before start");
+            Assert.IsFalse(effect.IsActive(0.4f), "Should not be active at end time (exclusive)");
+            Assert.IsFalse(effect.IsActive(1.0f), "Should not be active well after end");
+        }
+
+        [Test]
+        public void ActionEffect_EndTime_ReturnsCorrectValue()
+        {
+            ActionEffect effect = new ActionEffect
+            {
+                startTime = 0.2f,
+                duration = 0.5f
+            };
+
+            Assert.AreEqual(0.7f, effect.EndTime, 0.001f);
+        }
+
+        // ===== Evaluate テスト =====
+
+        [Test]
+        public void Evaluate_NullEffects_ReturnsDefault()
+        {
+            ActionEffectProcessor.EffectState state = ActionEffectProcessor.Evaluate(null, 0.5f);
+
+            Assert.IsFalse(state.isInvincible);
+            Assert.IsFalse(state.hasSuperArmor);
+            Assert.IsFalse(state.hasGuardPoint);
+            Assert.AreEqual(0f, state.actionArmorValue);
+            Assert.AreEqual(0f, state.damageReduction);
+        }
+
+        [Test]
+        public void Evaluate_EmptyEffects_ReturnsDefault()
+        {
+            ActionEffect[] effects = new ActionEffect[0];
+
+            ActionEffectProcessor.EffectState state = ActionEffectProcessor.Evaluate(effects, 0.5f);
+
+            Assert.IsFalse(state.isInvincible);
+            Assert.AreEqual(0f, state.actionArmorValue);
+        }
+
+        [Test]
+        public void Evaluate_ArmorEffect_ReturnsArmorValue()
+        {
+            ActionEffect[] effects = new ActionEffect[]
+            {
+                new ActionEffect { type = ActionEffectType.Armor, startTime = 0f, duration = 1f, value = 30f }
+            };
+
+            ActionEffectProcessor.EffectState state = ActionEffectProcessor.Evaluate(effects, 0.5f);
+
+            Assert.AreEqual(30f, state.actionArmorValue, 0.001f);
+        }
+
+        [Test]
+        public void Evaluate_MultipleArmors_Stacks()
+        {
+            ActionEffect[] effects = new ActionEffect[]
+            {
+                new ActionEffect { type = ActionEffectType.Armor, startTime = 0f, duration = 1f, value = 20f },
+                new ActionEffect { type = ActionEffectType.Armor, startTime = 0.3f, duration = 0.5f, value = 15f }
+            };
+
+            ActionEffectProcessor.EffectState state = ActionEffectProcessor.Evaluate(effects, 0.5f);
+
+            Assert.AreEqual(35f, state.actionArmorValue, 0.001f, "Multiple armor effects should stack");
+        }
+
+        [Test]
+        public void Evaluate_SuperArmor_SetsFlag()
+        {
+            ActionEffect[] effects = new ActionEffect[]
+            {
+                new ActionEffect { type = ActionEffectType.SuperArmor, startTime = 0.2f, duration = 0.3f }
+            };
+
+            Assert.IsFalse(ActionEffectProcessor.Evaluate(effects, 0.1f).hasSuperArmor, "Before start");
+            Assert.IsTrue(ActionEffectProcessor.Evaluate(effects, 0.3f).hasSuperArmor, "During window");
+            Assert.IsFalse(ActionEffectProcessor.Evaluate(effects, 0.5f).hasSuperArmor, "After end");
+        }
+
+        [Test]
+        public void Evaluate_Invincible_SetsFlag()
+        {
+            ActionEffect[] effects = new ActionEffect[]
+            {
+                new ActionEffect { type = ActionEffectType.Invincible, startTime = 0.05f, duration = 0.1f }
+            };
+
+            ActionEffectProcessor.EffectState state = ActionEffectProcessor.Evaluate(effects, 0.1f);
+
+            Assert.IsTrue(state.isInvincible);
+        }
+
+        [Test]
+        public void Evaluate_DamageReduction_TakesMax()
+        {
+            ActionEffect[] effects = new ActionEffect[]
+            {
+                new ActionEffect { type = ActionEffectType.DamageReduction, startTime = 0f, duration = 1f, value = 0.3f },
+                new ActionEffect { type = ActionEffectType.DamageReduction, startTime = 0f, duration = 1f, value = 0.5f }
+            };
+
+            ActionEffectProcessor.EffectState state = ActionEffectProcessor.Evaluate(effects, 0.5f);
+
+            Assert.AreEqual(0.5f, state.damageReduction, 0.001f, "Should take maximum reduction");
+        }
+
+        [Test]
+        public void Evaluate_GuardPoint_SetsFlag()
+        {
+            ActionEffect[] effects = new ActionEffect[]
+            {
+                new ActionEffect { type = ActionEffectType.GuardPoint, startTime = 0f, duration = 0.2f }
+            };
+
+            Assert.IsTrue(ActionEffectProcessor.Evaluate(effects, 0.1f).hasGuardPoint);
+            Assert.IsFalse(ActionEffectProcessor.Evaluate(effects, 0.3f).hasGuardPoint);
+        }
+
+        [Test]
+        public void Evaluate_MixedEffects_AllActive()
+        {
+            ActionEffect[] effects = new ActionEffect[]
+            {
+                new ActionEffect { type = ActionEffectType.Armor, startTime = 0f, duration = 0.5f, value = 25f },
+                new ActionEffect { type = ActionEffectType.SuperArmor, startTime = 0.2f, duration = 0.3f },
+                new ActionEffect { type = ActionEffectType.DamageReduction, startTime = 0f, duration = 0.5f, value = 0.2f }
+            };
+
+            ActionEffectProcessor.EffectState state = ActionEffectProcessor.Evaluate(effects, 0.3f);
+
+            Assert.AreEqual(25f, state.actionArmorValue, 0.001f);
+            Assert.IsTrue(state.hasSuperArmor);
+            Assert.AreEqual(0.2f, state.damageReduction, 0.001f);
+            Assert.IsFalse(state.isInvincible);
+        }
+
+        [Test]
+        public void Evaluate_SequentialEffects_OnlyActiveOneApplies()
+        {
+            ActionEffect[] effects = new ActionEffect[]
+            {
+                new ActionEffect { type = ActionEffectType.Armor, startTime = 0f, duration = 0.3f, value = 10f },
+                new ActionEffect { type = ActionEffectType.SuperArmor, startTime = 0.3f, duration = 0.5f }
+            };
+
+            // At t=0.2: only armor active
+            ActionEffectProcessor.EffectState state1 = ActionEffectProcessor.Evaluate(effects, 0.2f);
+            Assert.AreEqual(10f, state1.actionArmorValue, 0.001f);
+            Assert.IsFalse(state1.hasSuperArmor);
+
+            // At t=0.5: only super armor active
+            ActionEffectProcessor.EffectState state2 = ActionEffectProcessor.Evaluate(effects, 0.5f);
+            Assert.AreEqual(0f, state2.actionArmorValue, 0.001f);
+            Assert.IsTrue(state2.hasSuperArmor);
+        }
+
+        // ===== HasActiveEffect テスト =====
+
+        [Test]
+        public void HasActiveEffect_WhenActive_ReturnsTrue()
+        {
+            ActionEffect[] effects = new ActionEffect[]
+            {
+                new ActionEffect { type = ActionEffectType.Invincible, startTime = 0.1f, duration = 0.2f }
+            };
+
+            Assert.IsTrue(ActionEffectProcessor.HasActiveEffect(effects, 0.15f, ActionEffectType.Invincible));
+        }
+
+        [Test]
+        public void HasActiveEffect_WhenInactive_ReturnsFalse()
+        {
+            ActionEffect[] effects = new ActionEffect[]
+            {
+                new ActionEffect { type = ActionEffectType.Invincible, startTime = 0.1f, duration = 0.2f }
+            };
+
+            Assert.IsFalse(ActionEffectProcessor.HasActiveEffect(effects, 0.5f, ActionEffectType.Invincible));
+        }
+
+        [Test]
+        public void HasActiveEffect_WrongType_ReturnsFalse()
+        {
+            ActionEffect[] effects = new ActionEffect[]
+            {
+                new ActionEffect { type = ActionEffectType.Armor, startTime = 0f, duration = 1f, value = 10f }
+            };
+
+            Assert.IsFalse(ActionEffectProcessor.HasActiveEffect(effects, 0.5f, ActionEffectType.Invincible));
+        }
+
+        [Test]
+        public void HasActiveEffect_NullEffects_ReturnsFalse()
+        {
+            Assert.IsFalse(ActionEffectProcessor.HasActiveEffect(null, 0.5f, ActionEffectType.Armor));
+        }
+
+        // ===== GetActiveValue テスト =====
+
+        [Test]
+        public void GetActiveValue_SingleEffect_ReturnsValue()
+        {
+            ActionEffect[] effects = new ActionEffect[]
+            {
+                new ActionEffect { type = ActionEffectType.Armor, startTime = 0f, duration = 1f, value = 25f }
+            };
+
+            float result = ActionEffectProcessor.GetActiveValue(effects, 0.5f, ActionEffectType.Armor);
+
+            Assert.AreEqual(25f, result, 0.001f);
+        }
+
+        [Test]
+        public void GetActiveValue_MultipleActiveEffects_SumsValues()
+        {
+            ActionEffect[] effects = new ActionEffect[]
+            {
+                new ActionEffect { type = ActionEffectType.Armor, startTime = 0f, duration = 1f, value = 10f },
+                new ActionEffect { type = ActionEffectType.Armor, startTime = 0.3f, duration = 0.5f, value = 15f },
+                new ActionEffect { type = ActionEffectType.SuperArmor, startTime = 0f, duration = 1f }
+            };
+
+            float result = ActionEffectProcessor.GetActiveValue(effects, 0.5f, ActionEffectType.Armor);
+
+            Assert.AreEqual(25f, result, 0.001f, "Should sum only matching active effects");
+        }
+
+        [Test]
+        public void GetActiveValue_NullEffects_ReturnsZero()
+        {
+            Assert.AreEqual(0f, ActionEffectProcessor.GetActiveValue(null, 0.5f, ActionEffectType.Armor));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/DamageHpArmorTests.cs
+++ b/Assets/Tests/EditMode/DamageHpArmorTests.cs
@@ -14,10 +14,11 @@ namespace Game.Tests.EditMode
             float currentArmor = 0f;
             int rawDamage = 30;
             float armorBreakValue = 0f;
+            float actionArmor = 0f;
 
             // Act
             (int actualDamage, bool isKill, bool armorBroken) result =
-                HpArmorLogic.ApplyDamage(ref currentHp, ref currentArmor, rawDamage, armorBreakValue);
+                HpArmorLogic.ApplyDamage(ref currentHp, ref currentArmor, rawDamage, armorBreakValue, ref actionArmor);
 
             // Assert
             Assert.AreEqual(70, currentHp, "HP should be reduced by raw damage");
@@ -34,10 +35,11 @@ namespace Game.Tests.EditMode
             float currentArmor = 0f;
             int rawDamage = 30;
             float armorBreakValue = 0f;
+            float actionArmor = 0f;
 
             // Act
             (int actualDamage, bool isKill, bool armorBroken) result =
-                HpArmorLogic.ApplyDamage(ref currentHp, ref currentArmor, rawDamage, armorBreakValue);
+                HpArmorLogic.ApplyDamage(ref currentHp, ref currentArmor, rawDamage, armorBreakValue, ref actionArmor);
 
             // Assert
             Assert.AreEqual(0, currentHp, "HP should clamp to 0");
@@ -52,10 +54,11 @@ namespace Game.Tests.EditMode
             float currentArmor = 10f;
             int rawDamage = 20;
             float armorBreakValue = 15f;
+            float actionArmor = 0f;
 
             // Act
             (int actualDamage, bool isKill, bool armorBroken) result =
-                HpArmorLogic.ApplyDamage(ref currentHp, ref currentArmor, rawDamage, armorBreakValue);
+                HpArmorLogic.ApplyDamage(ref currentHp, ref currentArmor, rawDamage, armorBreakValue, ref actionArmor);
 
             // Assert
             Assert.IsTrue(result.armorBroken, "Armor should be broken when armorBreakValue exceeds currentArmor");
@@ -83,6 +86,150 @@ namespace Game.Tests.EditMode
                 "Knockback X should be reduced by resistance");
             Assert.AreEqual(3.5f, knockback.y, 0.001f,
                 "Knockback Y should be reduced by resistance");
+        }
+
+        // ===== 行動アーマー優先消費テスト =====
+
+        [Test]
+        public void HpArmorLogic_ApplyDamage_ActionArmorConsumedFirst()
+        {
+            // Arrange
+            int currentHp = 100;
+            float currentArmor = 20f;
+            float actionArmor = 15f;
+            int rawDamage = 20;
+            float armorBreakValue = 10f;
+
+            // Act
+            HpArmorLogic.ApplyDamage(ref currentHp, ref currentArmor, rawDamage, armorBreakValue, ref actionArmor);
+
+            // Assert
+            Assert.AreEqual(5f, actionArmor, 0.001f, "Action armor should be reduced by break value");
+            Assert.AreEqual(20f, currentArmor, 0.001f, "Base armor should remain untouched when action armor absorbs all");
+        }
+
+        [Test]
+        public void HpArmorLogic_ApplyDamage_ActionArmorOverflow_GoesToBaseArmor()
+        {
+            // Arrange
+            int currentHp = 100;
+            float currentArmor = 20f;
+            float actionArmor = 5f;
+            int rawDamage = 20;
+            float armorBreakValue = 12f;
+
+            // Act
+            HpArmorLogic.ApplyDamage(ref currentHp, ref currentArmor, rawDamage, armorBreakValue, ref actionArmor);
+
+            // Assert
+            Assert.AreEqual(0f, actionArmor, 0.001f, "Action armor should be fully consumed");
+            Assert.AreEqual(13f, currentArmor, 0.001f, "Base armor should absorb remaining break value (20 - 7 = 13)");
+            Assert.IsFalse(currentArmor <= 0f, "Base armor should not be broken");
+        }
+
+        [Test]
+        public void HpArmorLogic_ApplyDamage_BothArmorsBroken_BonusDamage()
+        {
+            // Arrange
+            int currentHp = 100;
+            float currentArmor = 3f;
+            float actionArmor = 2f;
+            int rawDamage = 20;
+            float armorBreakValue = 10f;
+
+            // Act
+            (int actualDamage, bool isKill, bool armorBroken) result =
+                HpArmorLogic.ApplyDamage(ref currentHp, ref currentArmor, rawDamage, armorBreakValue, ref actionArmor);
+
+            // Assert
+            Assert.IsTrue(result.armorBroken, "Both armors depleted should trigger armor break");
+            int expectedDamage = Mathf.FloorToInt(rawDamage * HpArmorLogic.k_ArmorBreakBonusMult);
+            Assert.AreEqual(expectedDamage, result.actualDamage, "Should apply armor break bonus");
+        }
+
+        [Test]
+        public void HpArmorLogic_ApplyDamage_ActionArmorOnly_NoBreakWhenBaseRemains()
+        {
+            // Arrange
+            int currentHp = 100;
+            float currentArmor = 20f;
+            float actionArmor = 3f;
+            int rawDamage = 20;
+            float armorBreakValue = 5f;
+
+            // Act
+            (int actualDamage, bool isKill, bool armorBroken) result =
+                HpArmorLogic.ApplyDamage(ref currentHp, ref currentArmor, rawDamage, armorBreakValue, ref actionArmor);
+
+            // Assert
+            Assert.IsFalse(result.armorBroken, "Armor break should not trigger when base armor remains");
+            Assert.AreEqual(20, result.actualDamage, "Damage should not have bonus multiplier");
+        }
+
+        // ===== アーマー回復テスト =====
+
+        [Test]
+        public void HpArmorLogic_RecoverArmor_IncreasesArmor()
+        {
+            // Arrange
+            float currentArmor = 10f;
+            float maxArmor = 50f;
+            float recoveryRate = 5f;
+            float deltaTime = 1f;
+
+            // Act
+            HpArmorLogic.RecoverArmor(ref currentArmor, maxArmor, recoveryRate, deltaTime);
+
+            // Assert
+            Assert.AreEqual(15f, currentArmor, 0.001f, "Armor should increase by rate * deltaTime");
+        }
+
+        [Test]
+        public void HpArmorLogic_RecoverArmor_ClampsToMax()
+        {
+            // Arrange
+            float currentArmor = 48f;
+            float maxArmor = 50f;
+            float recoveryRate = 10f;
+            float deltaTime = 1f;
+
+            // Act
+            HpArmorLogic.RecoverArmor(ref currentArmor, maxArmor, recoveryRate, deltaTime);
+
+            // Assert
+            Assert.AreEqual(50f, currentArmor, 0.001f, "Armor should clamp to max");
+        }
+
+        [Test]
+        public void HpArmorLogic_RecoverArmor_WhenAlreadyMax_NoChange()
+        {
+            // Arrange
+            float currentArmor = 50f;
+            float maxArmor = 50f;
+            float recoveryRate = 5f;
+            float deltaTime = 1f;
+
+            // Act
+            HpArmorLogic.RecoverArmor(ref currentArmor, maxArmor, recoveryRate, deltaTime);
+
+            // Assert
+            Assert.AreEqual(50f, currentArmor, 0.001f, "Armor should not exceed max");
+        }
+
+        [Test]
+        public void HpArmorLogic_RecoverArmor_ZeroRate_NoChange()
+        {
+            // Arrange
+            float currentArmor = 10f;
+            float maxArmor = 50f;
+            float recoveryRate = 0f;
+            float deltaTime = 1f;
+
+            // Act
+            HpArmorLogic.RecoverArmor(ref currentArmor, maxArmor, recoveryRate, deltaTime);
+
+            // Assert
+            Assert.AreEqual(10f, currentArmor, 0.001f, "Armor should not recover with zero rate");
         }
     }
 }


### PR DESCRIPTION
## Summary
- 全行動に共通の特殊効果（アーマー/スーパーアーマー/無敵/ダメージ軽減/ガードポイント）を「開始時間＋持続時間」で設定可能にするActionEffectシステムを追加
- アーマーを二層構造（ベースアーマー＋行動アーマー）にし、行動アーマー優先消費ロジックを実装
- ベースアーマーの自然回復機能を追加（被弾後のディレイ付き）
- エディタ改善: AIInfo行動インデックスの名前ベースDropdown、ElementalStatus物理/魔法内訳表示、FindMissingReferencesプログレスバー

## 変更ファイル
- **Enums.cs**: ActionEffectType enum追加
- **Structs.cs**: ActionEffect struct, AttackMotionData.actionName/actionEffects追加, ElementalStatus内訳表示
- **AttackInfo.cs**: MotionInfo.actionEffects追加
- **CharacterInfo.cs**: maxArmor/armorRecoveryRate/armorRecoveryDelay追加
- **HpArmorLogic.cs**: 行動アーマー優先消費 + RecoverArmor()
- **ActionEffectProcessor.cs**: 新規 - 効果判定ロジック
- **AIInfoEditor.cs**: 名前ベースDropdown追加
- **GameEditorTools.cs**: プログレスバー追加
- **Architect/04**: アーマー・ActionEffectセクション追加
- **architecture.md**: ルール追加

## Test plan
- [x] ActionEffect.IsActive の境界値テスト（開始・終了・範囲外）
- [x] ActionEffectProcessor.Evaluate の各効果タイプ（合算/最大値/OR）
- [x] HpArmorLogic 行動アーマー優先消費（全吸収/オーバーフロー/両方ブレイク）
- [x] HpArmorLogic アーマー回復（通常/クランプ/最大時/ゼロレート）
- [x] 既存テスト4件がシグネチャ変更後もPass

🤖 Generated with [Claude Code](https://claude.com/claude-code)