### PR TITLE
feat(save): ISaveable統一・SaveManager配線・FlagManager新設

### DIFF
--- a/Assets/MyAsset/Core/Economy/CurrencyManager.cs
+++ b/Assets/MyAsset/Core/Economy/CurrencyManager.cs
@@ -6,7 +6,7 @@ namespace Game.Core
     /// 通貨の獲得・消費・残高管理を担当。
     /// デスペナルティ（残高の20%ロスト）にも対応。
     /// </summary>
-    public class CurrencyManager
+    public class CurrencyManager : ISaveable
     {
         public const float k_DeathPenaltyRate = 0.2f;
 
@@ -57,15 +57,30 @@ namespace Game.Core
         }
 
         /// <summary>永続化用: 残高をシリアライズ。</summary>
-        public int Serialize()
+        public int SerializeBalance()
         {
             return _balance;
         }
 
         /// <summary>永続化用: 残高をデシリアライズ。負数は0にクランプ。</summary>
-        public void Deserialize(int balance)
+        public void DeserializeBalance(int balance)
         {
             _balance = Math.Max(0, balance);
+        }
+
+        // ===== ISaveable =====
+
+        public string SaveId => "CurrencyManager";
+
+        object ISaveable.Serialize()
+        {
+            return SerializeBalance();
+        }
+
+        void ISaveable.Deserialize(object data)
+        {
+            int balance = Convert.ToInt32(data);
+            DeserializeBalance(balance);
         }
     }
 }

--- a/Assets/MyAsset/Core/Inventory/InventoryManager.cs
+++ b/Assets/MyAsset/Core/Inventory/InventoryManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace Game.Core
 {
@@ -23,6 +24,17 @@ namespace Game.Core
                 for (int i = 0; i < items.Count; i++)
                 {
                     _items.Add(items[i]);
+                }
+            }
+            else if (data is JArray jArray)
+            {
+                List<ItemEntry> converted = jArray.ToObject<List<ItemEntry>>();
+                if (converted != null)
+                {
+                    for (int i = 0; i < converted.Count; i++)
+                    {
+                        _items.Add(converted[i]);
+                    }
                 }
             }
         }

--- a/Assets/MyAsset/Core/Inventory/InventoryManager.cs
+++ b/Assets/MyAsset/Core/Inventory/InventoryManager.cs
@@ -3,9 +3,29 @@ using System.Collections.Generic;
 
 namespace Game.Core
 {
-    public class InventoryManager
+    public class InventoryManager : ISaveable
     {
         private readonly List<ItemEntry> _items;
+
+        // ===== ISaveable =====
+        public string SaveId => "InventoryManager";
+
+        object ISaveable.Serialize()
+        {
+            return new List<ItemEntry>(_items);
+        }
+
+        void ISaveable.Deserialize(object data)
+        {
+            _items.Clear();
+            if (data is List<ItemEntry> items)
+            {
+                for (int i = 0; i < items.Count; i++)
+                {
+                    _items.Add(items[i]);
+                }
+            }
+        }
 
         public int ItemCount => _items.Count;
 

--- a/Assets/MyAsset/Core/LevelUp/LevelUpLogic.cs
+++ b/Assets/MyAsset/Core/LevelUp/LevelUpLogic.cs
@@ -3,10 +3,22 @@ using System;
 namespace Game.Core
 {
     /// <summary>
+    /// LevelUpLogicのセーブデータ。
+    /// </summary>
+    [Serializable]
+    public struct LevelUpSaveData
+    {
+        public int level;
+        public int currentExp;
+        public int availablePoints;
+        public StatModifier allocatedStats;
+    }
+
+    /// <summary>
     /// Handles experience accumulation, level-up judgment, stat point allocation,
     /// and vitals recalculation.
     /// </summary>
-    public class LevelUpLogic
+    public class LevelUpLogic : ISaveable
     {
         public const int k_PointsPerLevel = 3;
         public const int k_HpPerVit = 10;
@@ -121,6 +133,32 @@ namespace Game.Core
             result.maxMp = baseVitals.maxMp + (_allocatedStats.mnd * k_MpPerMnd);
             result.level = _level;
             return result;
+        }
+
+        // ===== ISaveable =====
+
+        public string SaveId => "LevelUpLogic";
+
+        object ISaveable.Serialize()
+        {
+            return new LevelUpSaveData
+            {
+                level = _level,
+                currentExp = _currentExp,
+                availablePoints = _availablePoints,
+                allocatedStats = _allocatedStats
+            };
+        }
+
+        void ISaveable.Deserialize(object data)
+        {
+            if (data is LevelUpSaveData saveData)
+            {
+                _level = Math.Max(1, saveData.level);
+                _currentExp = Math.Max(0, saveData.currentExp);
+                _availablePoints = Math.Max(0, saveData.availablePoints);
+                _allocatedStats = saveData.allocatedStats;
+            }
         }
     }
 

--- a/Assets/MyAsset/Core/LevelUp/LevelUpLogic.cs
+++ b/Assets/MyAsset/Core/LevelUp/LevelUpLogic.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json.Linq;
 
 namespace Game.Core
 {
@@ -152,13 +153,24 @@ namespace Game.Core
 
         void ISaveable.Deserialize(object data)
         {
-            if (data is LevelUpSaveData saveData)
+            LevelUpSaveData saveData;
+            if (data is LevelUpSaveData direct)
             {
-                _level = Math.Max(1, saveData.level);
-                _currentExp = Math.Max(0, saveData.currentExp);
-                _availablePoints = Math.Max(0, saveData.availablePoints);
-                _allocatedStats = saveData.allocatedStats;
+                saveData = direct;
             }
+            else if (data is JObject jObj)
+            {
+                saveData = jObj.ToObject<LevelUpSaveData>();
+            }
+            else
+            {
+                return;
+            }
+
+            _level = Math.Max(1, saveData.level);
+            _currentExp = Math.Max(0, saveData.currentExp);
+            _availablePoints = Math.Max(0, saveData.availablePoints);
+            _allocatedStats = saveData.allocatedStats;
         }
     }
 

--- a/Assets/MyAsset/Core/Save/FlagManager.cs
+++ b/Assets/MyAsset/Core/Save/FlagManager.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+
+namespace Game.Core
+{
+    /// <summary>
+    /// FlagManagerのセーブデータ。
+    /// </summary>
+    [Serializable]
+    public class FlagSaveData
+    {
+        public Dictionary<string, bool> globalFlags;
+        public Dictionary<string, Dictionary<string, bool>> mapLocalFlags;
+        public string currentMapId;
+    }
+
+    /// <summary>
+    /// グローバルフラグ + マップローカルフラグを管理する。
+    /// グローバル: ストーリー進行、好感度、実績等。
+    /// マップローカル: イベント再生済み、宝箱開封等（mapId単位で切替）。
+    /// ISaveable対応で永続化可能。
+    /// </summary>
+    public class FlagManager : ISaveable
+    {
+        private readonly Dictionary<string, bool> _globalFlags;
+        private readonly Dictionary<string, Dictionary<string, bool>> _mapLocalFlags;
+        private string _currentMapId;
+
+        /// <summary>現在のマップID。SwitchMap未呼び出し時はnull。</summary>
+        public string CurrentMapId => _currentMapId;
+
+        public FlagManager()
+        {
+            _globalFlags = new Dictionary<string, bool>();
+            _mapLocalFlags = new Dictionary<string, Dictionary<string, bool>>();
+            _currentMapId = null;
+        }
+
+        // ===== グローバルフラグ =====
+
+        /// <summary>グローバルフラグを設定する。</summary>
+        public void SetGlobalFlag(string flagId, bool value)
+        {
+            _globalFlags[flagId] = value;
+        }
+
+        /// <summary>グローバルフラグを取得する。未設定の場合はfalse。</summary>
+        public bool GetGlobalFlag(string flagId)
+        {
+            if (_globalFlags.TryGetValue(flagId, out bool value))
+            {
+                return value;
+            }
+            return false;
+        }
+
+        // ===== マップローカルフラグ =====
+
+        /// <summary>マップを切り替える。ローカルフラグセットが切り替わる。</summary>
+        public void SwitchMap(string mapId)
+        {
+            if (mapId == null)
+            {
+                return;
+            }
+
+            _currentMapId = mapId;
+
+            if (!_mapLocalFlags.ContainsKey(mapId))
+            {
+                _mapLocalFlags[mapId] = new Dictionary<string, bool>();
+            }
+        }
+
+        /// <summary>現在マップのローカルフラグを設定する。</summary>
+        public void SetLocalFlag(string flagId, bool value)
+        {
+            if (_currentMapId == null)
+            {
+                return;
+            }
+
+            _mapLocalFlags[_currentMapId][flagId] = value;
+        }
+
+        /// <summary>現在マップのローカルフラグを取得する。未設定またはマップ未切替時はfalse。</summary>
+        public bool GetLocalFlag(string flagId)
+        {
+            if (_currentMapId == null)
+            {
+                return false;
+            }
+
+            if (_mapLocalFlags.TryGetValue(_currentMapId, out Dictionary<string, bool> localFlags))
+            {
+                if (localFlags.TryGetValue(flagId, out bool value))
+                {
+                    return value;
+                }
+            }
+            return false;
+        }
+
+        // ===== ISaveable =====
+
+        public string SaveId => "FlagManager";
+
+        object ISaveable.Serialize()
+        {
+            FlagSaveData saveData = new FlagSaveData
+            {
+                globalFlags = new Dictionary<string, bool>(_globalFlags),
+                mapLocalFlags = new Dictionary<string, Dictionary<string, bool>>(),
+                currentMapId = _currentMapId
+            };
+
+            foreach (KeyValuePair<string, Dictionary<string, bool>> kvp in _mapLocalFlags)
+            {
+                saveData.mapLocalFlags[kvp.Key] = new Dictionary<string, bool>(kvp.Value);
+            }
+
+            return saveData;
+        }
+
+        void ISaveable.Deserialize(object data)
+        {
+            if (data is FlagSaveData saveData)
+            {
+                _globalFlags.Clear();
+                if (saveData.globalFlags != null)
+                {
+                    foreach (KeyValuePair<string, bool> kvp in saveData.globalFlags)
+                    {
+                        _globalFlags[kvp.Key] = kvp.Value;
+                    }
+                }
+
+                _mapLocalFlags.Clear();
+                if (saveData.mapLocalFlags != null)
+                {
+                    foreach (KeyValuePair<string, Dictionary<string, bool>> kvp in saveData.mapLocalFlags)
+                    {
+                        _mapLocalFlags[kvp.Key] = new Dictionary<string, bool>(kvp.Value);
+                    }
+                }
+
+                _currentMapId = saveData.currentMapId;
+            }
+        }
+    }
+}

--- a/Assets/MyAsset/Core/Save/FlagManager.cs
+++ b/Assets/MyAsset/Core/Save/FlagManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace Game.Core
 {
@@ -124,28 +125,39 @@ namespace Game.Core
 
         void ISaveable.Deserialize(object data)
         {
-            if (data is FlagSaveData saveData)
+            FlagSaveData saveData;
+            if (data is FlagSaveData direct)
             {
-                _globalFlags.Clear();
-                if (saveData.globalFlags != null)
-                {
-                    foreach (KeyValuePair<string, bool> kvp in saveData.globalFlags)
-                    {
-                        _globalFlags[kvp.Key] = kvp.Value;
-                    }
-                }
-
-                _mapLocalFlags.Clear();
-                if (saveData.mapLocalFlags != null)
-                {
-                    foreach (KeyValuePair<string, Dictionary<string, bool>> kvp in saveData.mapLocalFlags)
-                    {
-                        _mapLocalFlags[kvp.Key] = new Dictionary<string, bool>(kvp.Value);
-                    }
-                }
-
-                _currentMapId = saveData.currentMapId;
+                saveData = direct;
             }
+            else if (data is JObject jObj)
+            {
+                saveData = jObj.ToObject<FlagSaveData>();
+            }
+            else
+            {
+                return;
+            }
+
+            _globalFlags.Clear();
+            if (saveData.globalFlags != null)
+            {
+                foreach (KeyValuePair<string, bool> kvp in saveData.globalFlags)
+                {
+                    _globalFlags[kvp.Key] = kvp.Value;
+                }
+            }
+
+            _mapLocalFlags.Clear();
+            if (saveData.mapLocalFlags != null)
+            {
+                foreach (KeyValuePair<string, Dictionary<string, bool>> kvp in saveData.mapLocalFlags)
+                {
+                    _mapLocalFlags[kvp.Key] = new Dictionary<string, bool>(kvp.Value);
+                }
+            }
+
+            _currentMapId = saveData.currentMapId;
         }
     }
 }

--- a/Assets/MyAsset/Core/Save/FlagManager.cs.meta
+++ b/Assets/MyAsset/Core/Save/FlagManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 615865a113aa4272ae5e08d676ddf3c0

--- a/Assets/MyAsset/Core/Save/SaveDataStore.cs
+++ b/Assets/MyAsset/Core/Save/SaveDataStore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -51,7 +52,7 @@ namespace Game.Core
             foreach (KeyValuePair<string, object> kvp in slotData.entries)
             {
                 string json = JsonConvert.SerializeObject(kvp.Value);
-                string typeName = kvp.Value != null ? kvp.Value.GetType().AssemblyQualifiedName : "null";
+                string typeName = kvp.Value != null ? kvp.Value.GetType().FullName : "null";
 
                 fileData.entries[kvp.Key] = new SaveEntryData
                 {
@@ -97,7 +98,7 @@ namespace Game.Core
                         continue;
                     }
 
-                    Type type = Type.GetType(entryData.typeName);
+                    Type type = ResolveType(entryData.typeName);
                     if (type != null)
                     {
                         object value = JsonConvert.DeserializeObject(entryData.json, type);
@@ -128,6 +129,32 @@ namespace Game.Core
         public bool HasSlotFile(int slotIndex)
         {
             return File.Exists(GetSlotFilePath(slotIndex));
+        }
+
+        /// <summary>
+        /// FullNameから型を解決する。Type.GetTypeで見つからない場合は
+        /// 全アセンブリを検索するフォールバックを行う。
+        /// </summary>
+        private static Type ResolveType(string typeName)
+        {
+            Type type = Type.GetType(typeName);
+            if (type != null)
+            {
+                return type;
+            }
+
+            // FullNameの場合Type.GetTypeが失敗することがあるので全アセンブリから検索
+            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            for (int i = 0; i < assemblies.Length; i++)
+            {
+                type = assemblies[i].GetType(typeName);
+                if (type != null)
+                {
+                    return type;
+                }
+            }
+
+            return null;
         }
 
         private string GetSlotFilePath(int slotIndex)

--- a/Assets/MyAsset/Core/Save/SaveDataStore.cs
+++ b/Assets/MyAsset/Core/Save/SaveDataStore.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Game.Core
+{
+    /// <summary>
+    /// SaveSlotDataのディスク永続化を担当する純ロジッククラス。
+    /// JSON変換にはNewtonsoft.Jsonを使用。
+    /// entries の Dictionary&lt;string, object&gt; を型情報付きで保存・復元する。
+    /// </summary>
+    public class SaveDataStore
+    {
+        public const int k_CurrentVersion = 1;
+
+        private readonly string _basePath;
+        private readonly string _savesDir;
+
+        /// <summary>
+        /// コンストラクタ。basePath配下に saves/ ディレクトリを作成する。
+        /// </summary>
+        public SaveDataStore(string basePath)
+        {
+            _basePath = basePath;
+            _savesDir = Path.Combine(_basePath, "saves");
+        }
+
+        /// <summary>SaveSlotDataをJSONファイルとしてディスクに書き出す。</summary>
+        public void WriteToDisk(SaveSlotData slotData)
+        {
+            if (slotData == null)
+            {
+                return;
+            }
+
+            if (!Directory.Exists(_savesDir))
+            {
+                Directory.CreateDirectory(_savesDir);
+            }
+
+            SaveFileData fileData = new SaveFileData
+            {
+                version = k_CurrentVersion,
+                slotIndex = slotData.slotIndex,
+                timestamp = slotData.timestamp,
+                entries = new Dictionary<string, SaveEntryData>()
+            };
+
+            foreach (KeyValuePair<string, object> kvp in slotData.entries)
+            {
+                string json = JsonConvert.SerializeObject(kvp.Value);
+                string typeName = kvp.Value != null ? kvp.Value.GetType().AssemblyQualifiedName : "null";
+
+                fileData.entries[kvp.Key] = new SaveEntryData
+                {
+                    typeName = typeName,
+                    json = json
+                };
+            }
+
+            string fileJson = JsonConvert.SerializeObject(fileData, Formatting.Indented);
+            string filePath = GetSlotFilePath(slotData.slotIndex);
+            File.WriteAllText(filePath, fileJson);
+        }
+
+        /// <summary>ディスクからJSONファイルを読み込みSaveSlotDataに復元する。</summary>
+        public SaveSlotData ReadFromDisk(int slotIndex)
+        {
+            string filePath = GetSlotFilePath(slotIndex);
+
+            if (!File.Exists(filePath))
+            {
+                return null;
+            }
+
+            string fileJson = File.ReadAllText(filePath);
+            SaveFileData fileData = JsonConvert.DeserializeObject<SaveFileData>(fileJson);
+
+            if (fileData == null)
+            {
+                return null;
+            }
+
+            SaveSlotData slotData = new SaveSlotData(fileData.slotIndex);
+            slotData.timestamp = fileData.timestamp;
+
+            if (fileData.entries != null)
+            {
+                foreach (KeyValuePair<string, SaveEntryData> kvp in fileData.entries)
+                {
+                    SaveEntryData entryData = kvp.Value;
+                    if (entryData.typeName == "null")
+                    {
+                        slotData.entries[kvp.Key] = null;
+                        continue;
+                    }
+
+                    Type type = Type.GetType(entryData.typeName);
+                    if (type != null)
+                    {
+                        object value = JsonConvert.DeserializeObject(entryData.json, type);
+                        slotData.entries[kvp.Key] = value;
+                    }
+                    else
+                    {
+                        // 型が見つからない場合はJToken(JObject/JArray/JValue)のまま保持
+                        slotData.entries[kvp.Key] = JsonConvert.DeserializeObject(entryData.json);
+                    }
+                }
+            }
+
+            return slotData;
+        }
+
+        /// <summary>スロットファイルを削除する。</summary>
+        public void DeleteSlot(int slotIndex)
+        {
+            string filePath = GetSlotFilePath(slotIndex);
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+
+        /// <summary>スロットファイルが存在するか。</summary>
+        public bool HasSlotFile(int slotIndex)
+        {
+            return File.Exists(GetSlotFilePath(slotIndex));
+        }
+
+        private string GetSlotFilePath(int slotIndex)
+        {
+            return Path.Combine(_savesDir, $"slot_{slotIndex}.json");
+        }
+
+        // ===== 内部データ構造 =====
+
+        [Serializable]
+        private class SaveFileData
+        {
+            public int version;
+            public int slotIndex;
+            public string timestamp;
+            public Dictionary<string, SaveEntryData> entries;
+        }
+
+        [Serializable]
+        private class SaveEntryData
+        {
+            public string typeName;
+            public string json;
+        }
+    }
+}

--- a/Assets/MyAsset/Core/Save/SaveDataStore.cs.meta
+++ b/Assets/MyAsset/Core/Save/SaveDataStore.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0306e2293f144ffcaf1fc8b43c879c30

--- a/Assets/MyAsset/Core/Save/SaveManager.cs
+++ b/Assets/MyAsset/Core/Save/SaveManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Game.Core
@@ -5,25 +6,30 @@ namespace Game.Core
     /// <summary>
     /// セーブデータ管理（スロット制）。
     /// ISaveableを登録し、スロット単位でシリアライズ/デシリアライズを行う。
+    /// IGameSubManagerとしてGameManagerCoreに登録可能。
     /// </summary>
-    public class SaveManager
+    public class SaveManager : IGameSubManager
     {
         public const int k_MaxSlots = 3;
+        private const int k_InitOrder = 900;
 
         private readonly SaveSlotData[] _slots;
         private readonly List<ISaveable> _saveables;
+        private readonly HashSet<string> _registeredIds;
         private int _activeSlotIndex;
 
         public int ActiveSlotIndex => _activeSlotIndex;
+        public int InitOrder => k_InitOrder;
 
         public SaveManager()
         {
             _slots = new SaveSlotData[k_MaxSlots];
             _saveables = new List<ISaveable>();
+            _registeredIds = new HashSet<string>();
             _activeSlotIndex = 0;
         }
 
-        /// <summary>ISaveableを登録</summary>
+        /// <summary>ISaveableを登録。SaveIdの重複は例外。同一インスタンスの再登録は無視。</summary>
         public void Register(ISaveable saveable)
         {
             if (saveable == null)
@@ -31,7 +37,35 @@ namespace Game.Core
                 return;
             }
 
+            // 同一インスタンスの再登録は無視
+            if (_saveables.Contains(saveable))
+            {
+                return;
+            }
+
+            // SaveIdの重複チェック
+            if (_registeredIds.Contains(saveable.SaveId))
+            {
+                throw new InvalidOperationException(
+                    $"SaveId '{saveable.SaveId}' is already registered. Each ISaveable must have a unique SaveId.");
+            }
+
             _saveables.Add(saveable);
+            _registeredIds.Add(saveable.SaveId);
+        }
+
+        /// <summary>ISaveableを解除。シーン遷移時などに使用。</summary>
+        public void Unregister(ISaveable saveable)
+        {
+            if (saveable == null)
+            {
+                return;
+            }
+
+            if (_saveables.Remove(saveable))
+            {
+                _registeredIds.Remove(saveable.SaveId);
+            }
         }
 
         /// <summary>全ISaveableをシリアライズしてスロットに保存</summary>
@@ -112,6 +146,31 @@ namespace Game.Core
             }
 
             return _slots[slotIndex];
+        }
+
+        /// <summary>スロットデータを外部から設定（SaveDataStoreからのロード時に使用）</summary>
+        public void SetSlotData(int slotIndex, SaveSlotData data)
+        {
+            if (slotIndex < 0 || slotIndex >= k_MaxSlots)
+            {
+                return;
+            }
+
+            _slots[slotIndex] = data;
+        }
+
+        // ===== IGameSubManager =====
+
+        public void Initialize(SoACharaDataDic data, GameEvents events)
+        {
+            // SaveManagerはSoAデータに依存しないが、
+            // GameEventsのセーブ関連イベントを購読する場所として使用可能
+        }
+
+        public void Dispose()
+        {
+            _saveables.Clear();
+            _registeredIds.Clear();
         }
     }
 }

--- a/Assets/MyAsset/Core/Save/SaveManager.cs
+++ b/Assets/MyAsset/Core/Save/SaveManager.cs
@@ -171,6 +171,10 @@ namespace Game.Core
         {
             _saveables.Clear();
             _registeredIds.Clear();
+            for (int i = 0; i < _slots.Length; i++)
+            {
+                _slots[i] = null;
+            }
         }
     }
 }

--- a/Assets/MyAsset/Core/World/Backtrack/BacktrackRewardManager.cs
+++ b/Assets/MyAsset/Core/World/Backtrack/BacktrackRewardManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace Game.Core
 {
@@ -194,6 +195,14 @@ namespace Game.Core
             if (data is string[] ids)
             {
                 LoadCollectedIds(ids);
+            }
+            else if (data is JArray jArray)
+            {
+                string[] converted = jArray.ToObject<string[]>();
+                if (converted != null)
+                {
+                    LoadCollectedIds(converted);
+                }
             }
         }
     }

--- a/Assets/MyAsset/Core/World/Backtrack/BacktrackRewardManager.cs
+++ b/Assets/MyAsset/Core/World/Backtrack/BacktrackRewardManager.cs
@@ -23,7 +23,7 @@ namespace Game.Core
     /// 全バックトラック報酬の状態管理。
     /// エリアごとの報酬登録、回収状態追跡、能力獲得時の再評価を担う。
     /// </summary>
-    public class BacktrackRewardManager
+    public class BacktrackRewardManager : ISaveable
     {
         private readonly Dictionary<string, BacktrackRewardData[]> _areaRewards;
         private readonly HashSet<string> _collectedRewards;
@@ -177,6 +177,23 @@ namespace Game.Core
                 {
                     _collectedRewards.Add(ids[i]);
                 }
+            }
+        }
+
+        // ===== ISaveable =====
+
+        public string SaveId => "BacktrackRewardManager";
+
+        object ISaveable.Serialize()
+        {
+            return GetCollectedIds();
+        }
+
+        void ISaveable.Deserialize(object data)
+        {
+            if (data is string[] ids)
+            {
+                LoadCollectedIds(ids);
             }
         }
     }

--- a/Assets/MyAsset/Core/World/Gate/GateRegistry.cs
+++ b/Assets/MyAsset/Core/World/Gate/GateRegistry.cs
@@ -6,7 +6,7 @@ namespace Game.Core
     /// Tracks open/closed state of all gates in the current map.
     /// Supports serialization for save/load.
     /// </summary>
-    public class GateRegistry
+    public class GateRegistry : ISaveable
     {
         private Dictionary<string, bool> _gateStates;
 
@@ -58,6 +58,23 @@ namespace Game.Core
             foreach (KeyValuePair<string, bool> kvp in data)
             {
                 _gateStates[kvp.Key] = kvp.Value;
+            }
+        }
+
+        // ===== ISaveable =====
+
+        public string SaveId => "GateRegistry";
+
+        object ISaveable.Serialize()
+        {
+            return SerializeAll();
+        }
+
+        void ISaveable.Deserialize(object data)
+        {
+            if (data is Dictionary<string, bool> gateData)
+            {
+                DeserializeAll(gateData);
             }
         }
     }

--- a/Assets/MyAsset/Core/World/Gate/GateRegistry.cs
+++ b/Assets/MyAsset/Core/World/Gate/GateRegistry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace Game.Core
 {
@@ -75,6 +76,14 @@ namespace Game.Core
             if (data is Dictionary<string, bool> gateData)
             {
                 DeserializeAll(gateData);
+            }
+            else if (data is JObject jObj)
+            {
+                Dictionary<string, bool> converted = jObj.ToObject<Dictionary<string, bool>>();
+                if (converted != null)
+                {
+                    DeserializeAll(converted);
+                }
             }
         }
     }

--- a/Assets/Tests/EditMode/CurrencySystemCoreTests.cs
+++ b/Assets/Tests/EditMode/CurrencySystemCoreTests.cs
@@ -41,10 +41,10 @@ namespace Game.Tests.EditMode
         public void CurrencyManager_SerializeDeserialize_RestoresBalance()
         {
             CurrencyManager manager = new CurrencyManager(500);
-            int serialized = manager.Serialize();
+            int serialized = manager.SerializeBalance();
 
             CurrencyManager restored = new CurrencyManager();
-            restored.Deserialize(serialized);
+            restored.DeserializeBalance(serialized);
 
             Assert.AreEqual(500, restored.Balance);
         }

--- a/Assets/Tests/EditMode/FlagManagerTests.cs
+++ b/Assets/Tests/EditMode/FlagManagerTests.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Game.Core;
+
+namespace Game.Tests.EditMode
+{
+    public class FlagManagerTests
+    {
+        private FlagManager _flagManager;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _flagManager = new FlagManager();
+        }
+
+        // ===== ISaveable =====
+
+        [Test]
+        public void FlagManager_ImplementsISaveable()
+        {
+            Assert.IsInstanceOf<ISaveable>(_flagManager);
+        }
+
+        [Test]
+        public void FlagManager_SaveId_ReturnsFlagManager()
+        {
+            Assert.AreEqual("FlagManager", ((ISaveable)_flagManager).SaveId);
+        }
+
+        // ===== グローバルフラグ =====
+
+        [Test]
+        public void FlagManager_SetGlobalFlag_GetReturnsTrue()
+        {
+            _flagManager.SetGlobalFlag("story_chapter1_complete", true);
+
+            Assert.IsTrue(_flagManager.GetGlobalFlag("story_chapter1_complete"));
+        }
+
+        [Test]
+        public void FlagManager_GetGlobalFlag_NotSet_ReturnsFalse()
+        {
+            Assert.IsFalse(_flagManager.GetGlobalFlag("nonexistent"));
+        }
+
+        [Test]
+        public void FlagManager_SetGlobalFlag_ToggleOff()
+        {
+            _flagManager.SetGlobalFlag("flag1", true);
+            _flagManager.SetGlobalFlag("flag1", false);
+
+            Assert.IsFalse(_flagManager.GetGlobalFlag("flag1"));
+        }
+
+        // ===== マップローカルフラグ =====
+
+        [Test]
+        public void FlagManager_SetLocalFlag_GetReturnsTrue()
+        {
+            _flagManager.SwitchMap("map_forest");
+            _flagManager.SetLocalFlag("chest_opened", true);
+
+            Assert.IsTrue(_flagManager.GetLocalFlag("chest_opened"));
+        }
+
+        [Test]
+        public void FlagManager_GetLocalFlag_NoMapSwitched_ReturnsFalse()
+        {
+            Assert.IsFalse(_flagManager.GetLocalFlag("any_flag"));
+        }
+
+        [Test]
+        public void FlagManager_SwitchMap_LocalFlagsSwitched()
+        {
+            _flagManager.SwitchMap("map_forest");
+            _flagManager.SetLocalFlag("event_played", true);
+
+            _flagManager.SwitchMap("map_cave");
+            _flagManager.SetLocalFlag("boss_defeated", true);
+
+            // forestに戻るとforestのフラグが見える
+            _flagManager.SwitchMap("map_forest");
+            Assert.IsTrue(_flagManager.GetLocalFlag("event_played"));
+            Assert.IsFalse(_flagManager.GetLocalFlag("boss_defeated"));
+
+            // caveに戻るとcaveのフラグが見える
+            _flagManager.SwitchMap("map_cave");
+            Assert.IsTrue(_flagManager.GetLocalFlag("boss_defeated"));
+            Assert.IsFalse(_flagManager.GetLocalFlag("event_played"));
+        }
+
+        [Test]
+        public void FlagManager_SwitchMap_Null_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => _flagManager.SwitchMap(null));
+        }
+
+        // ===== Serialize/Deserialize =====
+
+        [Test]
+        public void FlagManager_SerializeDeserialize_GlobalFlags_Preserved()
+        {
+            _flagManager.SetGlobalFlag("story_flag_1", true);
+            _flagManager.SetGlobalFlag("achievement_1", true);
+            ISaveable saveable = _flagManager;
+
+            object data = saveable.Serialize();
+
+            FlagManager restored = new FlagManager();
+            ((ISaveable)restored).Deserialize(data);
+
+            Assert.IsTrue(restored.GetGlobalFlag("story_flag_1"));
+            Assert.IsTrue(restored.GetGlobalFlag("achievement_1"));
+            Assert.IsFalse(restored.GetGlobalFlag("nonexistent"));
+        }
+
+        [Test]
+        public void FlagManager_SerializeDeserialize_LocalFlags_Preserved()
+        {
+            _flagManager.SwitchMap("map_a");
+            _flagManager.SetLocalFlag("chest_1", true);
+            _flagManager.SwitchMap("map_b");
+            _flagManager.SetLocalFlag("event_1", true);
+            ISaveable saveable = _flagManager;
+
+            object data = saveable.Serialize();
+
+            FlagManager restored = new FlagManager();
+            ((ISaveable)restored).Deserialize(data);
+
+            restored.SwitchMap("map_a");
+            Assert.IsTrue(restored.GetLocalFlag("chest_1"));
+
+            restored.SwitchMap("map_b");
+            Assert.IsTrue(restored.GetLocalFlag("event_1"));
+        }
+
+        [Test]
+        public void FlagManager_SerializeDeserialize_RoundTrip_CompleteState()
+        {
+            _flagManager.SetGlobalFlag("global_1", true);
+            _flagManager.SwitchMap("map_x");
+            _flagManager.SetLocalFlag("local_1", true);
+            _flagManager.SetLocalFlag("local_2", false);
+            ISaveable saveable = _flagManager;
+
+            object data = saveable.Serialize();
+
+            FlagManager restored = new FlagManager();
+            ((ISaveable)restored).Deserialize(data);
+
+            Assert.IsTrue(restored.GetGlobalFlag("global_1"));
+            restored.SwitchMap("map_x");
+            Assert.IsTrue(restored.GetLocalFlag("local_1"));
+            Assert.IsFalse(restored.GetLocalFlag("local_2"));
+        }
+
+        // ===== CurrentMapId =====
+
+        [Test]
+        public void FlagManager_CurrentMapId_ReturnsCurrentMap()
+        {
+            Assert.IsNull(_flagManager.CurrentMapId);
+
+            _flagManager.SwitchMap("map_forest");
+            Assert.AreEqual("map_forest", _flagManager.CurrentMapId);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/FlagManagerTests.cs.meta
+++ b/Assets/Tests/EditMode/FlagManagerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 67129e3e9b69422298d4a7df5ed3d66c

--- a/Assets/Tests/EditMode/Game.Tests.EditMode.asmdef
+++ b/Assets/Tests/EditMode/Game.Tests.EditMode.asmdef
@@ -17,7 +17,8 @@
     "overrideReferences": true,
     "precompiledReferences": [
         "nunit.framework.dll",
-        "R3.dll"
+        "R3.dll",
+        "Newtonsoft.Json.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/Assets/Tests/EditMode/ISaveableImplementationTests.cs
+++ b/Assets/Tests/EditMode/ISaveableImplementationTests.cs
@@ -1,0 +1,241 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Game.Core;
+
+namespace Game.Tests.EditMode
+{
+    /// <summary>
+    /// 各クラスのISaveable実装テスト。
+    /// SaveId一意性、Serialize/Deserialize往復を検証。
+    /// </summary>
+    public class ISaveableImplementationTests
+    {
+        // ===== CurrencyManager =====
+
+        [Test]
+        public void CurrencyManager_ImplementsISaveable()
+        {
+            CurrencyManager manager = new CurrencyManager();
+            Assert.IsInstanceOf<ISaveable>(manager);
+        }
+
+        [Test]
+        public void CurrencyManager_SaveId_ReturnsCurrencyManager()
+        {
+            CurrencyManager manager = new CurrencyManager();
+            ISaveable saveable = manager;
+            Assert.AreEqual("CurrencyManager", saveable.SaveId);
+        }
+
+        [Test]
+        public void CurrencyManager_SerializeDeserialize_RoundTrip()
+        {
+            CurrencyManager original = new CurrencyManager(500);
+            original.Add(200);
+            ISaveable saveable = original;
+
+            object data = saveable.Serialize();
+
+            CurrencyManager restored = new CurrencyManager();
+            ISaveable restoredSaveable = restored;
+            restoredSaveable.Deserialize(data);
+
+            Assert.AreEqual(700, restored.Balance);
+        }
+
+        [Test]
+        public void CurrencyManager_Deserialize_NegativeBalance_ClampsToZero()
+        {
+            CurrencyManager manager = new CurrencyManager();
+            ISaveable saveable = manager;
+            saveable.Deserialize(-100);
+
+            Assert.AreEqual(0, manager.Balance);
+        }
+
+        // ===== InventoryManager =====
+
+        [Test]
+        public void InventoryManager_ImplementsISaveable()
+        {
+            InventoryManager manager = new InventoryManager();
+            Assert.IsInstanceOf<ISaveable>(manager);
+        }
+
+        [Test]
+        public void InventoryManager_SaveId_ReturnsInventoryManager()
+        {
+            InventoryManager manager = new InventoryManager();
+            ISaveable saveable = manager;
+            Assert.AreEqual("InventoryManager", saveable.SaveId);
+        }
+
+        [Test]
+        public void InventoryManager_SerializeDeserialize_RoundTrip()
+        {
+            InventoryManager original = new InventoryManager();
+            original.Add(1, ItemCategory.Consumable, 3, 10);
+            original.Add(2, ItemCategory.Material, 5, 99);
+            ISaveable saveable = original;
+
+            object data = saveable.Serialize();
+
+            InventoryManager restored = new InventoryManager();
+            ISaveable restoredSaveable = restored;
+            restoredSaveable.Deserialize(data);
+
+            Assert.AreEqual(2, restored.ItemCount);
+            Assert.AreEqual(3, restored.GetCount(1));
+            Assert.AreEqual(5, restored.GetCount(2));
+        }
+
+        [Test]
+        public void InventoryManager_Deserialize_EmptyList_ClearsInventory()
+        {
+            InventoryManager manager = new InventoryManager();
+            manager.Add(1, ItemCategory.Consumable, 5, 10);
+            ISaveable saveable = manager;
+
+            saveable.Deserialize(new List<ItemEntry>());
+
+            Assert.AreEqual(0, manager.ItemCount);
+        }
+
+        // ===== LevelUpLogic =====
+
+        [Test]
+        public void LevelUpLogic_ImplementsISaveable()
+        {
+            LevelUpLogic logic = new LevelUpLogic();
+            Assert.IsInstanceOf<ISaveable>(logic);
+        }
+
+        [Test]
+        public void LevelUpLogic_SaveId_ReturnsLevelUpLogic()
+        {
+            LevelUpLogic logic = new LevelUpLogic();
+            ISaveable saveable = logic;
+            Assert.AreEqual("LevelUpLogic", saveable.SaveId);
+        }
+
+        [Test]
+        public void LevelUpLogic_SerializeDeserialize_RoundTrip()
+        {
+            LevelUpLogic original = new LevelUpLogic(1);
+            original.AddExp(250); // level 1→3 (100+200=300, remaining 250-100-200=-50? Let's check: level*100)
+            // level1: need 100. 250-100=150, level2. level2: need 200. 150<200. So level=2, exp=150
+            original.AllocatePoint(StatType.Str);
+            original.AllocatePoint(StatType.Vit);
+            ISaveable saveable = original;
+
+            object data = saveable.Serialize();
+
+            LevelUpLogic restored = new LevelUpLogic();
+            ISaveable restoredSaveable = restored;
+            restoredSaveable.Deserialize(data);
+
+            Assert.AreEqual(2, restored.Level);
+            Assert.AreEqual(150, restored.CurrentExp);
+            Assert.AreEqual(1, restored.AvailablePoints); // 3 gained - 2 allocated = 1
+            Assert.AreEqual(1, restored.AllocatedStats.str);
+            Assert.AreEqual(1, restored.AllocatedStats.vit);
+            Assert.AreEqual(0, restored.AllocatedStats.dex);
+        }
+
+        // ===== GateRegistry =====
+
+        [Test]
+        public void GateRegistry_ImplementsISaveable()
+        {
+            GateRegistry registry = new GateRegistry();
+            Assert.IsInstanceOf<ISaveable>(registry);
+        }
+
+        [Test]
+        public void GateRegistry_SaveId_ReturnsGateRegistry()
+        {
+            GateRegistry registry = new GateRegistry();
+            ISaveable saveable = registry;
+            Assert.AreEqual("GateRegistry", saveable.SaveId);
+        }
+
+        [Test]
+        public void GateRegistry_SerializeDeserialize_RoundTrip()
+        {
+            GateRegistry original = new GateRegistry();
+            original.Register("gate_a", false);
+            original.Register("gate_b", true);
+            original.Open("gate_a");
+            ISaveable saveable = original;
+
+            object data = saveable.Serialize();
+
+            GateRegistry restored = new GateRegistry();
+            ISaveable restoredSaveable = restored;
+            restoredSaveable.Deserialize(data);
+
+            Assert.IsTrue(restored.IsOpen("gate_a"));
+            Assert.IsTrue(restored.IsOpen("gate_b"));
+            Assert.AreEqual(2, restored.Count);
+        }
+
+        // ===== BacktrackRewardManager =====
+
+        [Test]
+        public void BacktrackRewardManager_ImplementsISaveable()
+        {
+            BacktrackRewardManager manager = new BacktrackRewardManager();
+            Assert.IsInstanceOf<ISaveable>(manager);
+        }
+
+        [Test]
+        public void BacktrackRewardManager_SaveId_ReturnsBacktrackRewardManager()
+        {
+            BacktrackRewardManager manager = new BacktrackRewardManager();
+            ISaveable saveable = manager;
+            Assert.AreEqual("BacktrackRewardManager", saveable.SaveId);
+        }
+
+        [Test]
+        public void BacktrackRewardManager_SerializeDeserialize_RoundTrip()
+        {
+            BacktrackRewardManager original = new BacktrackRewardManager();
+            original.MarkCollected("reward_1");
+            original.MarkCollected("reward_2");
+            ISaveable saveable = original;
+
+            object data = saveable.Serialize();
+
+            BacktrackRewardManager restored = new BacktrackRewardManager();
+            ISaveable restoredSaveable = restored;
+            restoredSaveable.Deserialize(data);
+
+            Assert.IsTrue(restored.IsCollected("reward_1"));
+            Assert.IsTrue(restored.IsCollected("reward_2"));
+            Assert.IsFalse(restored.IsCollected("reward_3"));
+        }
+
+        // ===== SaveId一意性テスト =====
+
+        [Test]
+        public void AllISaveables_HaveUniqueSaveIds()
+        {
+            HashSet<string> ids = new HashSet<string>();
+
+            ISaveable[] saveables = new ISaveable[]
+            {
+                new CurrencyManager(),
+                new InventoryManager(),
+                new LevelUpLogic(),
+                new GateRegistry(),
+                new BacktrackRewardManager(),
+            };
+
+            foreach (ISaveable saveable in saveables)
+            {
+                Assert.IsTrue(ids.Add(saveable.SaveId),
+                    $"Duplicate SaveId detected: {saveable.SaveId}");
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/ISaveableImplementationTests.cs.meta
+++ b/Assets/Tests/EditMode/ISaveableImplementationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6cd8a10f2538424d9fd9264d609340fb

--- a/Assets/Tests/EditMode/Integration_SaveSystemTests.cs
+++ b/Assets/Tests/EditMode/Integration_SaveSystemTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using NUnit.Framework;
 using Game.Core;
 
@@ -180,6 +181,118 @@ namespace Game.Tests.EditMode
             Assert.AreEqual(2, inventory.ItemCount);
             Assert.AreEqual(5, inventory.GetCount(1));
             Assert.AreEqual(3, inventory.GetCount(2));
+        }
+
+        [Test]
+        public void DiskRoundTrip_AllISaveables_RestoredAfterJsonSerialization()
+        {
+            // 一時ディレクトリを使用
+            string tempDir = Path.Combine(Path.GetTempPath(), "SaveSystemTest_" + System.Guid.NewGuid().ToString("N"));
+
+            try
+            {
+                // --- 準備: 各ISaveableにデータを設定 ---
+                CurrencyManager currency = new CurrencyManager(1234);
+                InventoryManager inventory = new InventoryManager();
+                inventory.Add(10, ItemCategory.Consumable, 3, 10);
+                inventory.Add(20, ItemCategory.Weapon, 1, 1);
+
+                LevelUpLogic levelUp = new LevelUpLogic(1);
+                levelUp.AddExp(250); // レベル2へ (exp 100必要, 残り150)
+                levelUp.AllocatePoint(StatType.Vit);
+                levelUp.AllocatePoint(StatType.Str);
+
+                GateRegistry gates = new GateRegistry();
+                gates.Register("gate_north", false);
+                gates.Register("gate_south", true);
+                gates.Open("gate_north");
+
+                BacktrackRewardManager backtrack = new BacktrackRewardManager();
+                backtrack.MarkCollected("chest_01");
+                backtrack.MarkCollected("chest_02");
+
+                FlagManager flags = new FlagManager();
+                flags.SetGlobalFlag("boss_defeated", true);
+                flags.SetGlobalFlag("intro_seen", true);
+                flags.SwitchMap("dungeon_1");
+                flags.SetLocalFlag("trap_triggered", true);
+
+                // --- Save: メモリに保存 → ディスクへ書き出し ---
+                _saveManager.Register(currency);
+                _saveManager.Register(inventory);
+                _saveManager.Register(levelUp);
+                _saveManager.Register(gates);
+                _saveManager.Register(backtrack);
+                _saveManager.Register(flags);
+
+                SaveSlotData savedSlot = _saveManager.Save(0);
+                Assert.IsNotNull(savedSlot);
+
+                SaveDataStore store = new SaveDataStore(tempDir);
+                store.WriteToDisk(savedSlot);
+
+                // --- Load: ディスクから読み込み → 新しいSaveManagerで復元 ---
+                SaveSlotData loadedSlot = store.ReadFromDisk(0);
+                Assert.IsNotNull(loadedSlot);
+
+                // 新しいSaveManagerと新しいISaveableインスタンスを用意
+                SaveManager saveManager2 = new SaveManager();
+                CurrencyManager currency2 = new CurrencyManager(0);
+                InventoryManager inventory2 = new InventoryManager();
+                LevelUpLogic levelUp2 = new LevelUpLogic(1);
+                GateRegistry gates2 = new GateRegistry();
+                BacktrackRewardManager backtrack2 = new BacktrackRewardManager();
+                FlagManager flags2 = new FlagManager();
+
+                saveManager2.Register(currency2);
+                saveManager2.Register(inventory2);
+                saveManager2.Register(levelUp2);
+                saveManager2.Register(gates2);
+                saveManager2.Register(backtrack2);
+                saveManager2.Register(flags2);
+
+                saveManager2.SetSlotData(0, loadedSlot);
+                bool loadResult = saveManager2.Load(0);
+                Assert.IsTrue(loadResult);
+
+                // --- 検証: 全ISaveableの値が正しく復元されていること ---
+
+                // CurrencyManager
+                Assert.AreEqual(1234, currency2.Balance, "CurrencyManager: 残高が復元されていない");
+
+                // InventoryManager
+                Assert.AreEqual(2, inventory2.ItemCount, "InventoryManager: アイテム数が復元されていない");
+                Assert.AreEqual(3, inventory2.GetCount(10), "InventoryManager: アイテム10の数量が正しくない");
+                Assert.AreEqual(1, inventory2.GetCount(20), "InventoryManager: アイテム20の数量が正しくない");
+
+                // LevelUpLogic
+                Assert.AreEqual(2, levelUp2.Level, "LevelUpLogic: レベルが復元されていない");
+                Assert.AreEqual(150, levelUp2.CurrentExp, "LevelUpLogic: 経験値が復元されていない");
+                Assert.AreEqual(1, levelUp2.AllocatedStats.vit, "LevelUpLogic: VIT割り振りが復元されていない");
+                Assert.AreEqual(1, levelUp2.AllocatedStats.str, "LevelUpLogic: STR割り振りが復元されていない");
+
+                // GateRegistry
+                Assert.IsTrue(gates2.IsOpen("gate_north"), "GateRegistry: gate_northが開いていない");
+                Assert.IsTrue(gates2.IsOpen("gate_south"), "GateRegistry: gate_southが開いていない");
+
+                // BacktrackRewardManager
+                Assert.IsTrue(backtrack2.IsCollected("chest_01"), "BacktrackRewardManager: chest_01が回収済みでない");
+                Assert.IsTrue(backtrack2.IsCollected("chest_02"), "BacktrackRewardManager: chest_02が回収済みでない");
+
+                // FlagManager
+                Assert.IsTrue(flags2.GetGlobalFlag("boss_defeated"), "FlagManager: boss_defeatedフラグが復元されていない");
+                Assert.IsTrue(flags2.GetGlobalFlag("intro_seen"), "FlagManager: intro_seenフラグが復元されていない");
+                flags2.SwitchMap("dungeon_1");
+                Assert.IsTrue(flags2.GetLocalFlag("trap_triggered"), "FlagManager: trap_triggeredローカルフラグが復元されていない");
+            }
+            finally
+            {
+                // テスト後に一時ディレクトリを削除
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, true);
+                }
+            }
         }
     }
 }

--- a/Assets/Tests/EditMode/Integration_SaveSystemTests.cs
+++ b/Assets/Tests/EditMode/Integration_SaveSystemTests.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Game.Core;
+
+namespace Game.Tests.EditMode
+{
+    /// <summary>
+    /// セーブシステム結合テスト。
+    /// 複数ISaveableの一括保存/復元、スロット上書き、FlagManager連携を検証。
+    /// </summary>
+    public class Integration_SaveSystemTests
+    {
+        private SaveManager _saveManager;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _saveManager = new SaveManager();
+        }
+
+        [Test]
+        public void MultipleISaveables_SaveAndLoad_AllRestored()
+        {
+            CurrencyManager currency = new CurrencyManager(1000);
+            GateRegistry gates = new GateRegistry();
+            gates.Register("gate_a", false);
+            gates.Open("gate_a");
+            BacktrackRewardManager backtrack = new BacktrackRewardManager();
+            backtrack.MarkCollected("reward_1");
+
+            _saveManager.Register(currency);
+            _saveManager.Register(gates);
+            _saveManager.Register(backtrack);
+
+            _saveManager.Save(0);
+
+            // 状態をリセット
+            currency.TrySpend(1000);
+            gates.Close("gate_a");
+            // BacktrackRewardManagerにはクリアメソッドがないのでnew
+            BacktrackRewardManager backtrack2 = new BacktrackRewardManager();
+            _saveManager.Unregister(backtrack);
+            _saveManager.Register(backtrack2);
+
+            _saveManager.Load(0);
+
+            Assert.AreEqual(1000, currency.Balance);
+            Assert.IsTrue(gates.IsOpen("gate_a"));
+            Assert.IsTrue(backtrack2.IsCollected("reward_1"));
+        }
+
+        [Test]
+        public void SlotOverwrite_PreviousDataNotLeaked()
+        {
+            CurrencyManager currency = new CurrencyManager(500);
+            _saveManager.Register(currency);
+
+            // スロット0に保存
+            _saveManager.Save(0);
+
+            // 残高変更後にスロット0を上書き
+            currency.Add(300);
+            _saveManager.Save(0);
+
+            // ロードすると上書き後の値
+            currency.TrySpend(800);
+            _saveManager.Load(0);
+
+            Assert.AreEqual(800, currency.Balance);
+        }
+
+        [Test]
+        public void FlagManager_WithOtherISaveables_SimultaneousSaveLoad()
+        {
+            CurrencyManager currency = new CurrencyManager(250);
+            FlagManager flags = new FlagManager();
+            flags.SetGlobalFlag("story_complete", true);
+            flags.SwitchMap("map_1");
+            flags.SetLocalFlag("chest_opened", true);
+
+            _saveManager.Register(currency);
+            _saveManager.Register(flags);
+
+            _saveManager.Save(1);
+
+            // リセット
+            currency.TrySpend(250);
+            FlagManager flags2 = new FlagManager();
+            _saveManager.Unregister(flags);
+            _saveManager.Register(flags2);
+
+            _saveManager.Load(1);
+
+            Assert.AreEqual(250, currency.Balance);
+            Assert.IsTrue(flags2.GetGlobalFlag("story_complete"));
+            flags2.SwitchMap("map_1");
+            Assert.IsTrue(flags2.GetLocalFlag("chest_opened"));
+        }
+
+        [Test]
+        public void MultipleSlots_IndependentData()
+        {
+            CurrencyManager currency = new CurrencyManager(100);
+            _saveManager.Register(currency);
+
+            _saveManager.Save(0);
+
+            currency.Add(400);
+            _saveManager.Save(1);
+
+            // スロット0をロード → 100
+            _saveManager.Load(0);
+            Assert.AreEqual(100, currency.Balance);
+
+            // スロット1をロード → 500
+            _saveManager.Load(1);
+            Assert.AreEqual(500, currency.Balance);
+        }
+
+        [Test]
+        public void UnregisterAndReregister_DoesNotCorruptState()
+        {
+            CurrencyManager currency = new CurrencyManager(300);
+            _saveManager.Register(currency);
+            _saveManager.Save(0);
+
+            _saveManager.Unregister(currency);
+
+            // 同じSaveIdで再登録可能
+            CurrencyManager currency2 = new CurrencyManager(0);
+            _saveManager.Register(currency2);
+            _saveManager.Load(0);
+
+            Assert.AreEqual(300, currency2.Balance);
+        }
+
+        [Test]
+        public void LevelUpLogic_WithCurrency_IntegrationSaveLoad()
+        {
+            CurrencyManager currency = new CurrencyManager(999);
+            LevelUpLogic levelUp = new LevelUpLogic(1);
+            levelUp.AddExp(250);
+            levelUp.AllocatePoint(StatType.Str);
+
+            _saveManager.Register(currency);
+            _saveManager.Register(levelUp);
+
+            _saveManager.Save(0);
+
+            // リセット
+            currency.TrySpend(999);
+            LevelUpLogic levelUp2 = new LevelUpLogic();
+            _saveManager.Unregister(levelUp);
+            _saveManager.Register(levelUp2);
+
+            _saveManager.Load(0);
+
+            Assert.AreEqual(999, currency.Balance);
+            Assert.AreEqual(2, levelUp2.Level);
+            Assert.AreEqual(1, levelUp2.AllocatedStats.str);
+        }
+
+        [Test]
+        public void InventoryManager_SaveLoad_Integration()
+        {
+            InventoryManager inventory = new InventoryManager();
+            inventory.Add(1, ItemCategory.Consumable, 5, 10);
+            inventory.Add(2, ItemCategory.Material, 3, 99);
+
+            _saveManager.Register(inventory);
+            _saveManager.Save(0);
+
+            // リセット
+            inventory.Remove(1, 5);
+            inventory.Remove(2, 3);
+            Assert.AreEqual(0, inventory.ItemCount);
+
+            _saveManager.Load(0);
+
+            Assert.AreEqual(2, inventory.ItemCount);
+            Assert.AreEqual(5, inventory.GetCount(1));
+            Assert.AreEqual(3, inventory.GetCount(2));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Integration_SaveSystemTests.cs.meta
+++ b/Assets/Tests/EditMode/Integration_SaveSystemTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 77d03e5e327442408f1d5e923252b36d

--- a/Assets/Tests/EditMode/SaveDataStoreTests.cs
+++ b/Assets/Tests/EditMode/SaveDataStoreTests.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using Game.Core;
+
+namespace Game.Tests.EditMode
+{
+    public class SaveDataStoreTests
+    {
+        private string _testDir;
+        private SaveDataStore _store;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _testDir = Path.Combine(Path.GetTempPath(), "SaveDataStoreTest_" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_testDir);
+            _store = new SaveDataStore(_testDir);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_testDir))
+            {
+                Directory.Delete(_testDir, true);
+            }
+        }
+
+        [Test]
+        public void SaveDataStore_WriteToDisk_CreatesFile()
+        {
+            SaveSlotData slotData = new SaveSlotData(0);
+            slotData.entries["test"] = 42;
+
+            _store.WriteToDisk(slotData);
+
+            string filePath = Path.Combine(_testDir, "saves", "slot_0.json");
+            Assert.IsTrue(File.Exists(filePath));
+        }
+
+        [Test]
+        public void SaveDataStore_ReadFromDisk_RestoresData()
+        {
+            SaveSlotData original = new SaveSlotData(0);
+            original.entries["intVal"] = 42;
+            original.entries["strVal"] = "hello";
+
+            _store.WriteToDisk(original);
+            SaveSlotData restored = _store.ReadFromDisk(0);
+
+            Assert.IsNotNull(restored);
+            Assert.AreEqual(0, restored.slotIndex);
+            Assert.AreEqual(42, System.Convert.ToInt32(restored.entries["intVal"]));
+            Assert.AreEqual("hello", restored.entries["strVal"].ToString());
+        }
+
+        [Test]
+        public void SaveDataStore_ReadFromDisk_NonExistentSlot_ReturnsNull()
+        {
+            SaveSlotData result = _store.ReadFromDisk(2);
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void SaveDataStore_RoundTrip_PreservesComplexData()
+        {
+            SaveSlotData original = new SaveSlotData(1);
+            // int
+            original.entries["balance"] = 1000;
+            // string array
+            original.entries["collectedIds"] = new string[] { "reward_1", "reward_2" };
+            // dictionary
+            Dictionary<string, bool> gateStates = new Dictionary<string, bool>
+            {
+                { "gate_a", true },
+                { "gate_b", false }
+            };
+            original.entries["gates"] = gateStates;
+
+            _store.WriteToDisk(original);
+            SaveSlotData restored = _store.ReadFromDisk(1);
+
+            Assert.IsNotNull(restored);
+            Assert.AreEqual(1, restored.slotIndex);
+        }
+
+        [Test]
+        public void SaveDataStore_WriteToDisk_IncludesVersion()
+        {
+            SaveSlotData slotData = new SaveSlotData(0);
+            _store.WriteToDisk(slotData);
+
+            string filePath = Path.Combine(_testDir, "saves", "slot_0.json");
+            string json = File.ReadAllText(filePath);
+
+            Assert.IsTrue(json.Contains("\"version\""));
+        }
+
+        [Test]
+        public void SaveDataStore_Overwrite_ReplacesOldData()
+        {
+            SaveSlotData first = new SaveSlotData(0);
+            first.entries["val"] = 10;
+            _store.WriteToDisk(first);
+
+            SaveSlotData second = new SaveSlotData(0);
+            second.entries["val"] = 99;
+            _store.WriteToDisk(second);
+
+            SaveSlotData restored = _store.ReadFromDisk(0);
+            Assert.AreEqual(99, System.Convert.ToInt32(restored.entries["val"]));
+        }
+
+        [Test]
+        public void SaveDataStore_DeleteSlot_RemovesFile()
+        {
+            SaveSlotData slotData = new SaveSlotData(0);
+            slotData.entries["test"] = 1;
+            _store.WriteToDisk(slotData);
+
+            _store.DeleteSlot(0);
+
+            string filePath = Path.Combine(_testDir, "saves", "slot_0.json");
+            Assert.IsFalse(File.Exists(filePath));
+        }
+
+        [Test]
+        public void SaveDataStore_HasSlotFile_ReturnsTrueWhenExists()
+        {
+            SaveSlotData slotData = new SaveSlotData(0);
+            _store.WriteToDisk(slotData);
+
+            Assert.IsTrue(_store.HasSlotFile(0));
+            Assert.IsFalse(_store.HasSlotFile(1));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/SaveDataStoreTests.cs.meta
+++ b/Assets/Tests/EditMode/SaveDataStoreTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d017b7e4cbad4e6dbb8d297481685437

--- a/Assets/Tests/EditMode/SaveManagerWiringTests.cs
+++ b/Assets/Tests/EditMode/SaveManagerWiringTests.cs
@@ -1,0 +1,86 @@
+using NUnit.Framework;
+using Game.Core;
+
+namespace Game.Tests.EditMode
+{
+    /// <summary>
+    /// SaveManagerのIGameSubManager配線テスト。
+    /// GameManagerCoreに登録して正しく初期化・破棄されることを検証。
+    /// </summary>
+    public class SaveManagerWiringTests
+    {
+        private GameManagerCore _core;
+        private SaveManager _saveManager;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _core = new GameManagerCore();
+            _saveManager = new SaveManager();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _core?.Dispose();
+        }
+
+        [Test]
+        public void SaveManager_RegisterAsSubManager_InitializesWithoutError()
+        {
+            _core.RegisterSubManager(_saveManager);
+
+            Assert.DoesNotThrow(() => _core.Initialize(4));
+        }
+
+        [Test]
+        public void SaveManager_AfterCoreInitialize_StillFunctions()
+        {
+            _core.RegisterSubManager(_saveManager);
+            _core.Initialize(4);
+
+            // SaveManagerは初期化後も通常のSave/Load機能が動作する
+            MockSaveable mock = new MockSaveable { SaveId = "wiring_test", Value = 100 };
+            _saveManager.Register(mock);
+            _saveManager.Save(0);
+
+            mock.Value = 0;
+            _saveManager.Load(0);
+
+            Assert.AreEqual(100, mock.Value);
+        }
+
+        [Test]
+        public void SaveManager_AfterCoreDispose_SaveablesCleared()
+        {
+            _core.RegisterSubManager(_saveManager);
+            _core.Initialize(4);
+
+            MockSaveable mock = new MockSaveable { SaveId = "dispose_test", Value = 50 };
+            _saveManager.Register(mock);
+
+            _core.Dispose();
+
+            // Dispose後はsaveablesがクリアされているので、
+            // 再登録時に重複SaveIdエラーが出ない
+            SaveManager newManager = new SaveManager();
+            Assert.DoesNotThrow(() => newManager.Register(
+                new MockSaveable { SaveId = "dispose_test", Value = 0 }));
+        }
+
+        [Test]
+        public void SaveManager_InitOrder_Is900_InitializedLate()
+        {
+            // InitOrder=900はシステムの後半で初期化される
+            Assert.AreEqual(900, (_saveManager as IGameSubManager).InitOrder);
+        }
+
+        private class MockSaveable : ISaveable
+        {
+            public string SaveId { get; set; }
+            public int Value { get; set; }
+            public object Serialize() => Value;
+            public void Deserialize(object data) { Value = (int)data; }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/SaveManagerWiringTests.cs.meta
+++ b/Assets/Tests/EditMode/SaveManagerWiringTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aa183341913c471ea8c2e05ece1ff233

--- a/Assets/Tests/EditMode/SaveSystemCoreTests.cs
+++ b/Assets/Tests/EditMode/SaveSystemCoreTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using Game.Core;
 
@@ -76,6 +77,87 @@ namespace Game.Tests.EditMode
             Assert.IsFalse(_saveManager.Load(-1));
             Assert.IsFalse(_saveManager.Load(SaveManager.k_MaxSlots));
             Assert.IsFalse(_saveManager.Load(100));
+        }
+
+        // ===== Step 1: Unregister, 重複防止, IGameSubManager =====
+
+        [Test]
+        public void SaveManager_Unregister_ExcludesFromSave()
+        {
+            MockSaveable saveable = new MockSaveable { SaveId = "test", Value = 42 };
+            _saveManager.Register(saveable);
+            _saveManager.Unregister(saveable);
+
+            SaveSlotData slotData = _saveManager.Save(0);
+
+            Assert.IsFalse(slotData.entries.ContainsKey("test"));
+        }
+
+        [Test]
+        public void SaveManager_Unregister_ExcludesFromLoad()
+        {
+            MockSaveable saveable = new MockSaveable { SaveId = "test", Value = 42 };
+            _saveManager.Register(saveable);
+            _saveManager.Save(0);
+            _saveManager.Unregister(saveable);
+
+            saveable.Value = 0;
+            _saveManager.Load(0);
+
+            // Unregister後はLoad対象外なので値は0のまま
+            Assert.AreEqual(0, saveable.Value);
+        }
+
+        [Test]
+        public void SaveManager_Register_DuplicateSaveId_ThrowsException()
+        {
+            MockSaveable saveable1 = new MockSaveable { SaveId = "duplicate" };
+            MockSaveable saveable2 = new MockSaveable { SaveId = "duplicate" };
+
+            _saveManager.Register(saveable1);
+
+            Assert.Throws<InvalidOperationException>(() => _saveManager.Register(saveable2));
+        }
+
+        [Test]
+        public void SaveManager_Register_SameInstanceTwice_IgnoresSecond()
+        {
+            MockSaveable saveable = new MockSaveable { SaveId = "test", Value = 10 };
+            _saveManager.Register(saveable);
+            _saveManager.Register(saveable); // 同一インスタンスの再登録は無視
+
+            saveable.Value = 42;
+            SaveSlotData slotData = _saveManager.Save(0);
+
+            // エントリは1つだけ
+            Assert.AreEqual(1, slotData.entries.Count);
+            Assert.AreEqual(42, slotData.entries["test"]);
+        }
+
+        [Test]
+        public void SaveManager_ImplementsIGameSubManager()
+        {
+            Assert.IsInstanceOf<IGameSubManager>(_saveManager);
+        }
+
+        [Test]
+        public void SaveManager_InitOrder_Returns900()
+        {
+            IGameSubManager subManager = _saveManager as IGameSubManager;
+            Assert.AreEqual(900, subManager.InitOrder);
+        }
+
+        [Test]
+        public void SaveManager_Unregister_Null_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => _saveManager.Unregister(null));
+        }
+
+        [Test]
+        public void SaveManager_Unregister_NotRegistered_DoesNotThrow()
+        {
+            MockSaveable saveable = new MockSaveable { SaveId = "notRegistered" };
+            Assert.DoesNotThrow(() => _saveManager.Unregister(saveable));
         }
     }
 }


### PR DESCRIPTION
## Summary
- SaveManager基盤強化: Unregister追加、重複登録防止、IGameSubManager実装 (InitOrder=900)
- SaveDataStore新規: Newtonsoft.JsonによるJSON永続化、型情報付きエントリ保存
- ISaveable統一: CurrencyManager/InventoryManager/LevelUpLogic/GateRegistry/BacktrackRewardManagerの5クラスにISaveable実装追加
- FlagManager新規: グローバル+マップローカルフラグ管理、SwitchMapでフラグセット切替、ISaveable対応

## Test plan
- [ ] SaveSystemCoreTests (8件追加) — Unregister・重複登録
- [ ] SaveDataStoreTests (8件) — ファイルI/O・型復元・往復
- [ ] ISaveableImplementationTests (14件) — 各クラスのSerialize/Deserialize往復
- [ ] SaveManagerWiringTests (4件) — IGameSubManager配線
- [ ] FlagManagerTests (12件) — グローバル/ローカルフラグ・マップ切替
- [ ] Integration_SaveSystemTests (7件) — 一括保存復元・スロット独立性

🤖 Generated with [Claude Code](https://claude.com/claude-code)