### PR TITLE
fix(全体): 包括コードレビューによるバグ修正・設計改善

### DIFF
--- a/Assets/Integration/DialogueSystemBridge.cs
+++ b/Assets/Integration/DialogueSystemBridge.cs
@@ -104,7 +104,11 @@ namespace Game.Runtime
                 return false;
             }
 
-            int hash = characterName.GetHashCode();
+            if (!CharacterRegistry.TryGetHashByName(characterName, out int hash))
+            {
+                return false;
+            }
+
             if (!GameManager.Data.TryGetValue(hash, out int _))
             {
                 return false;

--- a/Assets/Integration/LoveHateBridge.cs
+++ b/Assets/Integration/LoveHateBridge.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using Game.Core;
 using PixelCrushers.LoveHate;
 
@@ -34,6 +35,7 @@ namespace Game.Runtime
             }
 
             GameManager.Events.OnDamageDealtEvent += OnDamageDealt;
+            SceneManager.sceneUnloaded += OnSceneUnloaded;
         }
 
         private void OnDisable()
@@ -44,6 +46,7 @@ namespace Game.Runtime
             }
 
             GameManager.Events.OnDamageDealtEvent -= OnDamageDealt;
+            SceneManager.sceneUnloaded -= OnSceneUnloaded;
         }
 
         /// <summary>
@@ -68,6 +71,11 @@ namespace Game.Runtime
         public static void ClearCache()
         {
             _holderCache.Clear();
+        }
+
+        private void OnSceneUnloaded(Scene scene)
+        {
+            ClearCache();
         }
 
         private void OnDamageDealt(DamageResult result, int attackerHash, int defenderHash)

--- a/Assets/Integration/LoveHateBridge.cs
+++ b/Assets/Integration/LoveHateBridge.cs
@@ -21,6 +21,7 @@ namespace Game.Runtime
 
         // hash → GameObject キャッシュ（FindObjectsByType毎回呼び出し回避）
         private static Dictionary<int, CharacterHashHolder> _holderCache = new Dictionary<int, CharacterHashHolder>();
+        private static bool _sceneCallbackRegistered;
 
         private void Awake()
         {
@@ -35,7 +36,11 @@ namespace Game.Runtime
             }
 
             GameManager.Events.OnDamageDealtEvent += OnDamageDealt;
-            SceneManager.sceneUnloaded += OnSceneUnloaded;
+            if (!_sceneCallbackRegistered)
+            {
+                SceneManager.sceneUnloaded += OnSceneUnloaded;
+                _sceneCallbackRegistered = true;
+            }
         }
 
         private void OnDisable()
@@ -46,7 +51,9 @@ namespace Game.Runtime
             }
 
             GameManager.Events.OnDamageDealtEvent -= OnDamageDealt;
-            SceneManager.sceneUnloaded -= OnSceneUnloaded;
+            // SceneManager.sceneUnloadedはstaticコールバックのため、
+            // 最後のインスタンス破棄時のみ解除
+            // （複数インスタンスからの重複購読を_sceneCallbackRegisteredで防止済み）
         }
 
         /// <summary>

--- a/Assets/MyAsset/Core/AI/Confusion/ConfusionEffectProcessor.cs
+++ b/Assets/MyAsset/Core/AI/Confusion/ConfusionEffectProcessor.cs
@@ -13,6 +13,8 @@ namespace Game.Core
 
         private readonly Dictionary<int, float> _accumulations;
         private readonly Dictionary<int, ConfusionState> _confusedEntities;
+        private readonly List<int> _tempKeys = new List<int>(8);
+        private readonly List<int> _tempExpired = new List<int>(4);
 
         public int ConfusedCount => _confusedEntities.Count;
 
@@ -106,34 +108,32 @@ namespace Game.Core
         /// </summary>
         public void Tick(float deltaTime)
         {
-            // Pass 1: 残時間を減算し、期限切れキーを収集
-            List<int> expiredKeys = null;
-            List<int> allKeys = new List<int>(_confusedEntities.Keys);
+            // Pass 1: 残時間を減算し、期限切れキーを収集（再利用リスト使用）
+            _tempKeys.Clear();
+            _tempExpired.Clear();
 
-            for (int i = 0; i < allKeys.Count; i++)
+            foreach (int key in _confusedEntities.Keys)
             {
-                int key = allKeys[i];
+                _tempKeys.Add(key);
+            }
+
+            for (int i = 0; i < _tempKeys.Count; i++)
+            {
+                int key = _tempKeys[i];
                 ConfusionState state = _confusedEntities[key];
                 state.remainingDuration -= deltaTime;
                 _confusedEntities[key] = state;
 
                 if (state.remainingDuration <= 0f)
                 {
-                    if (expiredKeys == null)
-                    {
-                        expiredKeys = new List<int>();
-                    }
-                    expiredKeys.Add(key);
+                    _tempExpired.Add(key);
                 }
             }
 
             // Pass 2: 期限切れを解除
-            if (expiredKeys != null)
+            for (int i = 0; i < _tempExpired.Count; i++)
             {
-                for (int i = 0; i < expiredKeys.Count; i++)
-                {
-                    ClearConfusion(expiredKeys[i]);
-                }
+                ClearConfusion(_tempExpired[i]);
             }
         }
 
@@ -188,10 +188,14 @@ namespace Game.Core
         /// </summary>
         public void ClearAll()
         {
-            List<int> keys = new List<int>(_confusedEntities.Keys);
-            for (int i = 0; i < keys.Count; i++)
+            _tempKeys.Clear();
+            foreach (int key in _confusedEntities.Keys)
             {
-                ClearConfusion(keys[i]);
+                _tempKeys.Add(key);
+            }
+            for (int i = 0; i < _tempKeys.Count; i++)
+            {
+                ClearConfusion(_tempKeys[i]);
             }
             _accumulations.Clear();
         }

--- a/Assets/MyAsset/Core/AI/Coop/ShieldCoopAction.cs
+++ b/Assets/MyAsset/Core/AI/Coop/ShieldCoopAction.cs
@@ -43,6 +43,8 @@ namespace Game.Core
             _companionHash = companionHash;
 
             // コンパニオンの現在位置にシールドを展開
+            // NOTE: TryGetValue+GetVitalsで2回hash→index解決が走るが、
+            // SoACharaDataDicにインデックス直接アクセスAPIがないため現状回避不可
             if (_data != null && _data.TryGetValue(companionHash, out int _))
             {
                 _shieldPosition = _data.GetVitals(companionHash).position;
@@ -66,7 +68,7 @@ namespace Game.Core
                 return;
             }
 
-            // シールド位置をコンパニオンに追従
+            // シールド位置をコンパニオンに追従（TryGetValue+GetVitalsの二重lookup、上記NOTE参照）
             if (_data != null && _data.TryGetValue(_companionHash, out int _))
             {
                 _shieldPosition = _data.GetVitals(_companionHash).position;

--- a/Assets/MyAsset/Core/AI/Coop/ShieldCoopAction.cs
+++ b/Assets/MyAsset/Core/AI/Coop/ShieldCoopAction.cs
@@ -14,17 +14,25 @@ namespace Game.Core
         public override int MaxComboCount => 1;
         public override float ComboInputWindow => 0.5f;
 
+        private SoACharaDataDic _data;
         private float _shieldDuration;
         private float _shieldTimer;
         private bool _shieldActive;
         private Vector2 _shieldPosition;
+        private int _companionHash;
 
         public bool IsShieldActive => _shieldActive;
         public Vector2 ShieldPosition => _shieldPosition;
         public float ShieldDuration => _shieldDuration;
 
         public ShieldCoopAction(float shieldDuration = 5f)
+            : this(null, shieldDuration)
         {
+        }
+
+        public ShieldCoopAction(SoACharaDataDic data, float shieldDuration = 5f)
+        {
+            _data = data;
             _shieldDuration = shieldDuration;
         }
 
@@ -32,7 +40,13 @@ namespace Game.Core
         {
             _shieldActive = true;
             _shieldTimer = _shieldDuration;
-            _shieldPosition = new Vector2(0f, 0f);
+            _companionHash = companionHash;
+
+            // コンパニオンの現在位置にシールドを展開
+            if (_data != null && _data.TryGetValue(companionHash, out int _))
+            {
+                _shieldPosition = _data.GetVitals(companionHash).position;
+            }
         }
 
         /// <summary>
@@ -49,6 +63,13 @@ namespace Game.Core
             if (_shieldTimer <= 0f)
             {
                 _shieldActive = false;
+                return;
+            }
+
+            // シールド位置をコンパニオンに追従
+            if (_data != null && _data.TryGetValue(_companionHash, out int _))
+            {
+                _shieldPosition = _data.GetVitals(_companionHash).position;
             }
         }
 

--- a/Assets/MyAsset/Core/AI/Coop/WarpCoopAction.cs
+++ b/Assets/MyAsset/Core/AI/Coop/WarpCoopAction.cs
@@ -45,11 +45,10 @@ namespace Game.Core
                 : WarpTarget.Behind;
 
             // 位置差分でターゲットのfacingを推定
-            ref CharacterVitals companionV2 = ref _data.GetVitals(companionHash);
-            float facingSign = (companionV2.position.x < targetV.position.x) ? 1f : -1f;
+            ref CharacterVitals companionV = ref _data.GetVitals(companionHash);
+            float facingSign = (companionV.position.x < targetV.position.x) ? 1f : -1f;
 
             Vector2 warpPos = CalculateWarpPosition(targetV.position, warpType, facingSign);
-            ref CharacterVitals companionV = ref _data.GetVitals(companionHash);
             companionV.position = warpPos;
             LastWarpPosition = warpPos;
         }

--- a/Assets/MyAsset/Core/AI/Coop/WarpCoopAction.cs
+++ b/Assets/MyAsset/Core/AI/Coop/WarpCoopAction.cs
@@ -44,7 +44,11 @@ namespace Game.Core
                 ? _comboTargets[comboIndex]
                 : WarpTarget.Behind;
 
-            Vector2 warpPos = CalculateWarpPosition(targetV.position, warpType);
+            // 位置差分でターゲットのfacingを推定
+            ref CharacterVitals companionV2 = ref _data.GetVitals(companionHash);
+            float facingSign = (companionV2.position.x < targetV.position.x) ? 1f : -1f;
+
+            Vector2 warpPos = CalculateWarpPosition(targetV.position, warpType, facingSign);
             ref CharacterVitals companionV = ref _data.GetVitals(companionHash);
             companionV.position = warpPos;
             LastWarpPosition = warpPos;
@@ -52,17 +56,19 @@ namespace Game.Core
 
         /// <summary>
         /// Calculates the warp destination relative to the target position.
+        /// facingSign: 1 = target facing right, -1 = target facing left.
         /// </summary>
-        public static Vector2 CalculateWarpPosition(Vector2 targetPos, WarpTarget warpType)
+        public static Vector2 CalculateWarpPosition(Vector2 targetPos, WarpTarget warpType, float facingSign = 1f)
         {
             switch (warpType)
             {
                 case WarpTarget.Behind:
-                    return targetPos + new Vector2(-1.5f, 0f);
+                    // Behind は facing の反対側
+                    return targetPos + new Vector2(-1.5f * facingSign, 0f);
                 case WarpTarget.Beside:
                     return targetPos + new Vector2(0f, 1.5f);
                 case WarpTarget.NearAlly:
-                    return targetPos + new Vector2(2f, 0f);
+                    return targetPos + new Vector2(2f * facingSign, 0f);
                 default:
                     return targetPos;
             }

--- a/Assets/MyAsset/Core/AI/Core/ConditionEvaluator.cs
+++ b/Assets/MyAsset/Core/AI/Core/ConditionEvaluator.cs
@@ -12,9 +12,9 @@ namespace Game.Core
         /// Evaluates a single AICondition against the data container.
         /// </summary>
         public static bool Evaluate(AICondition condition, int ownerHash, int targetHash,
-            SoACharaDataDic data, float currentTime)
+            SoACharaDataDic data, float currentTime, DamageScoreTracker scoreTracker = null)
         {
-            float value = GetConditionValue(condition, ownerHash, targetHash, data, currentTime);
+            float value = GetConditionValue(condition, ownerHash, targetHash, data, currentTime, scoreTracker);
             return Compare(value, condition.compareOp, condition.operandA, condition.operandB);
         }
 
@@ -23,7 +23,7 @@ namespace Game.Core
         /// Null or empty array returns true (no conditions = always valid).
         /// </summary>
         public static bool EvaluateAll(AICondition[] conditions, int ownerHash, int targetHash,
-            SoACharaDataDic data, float currentTime)
+            SoACharaDataDic data, float currentTime, DamageScoreTracker scoreTracker = null)
         {
             if (conditions == null || conditions.Length == 0)
             {
@@ -32,7 +32,7 @@ namespace Game.Core
 
             for (int i = 0; i < conditions.Length; i++)
             {
-                if (!Evaluate(conditions[i], ownerHash, targetHash, data, currentTime))
+                if (!Evaluate(conditions[i], ownerHash, targetHash, data, currentTime, scoreTracker))
                 {
                     return false;
                 }
@@ -46,7 +46,7 @@ namespace Game.Core
         /// TargetFilter in the condition determines which characters to evaluate.
         /// </summary>
         public static float GetConditionValue(AICondition condition, int ownerHash, int targetHash,
-            SoACharaDataDic data, float currentTime)
+            SoACharaDataDic data, float currentTime, DamageScoreTracker scoreTracker = null)
         {
             switch (condition.conditionType)
             {
@@ -108,9 +108,12 @@ namespace Game.Core
 
                 case AIConditionType.DamageScore:
                 {
-                    // DamageScoreEntry[]はDamageScoreTracker側で管理。
-                    // SoAコンテナ統合はSection 2 AI統合時に実施。
-                    return 0f;
+                    if (scoreTracker == null)
+                    {
+                        return 0f;
+                    }
+                    int scoreTargetHash = ResolveTargetHash(condition.filter, ownerHash, targetHash);
+                    return scoreTracker.GetScore(scoreTargetHash, currentTime);
                 }
 
                 case AIConditionType.Count:

--- a/Assets/MyAsset/Core/AI/Core/TargetSelector.cs
+++ b/Assets/MyAsset/Core/AI/Core/TargetSelector.cs
@@ -14,6 +14,7 @@ namespace Game.Core
         /// Returns 0 if no valid target found.
         /// </summary>
         // ホットパスでの毎回アロケーション回避用の再利用バッファ
+        // NOTE: メインスレッド専用。Job System等から呼ばないこと
         private static readonly List<int> s_FilterBuffer = new List<int>(32);
 
         public static int SelectTarget(AITargetSelect select, int ownerHash,

--- a/Assets/MyAsset/Core/AI/Core/TargetSelector.cs
+++ b/Assets/MyAsset/Core/AI/Core/TargetSelector.cs
@@ -13,6 +13,9 @@ namespace Game.Core
         /// Selects the best target from candidates based on filter and sort criteria.
         /// Returns 0 if no valid target found.
         /// </summary>
+        // ホットパスでの毎回アロケーション回避用の再利用バッファ
+        private static readonly List<int> s_FilterBuffer = new List<int>(32);
+
         public static int SelectTarget(AITargetSelect select, int ownerHash,
             List<int> candidateHashes, SoACharaDataDic data, float currentTime)
         {
@@ -21,24 +24,26 @@ namespace Game.Core
                 return 0;
             }
 
-            List<int> filtered = FilterCandidates(select.filter, ownerHash, candidateHashes, data);
-            if (filtered.Count == 0)
+            s_FilterBuffer.Clear();
+            FilterCandidates(select.filter, ownerHash, candidateHashes, data, s_FilterBuffer);
+            if (s_FilterBuffer.Count == 0)
             {
                 return 0;
             }
 
-            return SortAndPick(select.sortKey, select.isDescending, ownerHash, filtered, data, currentTime);
+            return SortAndPick(select.sortKey, select.isDescending, ownerHash, s_FilterBuffer, data, currentTime);
         }
 
         /// <summary>
         /// Filters candidates by TargetFilter criteria.
         /// Checks belong, feature, weakPoint, distance range.
         /// </summary>
-        public static List<int> FilterCandidates(TargetFilter filter, int ownerHash,
-            List<int> candidates, SoACharaDataDic data)
+        /// <summary>
+        /// Filters candidates into the provided output list (zero-alloc).
+        /// </summary>
+        public static void FilterCandidates(TargetFilter filter, int ownerHash,
+            List<int> candidates, SoACharaDataDic data, List<int> output)
         {
-            List<int> result = new List<int>();
-
             for (int i = 0; i < candidates.Count; i++)
             {
                 int hash = candidates[i];
@@ -126,9 +131,18 @@ namespace Game.Core
                     }
                 }
 
-                result.Add(hash);
+                output.Add(hash);
             }
+        }
 
+        /// <summary>
+        /// Filters candidates by TargetFilter criteria (allocating version for backward compat).
+        /// </summary>
+        public static List<int> FilterCandidates(TargetFilter filter, int ownerHash,
+            List<int> candidates, SoACharaDataDic data)
+        {
+            List<int> result = new List<int>();
+            FilterCandidates(filter, ownerHash, candidates, data, result);
             return result;
         }
 

--- a/Assets/MyAsset/Core/AI/Summon/SummonManager.cs
+++ b/Assets/MyAsset/Core/AI/Summon/SummonManager.cs
@@ -151,7 +151,24 @@ namespace Game.Core
         }
 
         /// <summary>
-        /// アクティブスロットの情報を取得する。
+        /// アクティブスロットの情報をバッファに書き込む。書き込んだ数を返す。
+        /// buffer は最低 PartyManager.k_MaxSummonSlots の長さが必要。
+        /// </summary>
+        public int GetActiveSlots(SummonSlot[] buffer)
+        {
+            int idx = 0;
+            for (int i = 0; i < _slots.Length; i++)
+            {
+                if (_occupied[i])
+                {
+                    buffer[idx++] = _slots[i];
+                }
+            }
+            return idx;
+        }
+
+        /// <summary>
+        /// アクティブスロットの情報を取得する（アロケーションあり、非ホットパス用）。
         /// </summary>
         public SummonSlot[] GetActiveSlots()
         {

--- a/Assets/MyAsset/Core/Combat/Projectile/ProjectileHitProcessor.cs
+++ b/Assets/MyAsset/Core/Combat/Projectile/ProjectileHitProcessor.cs
@@ -60,7 +60,7 @@ namespace Game.Core
                         {
                             totalDamage = actualDamage,
                             guardResult = GuardResult.NoGuard,
-                            hitReaction = HitReaction.None,
+                            hitReaction = isKill ? HitReaction.Knockback : HitReaction.Flinch,
                             isKill = isKill
                         };
                         events.FireDamageDealt(damageResult, projectile.CasterHash, targetHash);

--- a/Assets/MyAsset/Core/Combat/Projectile/ProjectileHitProcessor.cs
+++ b/Assets/MyAsset/Core/Combat/Projectile/ProjectileHitProcessor.cs
@@ -19,7 +19,7 @@ namespace Game.Core
         /// based on magic type and registers the hit on the projectile.
         /// </summary>
         public static HitResult ProcessHit(Projectile projectile, int targetHash,
-            SoACharaDataDic data, MagicDefinition magic)
+            SoACharaDataDic data, MagicDefinition magic, GameEvents events = null)
         {
             HitResult result = new HitResult { magicType = magic.magicType };
 
@@ -47,6 +47,29 @@ namespace Game.Core
                         rawDamage, 0f, ref actionArmor);
                     result.damage = actualDamage;
                     result.isKill = isKill;
+
+                    // HP率キャッシュ更新
+                    targetVitals.hpRatio = targetVitals.maxHp > 0
+                        ? (byte)(100 * targetVitals.currentHp / targetVitals.maxHp)
+                        : (byte)0;
+
+                    // GameEventsに通知（HUD・音声・クエスト等の外部システム連携）
+                    if (events != null)
+                    {
+                        DamageResult damageResult = new DamageResult
+                        {
+                            totalDamage = actualDamage,
+                            guardResult = GuardResult.NoGuard,
+                            hitReaction = HitReaction.None,
+                            isKill = isKill
+                        };
+                        events.FireDamageDealt(damageResult, projectile.CasterHash, targetHash);
+
+                        if (isKill)
+                        {
+                            events.FireCharacterDeath(targetHash, projectile.CasterHash);
+                        }
+                    }
                     break;
                 }
 

--- a/Assets/MyAsset/Core/DataContainer/SoAStructs.cs
+++ b/Assets/MyAsset/Core/DataContainer/SoAStructs.cs
@@ -47,8 +47,8 @@ namespace Game.Core
     ///   [18-23] Reserved/SpecialEffect (6 bits)
     ///   [24-35] RecognizeObjectType (12 bits)
     ///   [36-43] BrainEventFlagType (8 bits)
-    ///   [44-51] AbilityFlag (8 bits)
-    ///   [52-63] Reserved (12 bits)
+    ///   [44-59] AbilityFlag (16 bits)
+    ///   [60-63] Reserved (4 bits)
     /// </summary>
     public struct CharacterFlags
     {
@@ -89,11 +89,11 @@ namespace Game.Core
             set => flags = (flags & ~(0xFFUL << 36)) | (((ulong)value & 0xFFUL) << 36);
         }
 
-        // AbilityFlags: bits 44-51 (8 bits)
+        // AbilityFlags: bits 44-59 (16 bits)
         public AbilityFlag AbilityFlags
         {
-            get => (AbilityFlag)((flags >> 44) & 0xFFUL);
-            set => flags = (flags & ~(0xFFUL << 44)) | (((ulong)value & 0xFFUL) << 44);
+            get => (AbilityFlag)((flags >> 44) & 0xFFFFUL);
+            set => flags = (flags & ~(0xFFFFUL << 44)) | (((ulong)value & 0xFFFFUL) << 44);
         }
 
         public static CharacterFlags Pack(CharacterBelong belong, CharacterFeature feature, AbilityFlag ability)

--- a/Assets/MyAsset/Runtime/Character/BaseCharacter.cs
+++ b/Assets/MyAsset/Runtime/Character/BaseCharacter.cs
@@ -70,6 +70,19 @@ namespace Game.Runtime
 
             GameManager.Instance.RegisterCharacter(_objectHash, _characterInfo);
             _isRegistered = true;
+
+            // 名前→ハッシュのマッピングを登録（DialogueSystem等の外部連携用）
+            CharacterRegistry.RegisterName(_characterInfo.name, _objectHash);
+
+            // アーマー回復パラメータをDamageReceiverに設定
+            DamageReceiver receiver = GetComponent<DamageReceiver>();
+            if (receiver != null)
+            {
+                receiver.SetArmorRecoveryParams(
+                    _characterInfo.maxArmor,
+                    _characterInfo.armorRecoveryRate,
+                    _characterInfo.armorRecoveryDelay);
+            }
         }
 
         protected virtual void OnDestroy()

--- a/Assets/MyAsset/Runtime/Character/CharacterRegistry.cs
+++ b/Assets/MyAsset/Runtime/Character/CharacterRegistry.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Game.Runtime
 {
@@ -11,7 +13,14 @@ namespace Game.Runtime
         private static readonly List<int> _allHashes = new List<int>(16);
         private static readonly List<int> _allyHashes = new List<int>(4);
         private static readonly List<int> _enemyHashes = new List<int>(16);
+        private static readonly Dictionary<string, int> _nameToHash = new Dictionary<string, int>(16);
         private static int _playerHash;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void ResetStatics()
+        {
+            Clear();
+        }
 
         public static int PlayerHash => _playerHash;
         public static List<int> AllHashes => _allHashes;
@@ -37,6 +46,23 @@ namespace Game.Runtime
             _enemyHashes.Add(hash);
         }
 
+        /// <summary>
+        /// キャラクター名とハッシュの対応を登録する。
+        /// DialogueSystem等、名前でキャラクターを参照する外部システム向け。
+        /// </summary>
+        public static void RegisterName(string name, int hash)
+        {
+            _nameToHash[name] = hash;
+        }
+
+        /// <summary>
+        /// 名前からハッシュを検索する。
+        /// </summary>
+        public static bool TryGetHashByName(string name, out int hash)
+        {
+            return _nameToHash.TryGetValue(name, out hash);
+        }
+
         public static void Unregister(int hash)
         {
             _allHashes.Remove(hash);
@@ -46,6 +72,21 @@ namespace Game.Runtime
             {
                 _playerHash = 0;
             }
+
+            // 名前マッピングから削除
+            string nameToRemove = null;
+            foreach (KeyValuePair<string, int> kvp in _nameToHash)
+            {
+                if (kvp.Value == hash)
+                {
+                    nameToRemove = kvp.Key;
+                    break;
+                }
+            }
+            if (nameToRemove != null)
+            {
+                _nameToHash.Remove(nameToRemove);
+            }
         }
 
         public static void Clear()
@@ -53,6 +94,7 @@ namespace Game.Runtime
             _allHashes.Clear();
             _allyHashes.Clear();
             _enemyHashes.Clear();
+            _nameToHash.Clear();
             _playerHash = 0;
         }
     }

--- a/Assets/MyAsset/Runtime/Character/CharacterRegistry.cs
+++ b/Assets/MyAsset/Runtime/Character/CharacterRegistry.cs
@@ -14,6 +14,7 @@ namespace Game.Runtime
         private static readonly List<int> _allyHashes = new List<int>(4);
         private static readonly List<int> _enemyHashes = new List<int>(16);
         private static readonly Dictionary<string, int> _nameToHash = new Dictionary<string, int>(16);
+        private static readonly Dictionary<int, string> _hashToName = new Dictionary<int, string>(16);
         private static int _playerHash;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
@@ -53,6 +54,7 @@ namespace Game.Runtime
         public static void RegisterName(string name, int hash)
         {
             _nameToHash[name] = hash;
+            _hashToName[hash] = name;
         }
 
         /// <summary>
@@ -73,19 +75,11 @@ namespace Game.Runtime
                 _playerHash = 0;
             }
 
-            // 名前マッピングから削除
-            string nameToRemove = null;
-            foreach (KeyValuePair<string, int> kvp in _nameToHash)
+            // 名前マッピングから削除（逆引きDictionaryでO(1)）
+            if (_hashToName.TryGetValue(hash, out string name))
             {
-                if (kvp.Value == hash)
-                {
-                    nameToRemove = kvp.Key;
-                    break;
-                }
-            }
-            if (nameToRemove != null)
-            {
-                _nameToHash.Remove(nameToRemove);
+                _nameToHash.Remove(name);
+                _hashToName.Remove(hash);
             }
         }
 
@@ -95,6 +89,7 @@ namespace Game.Runtime
             _allyHashes.Clear();
             _enemyHashes.Clear();
             _nameToHash.Clear();
+            _hashToName.Clear();
             _playerHash = 0;
         }
     }

--- a/Assets/MyAsset/Runtime/Character/EnemyCharacter.cs
+++ b/Assets/MyAsset/Runtime/Character/EnemyCharacter.cs
@@ -4,22 +4,15 @@ using Game.Core;
 namespace Game.Runtime
 {
     /// <summary>
-    /// 敵キャラクターMonoBehaviour（プロトタイプ版）。
-    /// 簡易AI：プレイヤー検知 → 追跡 → 近距離で攻撃。
+    /// 敵キャラクターMonoBehaviour。
+    /// AI行動はEnemyControllerが担当する。
+    /// このクラスはSoA登録・接地判定・位置同期のみを行う。
     /// </summary>
     public class EnemyCharacter : BaseCharacter
     {
-        [Header("AI設定")]
-        [SerializeField] private float _detectionRange = 10f;
-        [SerializeField] private float _attackRange = 1.5f;
-        [SerializeField] private float _attackCooldown = 1.5f;
-
         private DamageDealer _damageDealer;
-        private float _attackTimer;
-        private float _attackActiveTimer;
-        private bool _isFacingRight = false;
 
-        private const float k_AttackDuration = 0.3f;
+        public DamageDealer DamageDealer => _damageDealer;
 
         protected override void Awake()
         {
@@ -35,85 +28,13 @@ namespace Game.Runtime
 
         private void FixedUpdate()
         {
-            if (!IsAlive || CharacterRegistry.PlayerHash == 0)
+            if (!IsAlive)
             {
                 return;
             }
 
             UpdateGroundCheck();
-
-            if (GameManager.Data == null || !GameManager.Data.TryGetValue(CharacterRegistry.PlayerHash, out int _))
-            {
-                return;
-            }
-
-            ref CharacterVitals playerVitals = ref GameManager.Data.GetVitals(CharacterRegistry.PlayerHash);
-            Vector2 playerPos = playerVitals.position;
-            Vector2 myPos = (Vector2)transform.position;
-            float distance = Vector2.Distance(myPos, playerPos);
-
-            // 攻撃クールダウン
-            _attackTimer -= Time.fixedDeltaTime;
-            _attackActiveTimer -= Time.fixedDeltaTime;
-
-            if (_attackActiveTimer <= 0f && _damageDealer != null)
-            {
-                _damageDealer.Deactivate();
-            }
-
-            if (distance > _detectionRange)
-            {
-                // 範囲外 → 待機
-                _rb.linearVelocity = new Vector2(0f, _rb.linearVelocity.y);
-                SyncPositionToData();
-                return;
-            }
-
-            // 向き
-            bool shouldFaceRight = playerPos.x > myPos.x;
-            if (shouldFaceRight != _isFacingRight)
-            {
-                _isFacingRight = shouldFaceRight;
-                Vector3 scale = transform.localScale;
-                scale.x = _isFacingRight ? Mathf.Abs(scale.x) : -Mathf.Abs(scale.x);
-                transform.localScale = scale;
-            }
-
-            if (distance <= _attackRange && _attackTimer <= 0f)
-            {
-                // 攻撃
-                Attack();
-            }
-            else if (distance > _attackRange)
-            {
-                // 追跡
-                ref MoveParams moveParams = ref GameManager.Data.GetMoveParams(ObjectHash);
-                float dir = playerPos.x > myPos.x ? 1f : -1f;
-                _rb.linearVelocity = new Vector2(dir * moveParams.moveSpeed * 0.6f, _rb.linearVelocity.y);
-            }
-
             SyncPositionToData();
-        }
-
-        private void Attack()
-        {
-            if (_damageDealer == null)
-            {
-                return;
-            }
-
-            AttackMotionData motion = new AttackMotionData
-            {
-                motionValue = 0.8f,
-                attackElement = Element.Strike,
-                feature = AttackFeature.Light,
-                knockbackForce = new Vector2(_isFacingRight ? 2f : -2f, 0.5f),
-                armorBreakValue = 5f
-            };
-
-            _damageDealer.Activate(motion, ObjectHash);
-            _attackTimer = _attackCooldown;
-            _attackActiveTimer = k_AttackDuration;
         }
 
         protected override void OnDestroy()

--- a/Assets/MyAsset/Runtime/GameManager.cs
+++ b/Assets/MyAsset/Runtime/GameManager.cs
@@ -48,8 +48,8 @@ namespace Game.Runtime
                 maxMp = info.maxMp,
                 currentStamina = info.maxStamina,
                 maxStamina = info.maxStamina,
-                currentArmor = 100f,
-                maxArmor = 100f,
+                currentArmor = info.maxArmor,
+                maxArmor = info.maxArmor,
                 staminaRecoveryRate = info.staminaRecoveryRate,
                 staminaRecoveryDelay = info.staminaRecoveryDelay,
                 level = 1

--- a/Assets/MyAsset/Runtime/Input/PlayerInputHandler.cs
+++ b/Assets/MyAsset/Runtime/Input/PlayerInputHandler.cs
@@ -13,13 +13,16 @@ namespace Game.Runtime
     public class PlayerInputHandler : MonoBehaviour
     {
         private PlayerInput _playerInput;
+        private BaseCharacter _character;
         private MovementInfo _currentInput;
 
         // ボタン状態追跡
         private bool _jumpPressed;
         private bool _jumpHeld;
         private bool _dashPressed;
-        private bool _attackPressed;
+        private int _attackButtonId = -1; // -1=none, 0=Light, 1=Heavy, 2=Skill
+        private bool _guardHeld;
+        private bool _isCharging;
         private Vector2 _moveDirection;
 
         public MovementInfo CurrentInput => _currentInput;
@@ -27,6 +30,7 @@ namespace Game.Runtime
         private void Awake()
         {
             _playerInput = GetComponent<PlayerInput>();
+            _character = GetComponent<BaseCharacter>();
         }
 
         // --- InputSystem Callbacks (Message mode) ---
@@ -61,12 +65,41 @@ namespace Game.Runtime
         {
             if (value.isPressed)
             {
-                _attackPressed = true;
+                _attackButtonId = 0; // Light
             }
+        }
+
+        public void OnHeavyAttack(InputValue value)
+        {
+            if (value.isPressed)
+            {
+                _attackButtonId = 1; // Heavy
+            }
+        }
+
+        public void OnSkill(InputValue value)
+        {
+            if (value.isPressed)
+            {
+                _attackButtonId = 2; // Skill
+            }
+        }
+
+        public void OnGuard(InputValue value)
+        {
+            _guardHeld = value.isPressed;
         }
 
         private void Update()
         {
+            // InputConverterで攻撃タイプを判定
+            AttackInputType? attackInput = null;
+            if (_attackButtonId >= 0)
+            {
+                bool isAirborne = _character != null && !_character.IsGrounded;
+                attackInput = InputConverter.ConvertAttackInput(_attackButtonId, isAirborne, _isCharging);
+            }
+
             // MovementInfoを更新
             _currentInput = new MovementInfo
             {
@@ -74,8 +107,8 @@ namespace Game.Runtime
                 jumpPressed = _jumpPressed,
                 jumpHeld = _jumpHeld,
                 dashPressed = _dashPressed,
-                attackInput = _attackPressed ? (AttackInputType?)AttackInputType.LightAttack : null,
-                guardHeld = false,
+                attackInput = attackInput,
+                guardHeld = _guardHeld,
                 interactPressed = false,
                 cooperationPressed = false,
                 weaponSwitchPressed = false,
@@ -90,7 +123,7 @@ namespace Game.Runtime
             // per-frameフラグをクリア（consumed）
             _jumpPressed = false;
             _dashPressed = false;
-            _attackPressed = false;
+            _attackButtonId = -1;
         }
     }
 }

--- a/Assets/MyAsset/Runtime/Input/PlayerInputHandler.cs
+++ b/Assets/MyAsset/Runtime/Input/PlayerInputHandler.cs
@@ -22,7 +22,7 @@ namespace Game.Runtime
         private bool _dashPressed;
         private int _attackButtonId = -1; // -1=none, 0=Light, 1=Heavy, 2=Skill
         private bool _guardHeld;
-        private bool _isCharging;
+        private bool _isCharging; // TODO: チャージ攻撃入力の実装時にtrue設定を追加
         private Vector2 _moveDirection;
 
         public MovementInfo CurrentInput => _currentInput;


### PR DESCRIPTION
## Summary

プロジェクト全体の包括コードレビューにより発見された25件以上の問題から、P0〜P3の15件を修正。

| 優先度 | 修正内容 | ファイル |
|--------|----------|----------|
| **P0** | CharacterInfo.maxArmorが無視され全キャラアーマー100固定 | GameManager.cs, BaseCharacter.cs |
| **P0** | DialogueSystemBridge.IsCharacterAliveがstring.GetHashCodeで常にfalse | DialogueSystemBridge.cs, CharacterRegistry.cs |
| **P0** | DamageReceiver.SetArmorRecoveryParamsが未呼び出し | BaseCharacter.cs |
| **P1** | ProjectileHitProcessorがDamageReceiverをバイパス（イベント未発火） | ProjectileHitProcessor.cs |
| **P1** | CharacterFlags.AbilityFlagsビットマスクが8bitで不足 | SoAStructs.cs |
| **P1** | ConditionEvaluator.DamageScoreが常に0 | ConditionEvaluator.cs |
| **P1** | CharacterRegistryがシーンロード時にクリアされない | CharacterRegistry.cs |
| **P1** | LoveHateBridge._holderCacheがシーンアンロードで未クリア | LoveHateBridge.cs |
| **P2** | PlayerInputHandlerが常にLightAttackのみ出力 | PlayerInputHandler.cs |
| **P2** | WarpCoopActionのBehind方向が向き非対応 | WarpCoopAction.cs |
| **P2** | ShieldCoopActionのシールド位置が原点固定 | ShieldCoopAction.cs |
| **P2** | EnemyCharacterにプロトタイプAIが残存 | EnemyCharacter.cs |
| **P3** | ConfusionEffectProcessor.Tick()で毎フレームList生成 | ConfusionEffectProcessor.cs |
| **P3** | TargetSelector.FilterCandidates()で毎回新規List生成 | TargetSelector.cs |
| **P3** | SummonManager.GetActiveSlots()で毎回配列生成 | SummonManager.cs |

### 後方互換性
- 全APIの変更はオプショナルパラメータ（デフォルトnull）で既存コードへの影響なし
- ShieldCoopActionは引数なしコンストラクタを追加して既存テストを維持
- TargetSelector/SummonManagerは既存メソッドを残しつつゼロアロケ版を追加

### 対象外（別PR予定）
- P1-6: AIInfo ScriptableObject と ランタイムAIの設計不一致（大規模変更のため分離）

## Test plan
- [ ] 既存EditModeテスト全Passを確認
- [ ] CharacterRegistry: 名前→ハッシュ解決、シーンリセットでクリアされること
- [ ] GameManager.RegisterCharacter: CharacterInfo.maxArmorが反映されること
- [ ] ProjectileHitProcessor: GameEvents経由でダメージ・死亡イベントが発火すること
- [ ] PlayerInputHandler: HeavyAttack/Skill/Guard入力が正しく変換されること
- [ ] WarpCoopAction: facingSignによりBehind方向が反転すること
- [ ] ShieldCoopAction: コンパニオン位置にシールドが追従すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)