### PR TITLE
docs(設計): ODCカスタムコンテナ汎用設計まとめ

### DIFF
--- a/designs/ODCカスタムコンテナ提案.md
+++ b/designs/ODCカスタムコンテナ提案.md
@@ -1,0 +1,1022 @@
+# ODC カスタムコンテナ提案
+
+ODC新バージョンで導入済みの10種コンテナとは別に、
+本プロジェクトのシステム設計書を横断分析して発見した追加カスタムコンテナの提案。
+
+**ODCの設計思想との整合基準**:
+- unmanaged 構造体のみ格納（GCフリー）
+- objectHash をキーとした O(1) アクセス
+- 配列ベースのキャッシュ効率重視
+- アロケーションフリーの操作
+- SoACharaDataDic と同じ密集配列 + スワップバック削除
+
+---
+
+## カスタムコンテナ一覧
+
+| # | コンテナ名 | 分類 | 優先度 | 主な適用先 |
+|---|-----------|------|--------|-----------|
+| C1 | SparseSetContainer\<T\> | 汎用 | ★★★★★ | 投射物・状態異常・スポーン管理 |
+| C2 | ThresholdAccumulatorContainer | ゲームロジック | ★★★★★ | EXP・状態異常蓄積・スコア |
+| C3 | WeightedSamplerContainer\<T\> | 汎用 | ★★★★☆ | ドロップ・スポーン確率選択 |
+| C4 | BitFlagTableContainer | 汎用 | ★★★★☆ | AbilityFlag・GateState・訪問済エリア |
+| C5 | FixedSlotContainer\<T, N\> | 汎用 | ★★★☆☆ | ベルト・武器スロット・召喚枠 |
+| C6 | FactionRelationContainer | ゲームロジック | ★★★☆☆ | 陣営間関係・混乱魔法 |
+
+---
+
+## C1. SparseSetContainer\<T\>
+
+### 概要
+「全キャラのうちの一部のみがアクティブな状態を持つ」ケースの高速管理。
+通常の辞書やbool配列とは異なり、**アクティブ要素のみを連続メモリで保持**し、
+フルスキャンなしで活性要素を一括走査できる。
+
+ECSのSparse Setが原点。SoACharaDataDicのサブセット版に相当。
+
+```
+sparse[]   : hash → dense_index (非アクティブは-1)
+dense[]    : 活性要素の値 T[]
+denseHash[]: dense[i]に対応するhash  (逆引き用)
+count      : 現在の活性数
+```
+
+### プロジェクトでの課題
+
+| システム | 課題 |
+|---------|------|
+| MagicSystem | `NativeArray<bool> _active` で投射物のアクティブ判定 → 全N要素スキャンが毎フレーム |
+| DamageSystem | `StatusEffectManager` が発症中エフェクトを `List<StatusEffect>` で管理 → GCアロケーション |
+| ConfusionMagic | `Dictionary<int, ConfusionState> _confusedEntities` → 混乱中の敵だけをイテレートしたい |
+| EnemySystem | アクティブ敵のみを更新ループ対象にしたい（非アクティブを飛ばしたい） |
+| SummonSystem | アクティブ召喚スロットのみを毎Tickで更新したい |
+
+### 設計案
+
+```csharp
+/// <summary>
+/// 疎集合コンテナ。全キャラのサブセット（アクティブな部分集合）を
+/// アロケーションなし・O(1)操作・連続メモリで管理する。
+/// </summary>
+public struct SparseSetContainer<T> : IDisposable
+    where T : unmanaged
+{
+    // sparse[hash % capacity] → dense_index (-1 = 非登録)
+    // dense[dense_index]      → T値
+    // denseHash[dense_index]  → 元のhash（逆引き）
+
+    /// <summary>ハッシュをキーに要素を登録/更新する。O(1)。</summary>
+    public void Set(int hash, in T value);
+
+    /// <summary>要素を削除する（スワップバック）。O(1)。</summary>
+    public bool Remove(int hash);
+
+    /// <summary>登録されているか確認。O(1)。</summary>
+    public bool Contains(int hash);
+
+    /// <summary>値を取得。O(1)。</summary>
+    public bool TryGet(int hash, out T value);
+
+    /// <summary>ref返しで直接書き換え。O(1)。</summary>
+    public ref T GetRef(int hash);
+
+    /// <summary>
+    /// 全アクティブ要素を連続メモリで取得。GCアロケーションなし。
+    /// ForEachループやJob Systemへ渡す際に使用。
+    /// </summary>
+    public ReadOnlySpan<T> ActiveValues { get; }
+    public ReadOnlySpan<int> ActiveHashes { get; }
+    public int Count { get; }
+}
+```
+
+### 使用例
+
+```csharp
+// 投射物管理（MagicSystem）
+SparseSetContainer<ProjectileData> _activeProjectiles;
+
+// フレームごとに全活性投射物を一括処理
+foreach (ref readonly ProjectileData proj in _activeProjectiles.ActiveValues)
+{
+    // GetComponent不要・GCなし・キャッシュ効率最良
+}
+
+// 混乱魔法（ConfusionMagic）
+SparseSetContainer<ConfusionState> _confused;
+_confused.Set(enemyHash, new ConfusionState { remainTime = 5f, originalFaction = ... });
+// 混乱中の全敵だけを走査（全敵スキャン不要）
+foreach (ref readonly ConfusionState c in _confused.ActiveValues) { ... }
+```
+
+### SoACharaDataDicとの違い
+
+| 比較点 | SoACharaDataDic | SparseSetContainer |
+|--------|----------------|-------------------|
+| 対象 | 全キャラ（常駐） | 一部キャラ（一時的） |
+| 用途 | キャラの恒常データ | 「今だけ」のサブセット状態 |
+| 登録 | BaseCharacter生成時 | 条件発生時（状態異常発症など） |
+| 削除 | BaseCharacter破棄時 | 条件消滅時（状態異常回復など） |
+
+### 汎用性評価
+汎用的。ECS・ゲームエンジン問わず広く使われる構造 ✓
+
+---
+
+## C2. ThresholdAccumulatorContainer
+
+### 概要
+「値を積み上げていき、閾値に達したら何かが起きる」パターンの汎用化。
+EXP→レベルアップ・状態異常蓄積→発症・スコア→ランク達成など、
+本プロジェクトでは**5システム以上で同じパターンが独立実装**されている。
+
+```
+accumulators[hash][key].current  : 現在の蓄積値
+accumulators[hash][key].threshold: 発火閾値
+accumulators[hash][key].overflow : 閾値超過分（次回持ち越し用）
+```
+
+### プロジェクトでの課題
+
+| システム | 蓄積対象 | 閾値 | 発火アクション |
+|---------|---------|------|--------------|
+| LevelUpSystem | EXP | レベルテーブル参照値 | レベルアップ処理 |
+| DamageSystem | 属性別蓄積ダメージ | 状態異常発症閾値 | 状態異常発症 |
+| ChallengeMode | スコア | ランク境界値 | ランク変更通知 |
+| BacktrackReward | 能力獲得トリガー | 報酬テーブル条件 | 報酬解放 |
+| CoopAction | コンボゲージ | コンボ技発動閾値 | 連携技発動 |
+
+### 設計案
+
+```csharp
+/// <summary>
+/// 蓄積値が閾値に達したらコールバックを発火するコンテナ。
+/// 複数のキー（ラベル）を1オブジェクトに持てる（EXP・HP蓄積・スタミナ蓄積等）。
+/// objectHash × key で O(1) アクセス。
+/// </summary>
+public struct ThresholdAccumulatorContainer : IDisposable
+{
+    /// <summary>
+    /// 蓄積値を加算する。閾値超過時はtrueを返す（コールバックが呼ばれる）。
+    /// overflow（超過分）を次回に持ち越すかどうかをオプション指定。
+    /// </summary>
+    public bool Add(int hash, int key, float amount, bool carryOverflow = false);
+
+    /// <summary>現在の蓄積値を取得。O(1)。</summary>
+    public float Get(int hash, int key);
+
+    /// <summary>進行率 (0.0〜1.0) を取得。UIバー表示に直結。</summary>
+    public float GetNormalized(int hash, int key);
+
+    /// <summary>閾値を変更する（レベルアップ後の次レベル要求EXP更新等）。</summary>
+    public void SetThreshold(int hash, int key, float threshold);
+
+    /// <summary>蓄積値をリセット（状態異常回復時等）。</summary>
+    public void Reset(int hash, int key);
+
+    /// <summary>閾値超過時コールバック。(hash, key, overflow) を受け取る。</summary>
+    public Action<int, int, float> OnThresholdReached { get; set; }
+}
+```
+
+### 使用例
+
+```csharp
+// LevelUpSystem
+_accumulator.SetThreshold(playerHash, (int)AccumKey.EXP, expTable[currentLevel]);
+bool leveledUp = _accumulator.Add(playerHash, (int)AccumKey.EXP, gainedExp, carryOverflow: true);
+
+// DamageSystem（属性蓄積）
+bool poisonProc = _accumulator.Add(enemyHash, (int)Element.Poison, poisonStack);
+if (poisonProc) ApplyStatusEffect(enemyHash, StatusEffect.Poison);
+
+// UIバー表示（進行率がそのままfillAmountに使える）
+float expBarFill = _accumulator.GetNormalized(playerHash, (int)AccumKey.EXP);
+```
+
+### 汎用性評価
+蓄積→閾値→発火はゲームを問わず汎用的なパターン ✓
+carryOverflow オプションで「溢れたEXPを次レベルに持ち越す」ニュアンスも表現できる
+
+---
+
+## C3. WeightedSamplerContainer\<T\>
+
+### 概要
+重み付き確率テーブルから**O(1)でサンプリング**するコンテナ。
+Walker's Alias Method を採用し、構築時O(n)・サンプリング時O(1)を実現。
+`Random.Range` + 線形スキャンの O(n) アキュムレータパターンを置き換える。
+
+### プロジェクトでの課題
+
+| システム | 確率選択の用途 | 現状 |
+|---------|--------------|------|
+| EnemySystem | DropTable確率計算 | float[] cumulative + 線形スキャン |
+| ShopSystem | ランダム商品生成 | 不明（未実装） |
+| MagicSystem | 子弾エフェクト選択 | childProfile配列から選択 |
+| EnemySystem | スポーンする敵種の重み付き選択 | 未設計 |
+| LevelUpSystem | ドロップスキルのランダム選択 | 未設計 |
+
+### 設計案
+
+```csharp
+/// <summary>
+/// Walker's Alias Method による O(1) 重み付きサンプリングコンテナ。
+/// 構築時に確率テーブルを事前計算し、以降のサンプリングをO(1)に。
+/// </summary>
+public struct WeightedSamplerContainer<T> : IDisposable
+    where T : unmanaged
+{
+    /// <summary>
+    /// (値, 重み) ペアのリストからテーブルを構築。O(n)。
+    /// 一度構築したらランタイムでのサンプリングは全てO(1)。
+    /// </summary>
+    public static WeightedSamplerContainer<T> Build(
+        ReadOnlySpan<T> items,
+        ReadOnlySpan<float> weights);
+
+    /// <summary>重み付き確率に従い1要素をサンプリング。O(1)。</summary>
+    public T Sample(ref Unity.Mathematics.Random rng);
+
+    /// <summary>重複なしでk個サンプリング（ドロップ複数品目等）。O(k)。</summary>
+    public void SampleDistinct(ref Unity.Mathematics.Random rng, Span<T> results, int k);
+
+    /// <summary>アイテム数。</summary>
+    public int Count { get; }
+}
+```
+
+### 使用例
+
+```csharp
+// EnemySystem: ドロップテーブル構築（敵初期化時に1回だけ）
+DropEntry[] items = enemyDef.dropTable;
+float[] weights = Array.ConvertAll(items, e => e.probability);
+WeightedSamplerContainer<DropEntry> dropSampler =
+    WeightedSamplerContainer<DropEntry>.Build(items, weights);
+
+// 敵撃破時: O(1)でドロップ決定
+DropEntry dropped = dropSampler.Sample(ref _rng);
+
+// 複数ドロップ（重複なし3個）
+Span<DropEntry> drops = stackalloc DropEntry[3];
+dropSampler.SampleDistinct(ref _rng, drops, 3);
+```
+
+### Walker's Alias Method の原理
+```
+構築: O(n)でprobability[]とalias[]テーブルを生成
+サンプリング:
+  1. i = rng.NextInt(0, n)           → どのバケットか
+  2. p = rng.NextFloat()
+  3. return p < probability[i] ? items[i] : alias[i]
+  → 常に2回の乱数生成のみ: O(1)
+```
+
+### 汎用性評価
+Walker's Alias Method は有名なアルゴリズムで汎用性が高い ✓
+`T : unmanaged` 制約でSoAと同等の型安全性を保てる
+
+---
+
+## C4. BitFlagTableContainer
+
+### 概要
+「objectHash ごとに複数のbooleanフラグをビット演算で管理」するコンテナ。
+SoACharaDataDicの `CharacterFlags` (ulong) が「1キャラ固定フラグ」向けなのに対し、
+こちらは「**可変個の対象×多数のフラグ**」を一元管理するテーブルとして機能する。
+
+アビリティ解放状態・ゲートの開閉・マップ訪問済み管理に適用する。
+
+```
+rows[hash → index].flags : ulong (64ビット) = 64フラグまで
+大規模フラグ: ulong[N] で拡張可
+```
+
+### プロジェクトでの課題
+
+| システム | フラグ用途 | 現状の問題 |
+|---------|-----------|-----------|
+| BacktrackReward | AbilityFlag（能力獲得済み判定） | `Dictionary<string, bool>`（文字列キー・GC） |
+| GateSystem | GateRegistry（ゲート開閉状態） | `Dictionary<string, bool>` |
+| MapSystem | 訪問済みエリア記録 | 未設計（bool[]想定） |
+| PlayerMovement | 解放済みアビリティ判定 | AbilityFlag ulong（直接ビット操作） |
+| EquipmentSystem | 装備由来AbilityFlag合算 | 各装備のフラグをOR演算で合算 |
+| AIRuleBuilder | ActionUnlockRegistry（アクション解放済み） | `HashSet<(ActionExecType, int)>` |
+
+### 設計案
+
+```csharp
+/// <summary>
+/// ハッシュキー × ビットフラグのテーブルコンテナ。
+/// 対象ごとに最大64フラグ（ulong）をO(1)で操作できる。
+/// GateRegistry / AbilityFlag / 訪問済みエリアなどに汎用的に使える。
+/// </summary>
+public struct BitFlagTableContainer : IDisposable
+{
+    /// <summary>フラグをセット。O(1)。</summary>
+    public void Set(int hash, ulong flagMask);
+
+    /// <summary>フラグをクリア。O(1)。</summary>
+    public void Clear(int hash, ulong flagMask);
+
+    /// <summary>フラグをトグル。O(1)。</summary>
+    public void Toggle(int hash, ulong flagMask);
+
+    /// <summary>指定フラグが全てセットされているか。O(1)。</summary>
+    public bool HasAll(int hash, ulong flagMask);
+
+    /// <summary>指定フラグのいずれかがセットされているか。O(1)。</summary>
+    public bool HasAny(int hash, ulong flagMask);
+
+    /// <summary>フラグを全取得（他システムとのOR合算用）。O(1)。</summary>
+    public ulong GetFlags(int hash);
+
+    /// <summary>全フラグをOR合算して返す（装備由来AbilityFlag合算等）。O(n)。</summary>
+    public ulong AggregateAll();
+
+    /// <summary>フラグが立っているエントリのhashを列挙。O(n)。</summary>
+    public ReadOnlySpan<int> QueryHashes(ulong flagMask);
+}
+```
+
+### 使用例
+
+```csharp
+// GateSystem: ゲート状態管理（string keyを排除してintハッシュ化）
+int gateHash = gateId.GetHashCode();
+_gateFlags.Set(gateHash, (ulong)GateFlag.Open);
+bool isOpen = _gateFlags.HasAll(gateHash, (ulong)GateFlag.Open);
+
+// BacktrackReward: 能力獲得フラグ
+_abilityFlags.Set(playerHash, (ulong)AbilityFlag.DoubleJump);
+bool canDoubleJump = _abilityFlags.HasAll(playerHash, (ulong)AbilityFlag.DoubleJump);
+
+// EquipmentSystem: 装備由来フラグの合算
+ulong totalFlags = _equipAbilityFlags.AggregateAll();
+// → 全装備の AbilityFlag を OR 合算 → CharacterFlags に反映
+```
+
+### 汎用性評価
+ビットフラグテーブルは汎用的。ゲームを問わずフラグ管理に使える ✓
+64ビットを超えるケースは `ulong[]` 拡張版で対応可能
+
+---
+
+## C5. FixedSlotContainer\<T, N\>
+
+### 概要
+**固定個数のスロット**（武器2本・ベルト4枠・召喚2枠など）を統一的に管理するコンテナ。
+「スロット番号でアクセス」「アクティブスロットのカーソル回転」「空きスロット検索」
+「スロット間スワップ」といった操作を毎回再実装せずに済む。
+
+固定サイズのためヒープアロケーション不要。`stackalloc` 互換を目指す設計。
+
+### プロジェクトでの課題
+
+| システム | スロット構成 | 現状の問題 |
+|---------|------------|-----------|
+| InventorySystem | BeltShortcut (4枠×2種) | 配列 + currentIndex カーソルを自前管理 |
+| WeaponSystem | 右手/左手武器スロット (2枠) | `rightWeaponId` / `leftWeaponId` 別フィールド |
+| SummonSystem | 召喚スロット (2枠固定) | `_slots[]` + 最古置換ロジックを自前実装 |
+| ParryGuardSystem | ガードスロット（盾装備有無） | bool + 参照の組み合わせ |
+| UISystem | CompanionStatusBar複数 | 固定2〜4本のバー参照を別々に保持 |
+
+### 設計案
+
+```csharp
+/// <summary>
+/// N個の固定スロットを管理する汎用コンテナ。
+/// アクティブスロットのカーソル・空き検索・スワップを提供。
+/// stackalloc 互換（ヒープアロケーションなし）。
+/// </summary>
+public struct FixedSlotContainer<T, N> : IDisposable
+    where T : unmanaged
+    where N : unmanaged, INativeCount  // 容量をコンパイル時定数で指定
+{
+    /// <summary>スロット番号で直接アクセス。O(1)。</summary>
+    public ref T this[int slotIndex] { get; }
+
+    /// <summary>スロットが空かどうか（デフォルト値との比較）。O(1)。</summary>
+    public bool IsEmpty(int slotIndex);
+
+    /// <summary>空きスロットの最初のインデックスを返す。O(N)（Nは固定小数）。</summary>
+    public int FindEmpty();
+
+    /// <summary>2スロット間の値をスワップ。O(1)。</summary>
+    public void Swap(int slotA, int slotB);
+
+    /// <summary>現在のアクティブスロットインデックス。</summary>
+    public int ActiveIndex { get; set; }
+
+    /// <summary>アクティブスロットを次に進める（ループ）。</summary>
+    public void RotateNext();
+
+    /// <summary>アクティブスロットの値への参照。</summary>
+    public ref T Active { get; }
+
+    /// <summary>全スロットをSpanで取得（一括処理用）。</summary>
+    public Span<T> AsSpan();
+}
+```
+
+### 使用例
+
+```csharp
+// InventorySystem: ベルトスロット
+FixedSlotContainer<ConsumableSlot, N4> _consumableBelt;
+_consumableBelt.RotateNext();                     // 次のスロットへ
+ref ConsumableSlot active = ref _consumableBelt.Active; // アクティブアイテム取得
+
+// SummonSystem: 召喚枠（最古置換）
+FixedSlotContainer<SummonSlot, N2> _summonSlots;
+int oldest = FindOldestSlot(_summonSlots);        // 最古スロット検索
+_summonSlots[oldest] = newSummon;                 // 置換
+
+// WeaponSystem: 武器スロット
+FixedSlotContainer<WeaponSlot, N2> _weaponSlots; // [0]=右手, [1]=左手
+ref WeaponSlot right = ref _weaponSlots[0];
+ref WeaponSlot left  = ref _weaponSlots[1];
+_weaponSlots.Swap(0, 1);                          // 武器持ち替え
+```
+
+### 汎用性評価
+固定スロット管理はRPG・アクション問わず広く使われる ✓
+コンパイル時定数N（N2/N4/N8等）で型安全性を保てる
+
+---
+
+## C6. FactionRelationContainer
+
+### 概要
+陣営ID × 陣営ID の関係（Hostile/Ally/Neutral）を**O(1)で双方向参照**するコンテナ。
+現状の `CharacterFlags.Belong` ビットフラグでは
+「この2体が敵対しているか」を毎回計算しており、
+混乱魔法やボス連携で陣営関係が動的に変化した場合の対応が複雑になる。
+
+```
+relations[factionA][factionB] = Relation (Hostile/Ally/Neutral)
+対角対称を保証（AがBに敵対 = BがAに敵対）
+```
+
+### プロジェクトでの課題
+
+| システム | 陣営関係の用途 | 現状の問題 |
+|---------|--------------|-----------|
+| AICore | 攻撃対象フィルタ（TargetSelector） | Belongビット比較を毎フレーム全キャラで実行 |
+| ConfusionMagic | 混乱中は味方を攻撃・敵を守る（関係反転） | 一時的な関係反転の管理が困難 |
+| CompanionAI | 連携可能なキャラを判定 | Belongビットの同一性チェック |
+| SummonSystem | 召喚キャラの陣営帰属 | 召喚者の陣営を継承する処理が手動 |
+| BossSystem | ボス第2フェーズで中立→敵対化 | フェーズ遷移時の陣営変更が散在 |
+
+### 設計案
+
+```csharp
+public enum Relation : byte
+{
+    Neutral = 0,
+    Allied  = 1,
+    Hostile = 2,
+}
+
+/// <summary>
+/// 陣営間の関係を管理するコンテナ。
+/// 最大N陣営（byte: 0〜255）の関係をO(1)で参照・更新できる。
+/// 混乱魔法等の一時的な関係上書きをスタック管理で実現。
+/// </summary>
+public struct FactionRelationContainer : IDisposable
+{
+    /// <summary>2陣営間の関係を取得。O(1)。</summary>
+    public Relation Get(byte factionA, byte factionB);
+
+    /// <summary>2陣営間の関係を設定（対称性を自動保証）。O(1)。</summary>
+    public void Set(byte factionA, byte factionB, Relation relation);
+
+    /// <summary>一時的な関係上書き（混乱魔法用）。Resetで元に戻る。</summary>
+    public void SetTemporary(byte factionA, byte factionB, Relation relation, float duration);
+
+    /// <summary>指定陣営が敵対する全陣営リストを取得。O(N)。</summary>
+    public ReadOnlySpan<byte> GetHostile(byte faction);
+
+    /// <summary>指定陣営が同盟する全陣営リストを取得。O(N)。</summary>
+    public ReadOnlySpan<byte> GetAllied(byte faction);
+
+    /// <summary>現在のフレームで一時上書きを更新（期限切れを元に戻す）。</summary>
+    public void Tick(float deltaTime);
+}
+```
+
+### 使用例
+
+```csharp
+// 初期化（ゲーム開始時）
+_factions.Set(Faction.Player, Faction.Enemy,   Relation.Hostile);
+_factions.Set(Faction.Player, Faction.Neutral, Relation.Neutral);
+_factions.Set(Faction.Player, Faction.Ally,    Relation.Allied);
+_factions.Set(Faction.Enemy,  Faction.Ally,    Relation.Hostile);
+
+// TargetSelector: 攻撃対象フィルタ（O(1)判定）
+bool isTarget = _factions.Get(attacker.faction, candidate.faction) == Relation.Hostile;
+
+// ConfusionMagic: 15秒間陣営関係を反転
+_factions.SetTemporary(Faction.Enemy, Faction.Enemy, Relation.Hostile, 15f);
+// ← 混乱中の敵同士が戦い始める。15秒後に自動で元に戻る
+
+// BossSystem: フェーズ2で中立NPCが敵対化
+_factions.Set(Faction.Neutral, Faction.Player, Relation.Hostile);
+```
+
+### N陣営の実装
+
+N=8 陣営として `byte[8][8]` = 64バイトで全関係を保持できる。
+キャッシュライン1本（64バイト）に収まり、参照コストが極小。
+
+### 汎用性評価
+陣営関係マトリックスはRTS・RPG・対戦ゲームで汎用的 ✓
+一時上書き機能はプロジェクト固有寄りだが、`SetTemporary` をオプショナルにすれば汎用性を損なわない
+
+---
+
+## 全提案サマリーと実装優先度
+
+### 優先度マトリックス
+
+| # | コンテナ | 解決する問題数 | ODC設計適合度 | 汎用性 | 実装難易度 | 総合 |
+|---|---------|-------------|-------------|--------|----------|------|
+| C1 | SparseSetContainer | 5システム | ◎ | ◎ | 中 | ★★★★★ |
+| C2 | ThresholdAccumulator | 5システム | ◎ | ◎ | 低 | ★★★★★ |
+| C3 | WeightedSampler | 4システム | ○ | ◎ | 中 | ★★★★☆ |
+| C4 | BitFlagTable | 6システム | ◎ | ◎ | 低 | ★★★★☆ |
+| C5 | FixedSlot | 5システム | ○ | ○ | 低 | ★★★☆☆ |
+| C6 | FactionRelation | 5システム | ○ | ○ | 中 | ★★★☆☆ |
+
+### ODCパッケージとの責務分担
+
+```
+ODC新バージョン既存コンテナ
+  ├── 時間系: CooldownContainer, TimedDataContainer, StateMapContainer
+  ├── 空間系: SpatialHashContainer2D
+  ├── プール系: PriorityPoolContainer, RingBufferContainer, GroupContainer
+  └── キャッシュ系: ComponentCache
+
+カスタムコンテナ（本提案）
+  ├── 部分集合反復: C1 SparseSetContainer      ← ODCに存在しないECS的パターン
+  ├── 蓄積トリガー: C2 ThresholdAccumulator     ← ゲーム固有だが汎用的なパターン
+  ├── 確率選択:    C3 WeightedSampler          ← アルゴリズム特化
+  ├── フラグ管理:  C4 BitFlagTable             ← SoAと相補的なビット集合
+  ├── スロット管理: C5 FixedSlot               ← UIとロジックをつなぐ固定配列
+  └── 関係管理:   C6 FactionRelation          ← ゲームルール層に近い
+
+SoACharaDataDic（プロジェクト専用）
+  └── キャラ恒常データの O(1) ハッシュアクセス
+```
+
+### 実装順序（推奨）
+
+```
+Phase A（コアシステム実装前に用意すべき）
+  C2 ThresholdAccumulator → DamageSystem・LevelUpSystemと同時に実装
+  C4 BitFlagTable         → GateSystem・BacktrackReward導入時に用意
+
+Phase B（戦闘・AIシステム拡張時）
+  C1 SparseSetContainer   → 投射物システム・ConfusionMagic実装時
+  C6 FactionRelation      → ConfusionMagic・BossSystemフェーズ実装時
+
+Phase C（コンテンツ拡充時）
+  C3 WeightedSampler      → DropTable・スポーンシステム拡充時
+  C5 FixedSlot            → UI整備・インベントリシステム実装時
+```
+
+---
+
+## SisterGameの課題から発想した汎用コンテナ提案
+
+SisterGameのシステム設計を分析する過程で見えてきた課題を起点に、
+**他のプロジェクトでも普通に使えるODCパッケージ候補**として設計し直したコンテナ群。
+各コンテナの「SisterGameでの動機」と「汎用適用例」を両方示す。
+
+
+
+---
+
+### G1. HitDeduplicationContainer（ヒット重複排除）
+
+**SisterGameでの動機**: WeaponSystemの `HitBox` が `Dictionary<int, bool>` で
+「今回の攻撃でヒット済みターゲット」を管理。攻撃1回ごとに Dictionary をnewしてGCが発生し、
+複数HitBoxが独立管理しているため貫通ヒットの重複防止が困難。
+
+**抽象化すると**: 「あるイベントインスタンス（攻撃・爆発・AoE等）に対して、
+ターゲットごとの"処理済み"状態をアロケーションなしで追跡する」コンテナ。
+
+**他プロジェクトでの用途**:
+- AoEスペル・チェインライトニングの複数ヒット防止
+- 範囲ピックアップ（コインが複数同時衝突する場合）
+- マルチヒット投射物（貫通矢・散弾）
+- トリガーゾーンの重複イベント防止
+
+```csharp
+/// <summary>
+/// イベントインスタンス単位でのターゲット処理重複を防止するコンテナ。
+/// Dictionary を使わず、ビットセットまたはSparseSetで GCフリーを実現する。
+/// eventHash（攻撃・スペル等のインスタンスID）× targetHash で O(1) 判定。
+/// </summary>
+public struct HitDeduplicationContainer : IDisposable
+{
+    /// <summary>
+    /// ターゲットへのヒットを試みる。
+    /// 初回はtrue（処理を進める）、既記録はfalse（スキップ）を返す。O(1)。
+    /// </summary>
+    public bool TryRecord(int eventHash, int targetHash);
+
+    /// <summary>
+    /// 貫通残回数付きのヒット試行。
+    /// pierceRemaining == 0 の場合は無制限貫通。O(1)。
+    /// </summary>
+    public bool TryRecord(int eventHash, int targetHash, ref byte pierceRemaining);
+
+    /// <summary>
+    /// イベント終了時にヒット記録を一括解放。O(k)（k=ヒット数）。
+    /// 攻撃モーション終了・スペル消滅・爆発後に呼ぶ。
+    /// </summary>
+    public void Release(int eventHash);
+
+    /// <summary>eventHashに対するヒット済みターゲット数。</summary>
+    public int GetHitCount(int eventHash);
+}
+```
+
+**使用例（SisterGame）**:
+```csharp
+// HitBox.OnTriggerEnter2D
+if (!GameManager.HitDedup.TryRecord(_attackHash, targetHash)) return;
+// → 同じ攻撃で同じターゲットに2回当たってもスキップ
+
+// 貫通武器（残り2回まで貫通可）
+byte pierce = 2;
+if (!GameManager.HitDedup.TryRecord(_attackHash, targetHash, ref pierce)) return;
+
+// アクション終了時
+GameManager.HitDedup.Release(_attackHash);
+```
+
+---
+
+### G2. FlagComboLookupContainer\<TEffect\>（フラグ組み合わせ効果テーブル）
+
+**SisterGameでの動機**: DamageSystem + ElementalGate で
+「Fire+Ice=蒸気爆発」のような属性組み合わせ判定を毎回
+`if(flags.HasFlag(Fire) && flags.HasFlag(Ice))` と書く必要があり、
+条件分岐がコード全体に散乱する。
+
+**抽象化すると**: 「ビットフラグの組み合わせ（ulong）をキーに、
+事前登録したエフェクトをO(1)で引く読み取り専用テーブル」。
+属性・状態異常・スキルシナジー・クラフトレシピなど、
+「フラグの重なりで何かが起きる」全ての場面に適用できる。
+
+**他プロジェクトでの用途**:
+- 属性相性・弱点テーブル（JRPG）
+- 装備セットボーナス（複数部位装備で追加効果）
+- スキルシナジー（A+BのスキルでCの効果が発動）
+- クラフトレシピ（素材の組み合わせ → 成果物）
+- 環境インタラクション（水+電撃=感電地形）
+
+```csharp
+/// <summary>
+/// ulong ビットフラグの組み合わせをキーに、事前登録したエフェクトをO(1)で取得する
+/// 読み取り専用テーブルコンテナ。
+/// 構築時 O(n)、サンプリング時 O(1)（完全ハッシュテーブル）。
+/// TEffect は unmanaged 構造体で自由に定義する。
+/// </summary>
+public struct FlagComboLookupContainer<TEffect> : IDisposable
+    where TEffect : unmanaged
+{
+    /// <summary>
+    /// (フラグ組み合わせ, エフェクト) ペアリストからテーブルを構築する。
+    /// requiredAll=true: 指定フラグを全て含む場合にマッチ。
+    /// requiredAll=false: いずれか含む場合にマッチ（OR検索）。
+    /// </summary>
+    public static FlagComboLookupContainer<TEffect> Build(
+        ReadOnlySpan<(ulong flagCombo, TEffect effect)> entries,
+        bool requiredAll = true);
+
+    /// <summary>
+    /// 入力フラグに対してマッチするエフェクトを返す。O(1)。
+    /// 複数マッチ時は登録順で最初にマッチしたものを返す。
+    /// </summary>
+    public bool TryGet(ulong inputFlags, out TEffect effect);
+
+    /// <summary>
+    /// 入力フラグにマッチする全エフェクトを列挙する。O(n)。
+    /// （クラフトで「このフラグ組み合わせで作れる全レシピ」等に使用）
+    /// </summary>
+    public int GetAll(ulong inputFlags, Span<TEffect> results);
+}
+```
+
+**使用例（SisterGame）**:
+```csharp
+// 構築（ゲーム起動時1回）
+var resonanceTable = FlagComboLookupContainer<ResonanceEffect>.Build(new (ulong, ResonanceEffect)[]
+{
+    ((ulong)(Element.Fire | Element.Ice),     new ResonanceEffect { damageMultiplier = 1.5f, aoeRadius = 3 }),
+    ((ulong)(Element.Thunder | Element.Ice),  new ResonanceEffect { damageMultiplier = 1.3f, procStatus = Status.Paralyze }),
+});
+
+// ダメージ計算時（O(1)）
+ulong comboKey = (ulong)(attackElement | targetAccumulated);
+if (resonanceTable.TryGet(comboKey, out ResonanceEffect resonance))
+    damage *= resonance.damageMultiplier;
+```
+
+---
+
+### G3. ScoredCandidateBuffer\<T\>（スコア付き候補バッファ）
+
+**SisterGameでの動機**: AICore の3層判定（Target判定 / Action判定）で、
+「複数の候補を評価してスコアを付け、最高スコアのものを選ぶ」処理を
+毎フレーム・全AIキャラ分行う。現状は中間配列の確保が分散しGCを生む。
+
+**抽象化すると**: 「ownerHash単位で複数の候補(T)を提出しスコアを付け、
+最高スコアのものを選択・取得するフレームバッファ」。
+AIに限らず「評価→選択」パターン全般に使える。
+
+**他プロジェクトでの用途**:
+- AIの行動選択・ターゲット選択（あらゆるゲームのAI）
+- ナビゲーションのウェイポイント選択
+- UIフォーカス管理（複数UI候補から最適なものを選択）
+- クエスト優先度管理（複数クエストからプレイヤー向け最優先を決定）
+- オートバトルの攻撃先/スキル選択
+
+```csharp
+/// <summary>
+/// ownerHash ごとに T 型の候補を提出・スコアリングし、
+/// 最高スコアの候補を選択するフレームバッファ。
+/// 毎フレームの評価サイクルを GCフリーでサポートする。
+/// </summary>
+public struct ScoredCandidateBuffer<T> : IDisposable
+    where T : unmanaged
+{
+    /// <summary>
+    /// 評価サイクルを開始する（前回の候補をクリア）。
+    /// 毎判定サイクルの先頭で呼ぶ。
+    /// </summary>
+    public void BeginEvaluation(int ownerHash);
+
+    /// <summary>
+    /// スコア付きで候補を提出する。O(1)。
+    /// 容量上限（maxCandidates）超過時は最低スコアの候補を自動排出。
+    /// </summary>
+    public void Submit(int ownerHash, in T candidate, float score);
+
+    /// <summary>最高スコアの候補を取得。O(1)。</summary>
+    public bool TryGetBest(int ownerHash, out T best, out float bestScore);
+
+    /// <summary>
+    /// スコア上位k件を取得（複数選択・表示用）。O(k log k)。
+    /// </summary>
+    public int GetTopK(int ownerHash, Span<T> results, int k);
+
+    /// <summary>現在の候補数。</summary>
+    public int GetCount(int ownerHash);
+}
+```
+
+**使用例（SisterGame）**:
+```csharp
+// JudgmentLoop内（AIターゲット選択）
+_candidateBuffer.BeginEvaluation(actorHash);
+foreach (int candidateHash in _sensor.Detected)
+{
+    float score = CalcThreat(actorHash, candidateHash);
+    _candidateBuffer.Submit(actorHash, candidateHash, score);
+}
+_candidateBuffer.TryGetBest(actorHash, out int bestTarget, out float _);
+
+// AIアクション選択も同じパターン
+_candidateBuffer.BeginEvaluation(actorHash);
+foreach (AIRule rule in aiRules)
+    _candidateBuffer.Submit(actorHash, rule.actionId, EvaluateRule(rule));
+_candidateBuffer.TryGetBest(actorHash, out ushort selectedAction, out float _);
+```
+
+---
+
+### G4. MultiPartySequenceContainer\<TState\>（複数参加者のシーケンス管理）
+
+**SisterGameでの動機**: CoopAction設計書の「プレイヤー+仲間が特定タイミングで
+連携技を発動する」仕組みでは、複数キャラ間で「今どのステップか」「入力猶予が残っているか」
+という状態を共有する必要がある。個々のSoAデータでは表現できない**グループ共有状態**。
+
+**抽象化すると**: 「複数の参加者エンティティが順番に条件を満たすことで
+ステップが進行し、全ステップ完了で何かが起きる、タイムアウト付きシーケンス管理」。
+
+**他プロジェクトでの用途**:
+- 協力パズル（複数プレイヤーが順番にスイッチを押す）
+- コンボシステム（複数の入力が順番に成立すると技発動）
+- マルチプレイヤーのトレード（双方がAcceptして成立）
+- NPCとの連携イベント（プレイヤー→NPC→プレイヤーの順で行動して発動）
+- ボスのギミック（複数プレイヤーが同時/順番に特定位置に立つ）
+
+```csharp
+/// <summary>
+/// 複数参加者が順番にステップをクリアするシーケンスを管理するコンテナ。
+/// 各ステップには時間ウィンドウがあり、超過するとシーケンスが失敗/リセットされる。
+/// TState は各ステップの共有状態（進行度・スコア等）を格納する unmanaged 構造体。
+/// </summary>
+public struct MultiPartySequenceContainer<TState> : IDisposable
+    where TState : unmanaged
+{
+    /// <summary>
+    /// 新しいシーケンスを開始する。
+    /// participants: 参加者の hash 配列（固定、最大8名）。
+    /// stepCount: 総ステップ数。
+    /// windowPerStep: 各ステップの入力猶予時間（秒）。
+    /// </summary>
+    public int Begin(ReadOnlySpan<int> participantHashes,
+                     byte stepCount,
+                     float windowPerStep,
+                     in TState initialState);
+
+    /// <summary>
+    /// 参加者がステップをクリアしたことを報告する。
+    /// シーケンスが次ステップに進んだ場合 true を返す。O(1)。
+    /// </summary>
+    public bool Advance(int sequenceId, int participantHash, in TState newState);
+
+    /// <summary>このエンティティが参加しているシーケンスを検索。O(1)。</summary>
+    public bool TryGetSequence(int participantHash, out int sequenceId,
+                                out byte currentStep, out TState state);
+
+    /// <summary>シーケンスが全ステップ完了しているか。O(1)。</summary>
+    public bool IsCompleted(int sequenceId);
+
+    /// <summary>シーケンスを明示的に終了（成功/失敗）。</summary>
+    public void End(int sequenceId);
+
+    /// <summary>時間ウィンドウ更新。タイムアウトしたシーケンスを自動終了。</summary>
+    public void Tick(float deltaTime);
+}
+```
+
+**使用例（SisterGame）**:
+```csharp
+// CoopAction: 連携技シーケンス開始
+int seqId = _sequence.Begin(
+    new[] { playerHash, companionHash },
+    stepCount: 3,
+    windowPerStep: 1.5f,
+    initialState: new CoopState { comboId = 42 }
+);
+
+// 各キャラからのステップ報告
+if (playerInputsComboA)
+    _sequence.Advance(seqId, playerHash, new CoopState { comboId = 42, step1Done = true });
+
+// 毎フレーム更新（タイムアウト管理）
+_sequence.Tick(Time.deltaTime);
+
+// シーケンス完了チェック
+if (_sequence.IsCompleted(seqId))
+    TriggerCoopAttack(seqId);
+```
+
+---
+
+### G5. StackableEffectContainer\<TEffect\>（スタック可能な時限エフェクトスロット）
+
+**SisterGameでの動機**: DamageSystem の状態異常管理では
+「蓄積値が閾値を超えると発症し、一定時間継続してDoTを与え、スタック可能で、
+回復すると即時解除される」という複合的な状態を管理する必要がある。
+`CharacterStatusEffects` 構造体での固定配列管理と Tick処理が複雑化している。
+
+**抽象化すると**: 「エンティティごとに固定N枠のエフェクトスロットを持ち、
+各スロットがスタック数・継続時間・Tick処理を管理する汎用バフ/デバフコンテナ」。
+
+**他プロジェクトでの用途**:
+- あらゆるRPG/アクションゲームのバフ/デバフ管理
+- DoT（毒・燃焼・出血等）の時間処理
+- シールド/バリア層の重ね掛け管理
+- スタックバフ（強化が10回積めるシステム）
+- チャージシステム（ゲージが最大スタックで技発動）
+
+```csharp
+/// <summary>
+/// エンティティごとに N 枠の時限スタックエフェクトスロットを管理するコンテナ。
+/// スタック加算・継続時間・周期Tick・期限切れ解放を一元管理する。
+/// TEffect は unmanaged 構造体で効果の定義を自由に格納する。
+/// </summary>
+public struct StackableEffectContainer<TEffect> : IDisposable
+    where TEffect : unmanaged
+{
+    /// <summary>
+    /// エフェクトを適用する。
+    /// 同一 effectKey のスロットが存在する場合はスタックを追加し継続時間を更新。
+    /// 存在しない場合は空きスロットに新規登録。O(N)（N=スロット数=固定小）。
+    /// </summary>
+    public bool Apply(int entityHash, int effectKey, in TEffect effectData,
+                      byte addStacks = 1, float duration = 0f,
+                      float tickInterval = 0f);
+
+    /// <summary>指定エフェクトを即時解除。O(N)。</summary>
+    public bool Remove(int entityHash, int effectKey);
+
+    /// <summary>指定エフェクトが発動中か。O(N)。</summary>
+    public bool IsActive(int entityHash, int effectKey);
+
+    /// <summary>スタック数を取得。O(N)。</summary>
+    public byte GetStacks(int entityHash, int effectKey);
+
+    /// <summary>
+    /// 1エンティティのエフェクトを時間更新する。
+    /// Tick対象エフェクトの処理用コールバックを受け取る。
+    /// 期限切れスロットを自動解放。O(N)。
+    /// </summary>
+    public void Tick(int entityHash, float deltaTime,
+                     TickCallback<TEffect> onTick = null,
+                     ExpireCallback<TEffect> onExpire = null);
+
+    /// <summary>全エンティティを一括Tick（毎フレーム呼ぶ版）。O(M×N)。</summary>
+    public void TickAll(float deltaTime,
+                        TickCallback<TEffect> onTick = null,
+                        ExpireCallback<TEffect> onExpire = null);
+
+    /// <summary>
+    /// エンティティのアクティブエフェクトを全て列挙する。
+    /// results に (effectKey, effectData, stacks, remainingTime) を書き込み、件数を返す。O(N)。
+    /// UI表示・デバッグ用途を想定。GCフリー（Span で受け取る）。
+    /// </summary>
+    public int GetActiveEffects(int entityHash,
+        Span<(int effectKey, TEffect effectData, byte stacks, float remainingTime)> results);
+
+    /// <summary>アクティブスロット数（現在かかっているエフェクトの種類数）。O(1)。</summary>
+    public int GetActiveCount(int entityHash);
+
+    public delegate void TickCallback<T>(int entityHash, int effectKey, in T effect, byte stacks)
+        where T : unmanaged;
+    public delegate void ExpireCallback<T>(int entityHash, int effectKey, in T effect)
+        where T : unmanaged;
+}
+```
+
+**使用例（SisterGame）**:
+```csharp
+// 毒状態の定義（unmanaged構造体 = どんなゲームでも自由に定義）
+public struct PoisonEffect : unmanaged
+{
+    public float damagePerTick;
+    public byte  elementType;
+}
+
+// 発症（蓄積閾値超過時）
+_effects.Apply(targetHash, effectKey: (int)Status.Poison,
+    effectData: new PoisonEffect { damagePerTick = 10f, elementType = (byte)Element.Dark },
+    addStacks: 1, duration: 10f, tickInterval: 0.5f);
+
+// 毎フレームTick（DoTダメージをDamageSystemに渡す）
+_effects.TickAll(Time.deltaTime,
+    onTick: (hash, key, effect, stacks) => {
+        DamageSystem.ApplyDot(hash, effect.damagePerTick * stacks);
+    },
+    onExpire: (hash, key, effect) => {
+        UISystem.RemoveStatusIcon(hash, key);
+    });
+
+// 解毒アイテム使用
+_effects.Remove(targetHash, (int)Status.Poison);
+```
+
+---
+
+### SisterGameの課題から発想した汎用コンテナ サマリー
+
+| # | コンテナ | SisterGameの動機 | 汎用パターン |
+|---|---------|----------------|------------|
+| G1 | `HitDeduplicationContainer` | HitBoxの二重ヒット防止 | イベントインスタンス×ターゲットの処理済み管理 |
+| G2 | `FlagComboLookupContainer<T>` | 属性組み合わせ効果テーブル | フラグ組み合わせ→エフェクトのO(1)引き当て |
+| G3 | `ScoredCandidateBuffer<T>` | AI三層判定の候補評価 | 評価→スコアリング→最適選択のフレームバッファ |
+| G4 | `MultiPartySequenceContainer<T>` | 連携アクションのステップ進行 | 複数エンティティ×ステップ×タイムウィンドウ |
+| G5 | `StackableEffectContainer<T>` | 状態異常スロット管理 | スタック可能・時限・Tick付きエフェクトスロット |
+
+### 全コンテナの関係図（C1〜C6 + G1〜G5）
+
+```
+汎用基盤層（ODCパッケージ）
+├── C1 SparseSetContainer     ← G1の内部実装に活用
+├── C2 ThresholdAccumulator   ← G5と組み合わせて「蓄積→発症」パイプライン
+├── C3 WeightedSampler        ← ドロップ・スポーン確率選択
+├── C4 BitFlagTable           ← G2のフラグキーに活用
+├── C5 FixedSlotContainer     ← G5の内部スロット実装
+└── C6 FactionRelation        ← G3のターゲット評価スコアに陣営係数を加算
+
+SisterGameの課題から発想した汎用層（ODCパッケージ候補）
+├── G1 HitDeduplicationContainer     ← アクション/スペル系ゲーム全般
+├── G2 FlagComboLookupContainer      ← 属性/シナジー/クラフト系ゲーム全般
+├── G3 ScoredCandidateBuffer         ← AI搭載ゲーム全般
+├── G4 MultiPartySequenceContainer   ← 協力プレイ/コンボ系ゲーム全般
+└── G5 StackableEffectContainer      ← RPG/アクション全般（最も汎用）
+
+組み合わせ活用例（SisterGame）
+  C2 ThresholdAccumulator.OnThreshold → G5 StackableEffectContainer.Apply
+  G3 ScoredCandidateBuffer.TryGetBest → C6 FactionRelation でスコア補正
+  G1 HitDeduplication + G5 StackableEffect → 一撃で状態異常スタックを複数付与しない制御
+```

--- a/designs/ODCコンテナ検討.md
+++ b/designs/ODCコンテナ検討.md
@@ -1,0 +1,414 @@
+# ObjectDataContainer 新バージョン コンテナ検討
+
+## 1. 新ランタイムコンテナの活用検討
+
+新バージョン(v1.0.0)で追加された10種のランタイムコンテナについて、本ゲームでの活用余地を検討する。
+
+---
+
+### 1-1. CooldownContainer — 活用度: ★★★★★（最優先）
+
+**概要**: GameObject単位で複数の名前付きクールダウンを管理。O(1)アクセス。
+
+**現状の課題**:
+- `CoopCooldownTracker` が単一クールダウンを自前実装
+- `ComboManager._inputWindowTimer` がタイマーを手動管理
+- `JudgmentLoop` が `_targetJudgeTimer` / `_actionJudgeTimer` を個別管理
+- `DamageReceiver._armorRecoveryTimer` も独自タイマー
+- スキルクールダウン、回避クールダウン等、今後増える一方
+
+**活用案**:
+- アビリティ/スキルのクールダウン一元管理
+- AI判定間隔タイマー（TargetJudge, ActionJudge）
+- 入力バッファのタイムアウト管理
+- アーマー回復ディレイ
+- 無敵時間管理（被弾後の無敵フレーム）
+
+---
+
+### 1-2. StateMapContainer\<TState\> — 活用度: ★★★★★（最優先）
+
+**概要**: GameObject単位のFSM。現在/前回の状態 + 経過時間を追跡。
+
+**現状の課題**:
+- `ModeController` がAIモード遷移を自前実装（_currentModeIndex, SetModes, SwitchMode）
+- `CharacterFlags.ActState` がビットフラグで状態管理（6ビット = 最大64状態）
+- 状態遷移の履歴（前回状態）や経過時間が取れない
+- `ActionBase._isExecuting` もbooleanで状態管理
+
+**活用案**:
+- AIモード管理（Idle/Chase/Attack/Flee等）→ ModeControllerの置き換え
+- キャラクター行動状態管理（ActState）の補完 — 経過時間付きで「スタン何秒経過」等が取れる
+- アクション実行状態のFSM化（Idle/PreMotion/Active/Recovery）
+- ボス戦フェーズ管理（Phase1/Phase2/Phase3 + 経過時間）
+
+---
+
+### 1-3. SpatialHashContainer2D\<T\> — 活用度: ★★★★☆（高）
+
+**概要**: 2D空間ハッシュ。近傍クエリをO(1)〜O(k)で実行。
+
+**現状の課題**:
+- `SensorSystem.UpdateDetection()` が全ハッシュを線形スキャンして距離チェック → O(n)
+- `TargetSelector.FilterCandidates()` も全候補に対してVector2.Distance → O(n)
+- `ConditionEvaluator.NearbyFaction` が全味方をイテレートして距離計算
+- `EnemySpawner.EvaluateSpawnPoints()` も距離チェックあり
+- キャラクター数が増えると線形スキャンがボトルネックに
+
+**活用案**:
+- AI認識システム（SensorSystem）の近傍検索高速化
+- ターゲット選択の距離フィルタリング高速化
+- 近接味方カウント（NearbyFaction条件）の高速化
+- 敵スポーンポイントの有効範囲判定
+- 将来的なAoE（範囲攻撃）の対象取得
+
+**注意**: 本ゲームは2Dサイドスクロールなので2D版が適切。XZ平面ではなくXY平面で動作するか確認が必要（現行はXZ平面操作）。
+
+---
+
+### 1-4. TimedDataContainer\<T\> / NotifyTimedDataContainer\<T\> — 活用度: ★★★★☆（高）
+
+**概要**: 時限付きデータ格納。期限切れで自動削除＋コールバック。
+
+**現状の課題**:
+- `StatusEffectManager` が手動でタイマー管理 + swap-remove
+- `ActionEffect` が `startTime + duration` で有効期間管理
+- バフ/デバフの残り時間管理が各所に散在
+- 今後、投射物（Projectile）の寿命管理も必要
+
+**活用案**:
+- バフ/デバフ管理 — 期限切れで自動解除 + UI通知コールバック
+- 投射物の寿命管理
+- 一時的な無敵状態（被弾後iフレーム）
+- ステージギミックの一時効果（加速パッド、毒沼等）
+- AI一時イベント（「助けて」シグナル等、一定時間で消失）
+
+---
+
+### 1-5. GroupContainer\<T\> — 活用度: ★★★★☆（高）
+
+**概要**: グループ単位のオブジェクト管理。O(1)グループ移動、Span一括取得。
+
+**現状の課題**:
+- `CharacterFlags.Belong` ビットフラグ(3ビット)で陣営管理（Ally/Enemy/Neutral等）
+- `TargetSelector` / `ConditionEvaluator` が全キャラをイテレートしてBelongフィルタ
+- 陣営ごとのキャラ一覧取得に毎回フルスキャンが必要
+- 味方AI（CompanionController）がプレイヤーとの関係を暗黙的に管理
+
+**活用案**:
+- 陣営別キャラクター管理（Ally/Enemy/Neutral/Boss）
+- ステージ別アクティブ敵管理（EnemySpawnerとの連携）
+- AI対象グループ（攻撃対象グループ / 防御対象グループ）
+- 寝返り・混乱魔法で `MoveToGroup()` による陣営変更（O(1)）
+
+---
+
+### 1-6. PriorityPoolContainer\<T\> — 活用度: ★★★☆☆（中）
+
+**概要**: 優先度付きプール。容量超過時に低優先度を自動排出。
+
+**現状の課題**:
+- `EnemySpawner` が `_maxActive` で同時敵数を制限
+- `ProjectilePool` が固定サイズプール管理
+- `DamageScoreTracker` が脅威度スコアを管理（暗黙的な優先度）
+
+**活用案**:
+- 敵スポーン管理 — 最大数超過時に画面外の低優先敵を自動despawn
+- エフェクトプール — パーティクル等の同時表示数制限
+- ダメージポップアップの表示数制限（古いものから消す）
+- AI認識リスト — 認識可能な最大ターゲット数を制限
+
+---
+
+### 1-7. RingBufferContainer\<T\> — 活用度: ★★★☆☆（中）
+
+**概要**: 固定サイズ循環バッファ。ヒープアロケーション無し。
+
+**現状の課題**:
+- `InputBuffer` が1スロットのみ（将来的にコマンド入力が欲しい）
+- `DamageScoreTracker` がダメージ履歴を減衰管理
+- 入力履歴がないためリプレイやAI学習データ収集が困難
+
+**活用案**:
+- 入力履歴バッファ（直近N入力を記録 → コマンド技判定）
+- ダメージ履歴（直近N回の被ダメージ記録 → AI判断材料）
+- 位置履歴（直近Nフレームの位置 → 軌跡エフェクト、移動予測）
+- デバッグログ（直近Nイベント記録 → AI行動ログ）
+
+---
+
+### 1-8. ComponentCache\<T\> — 活用度: ★★☆☆☆（低〜中）
+
+**概要**: GetComponent結果のキャッシュ。自動クリーンアップ付き。
+
+**現状の課題**:
+- `HitBox.OnTriggerEnter2D()` で `other.GetComponent<DamageReceiver>()` を毎回呼出
+- 設計上GetComponentは排除済み（SoAハッシュアクセス）だが、物理コールバックでは避けられない
+
+**活用案**:
+- 物理コールバック（OnTriggerEnter2D等）でのDamageReceiver/HitBoxキャッシュ
+- ただし、本ゲームのアーキテクチャでは大部分をSoAコンテナが代替済み
+- 限定的な用途（コライダー接触時のみ）
+
+---
+
+### 1-9. SpatialHashContainer3D\<T\> — 活用度: ★☆☆☆☆（低）
+
+**概要**: 3D空間ハッシュ。
+
+**判定**: 本ゲームは2Dサイドスクロールのため、3D版は不要。2D版で十分。
+
+---
+
+### 活用優先度まとめ
+
+| 優先度 | コンテナ | 主な用途 |
+|--------|---------|---------|
+| ★★★★★ | CooldownContainer | アビリティCD、AIタイマー、無敵時間 |
+| ★★★★★ | StateMapContainer | AIモード、行動状態、ボスフェーズ |
+| ★★★★☆ | SpatialHashContainer2D | AI認識、ターゲット選択、範囲攻撃 |
+| ★★★★☆ | TimedDataContainer / Notify版 | バフ/デバフ、投射物寿命、一時効果 |
+| ★★★★☆ | GroupContainer | 陣営管理、ステージ敵管理 |
+| ★★★☆☆ | PriorityPoolContainer | 敵スポーン制限、エフェクト制限 |
+| ★★★☆☆ | RingBufferContainer | 入力履歴、ダメージ履歴、位置軌跡 |
+| ★★☆☆☆ | ComponentCache | 物理コールバック時のみ |
+| ★☆☆☆☆ | SpatialHashContainer3D | 不要（2Dゲーム） |
+
+---
+
+## 2. 追加してほしいデータコンテナ一覧
+
+現在のSoACharaDataDicは `CharacterVitals`, `CombatStats`, `CharacterFlags`, `MoveParams`, `EquipmentStatus`, `CharacterStatusEffects` の6構造体を管理。以下は追加候補。
+
+### 2-1. キャラクター関連（SoAコンテナ管理対象）
+
+#### A. CharacterColdLog（AI判定ログ）
+```csharp
+public struct CharacterColdLog  // 設計書に記載あり、未実装
+{
+    public int characterId;        // キャラクター種別ID
+    public int objectHash;         // GameObjectハッシュ
+    public byte currentModeIndex;  // 現在のAIモードインデックス
+    public float lastTargetJudgeTime;  // 最後のターゲット判定時刻
+    public float lastActionJudgeTime;  // 最後のアクション判定時刻
+}
+```
+**理由**: AI判定間隔の管理。現在JudgmentLoopが個別にタイマーを持つが、SoAに入れればAIManagerから一括参照可能。
+
+#### B. DamageScoreEntry（ダメージスコア / ヘイト管理）
+```csharp
+public struct DamageScoreEntry  // 設計書に記載あり、未実装
+{
+    public int attackerHash;      // 攻撃者のハッシュ
+    public float score;           // 累積ダメージスコア（減衰付き）
+    public float lastUpdateTime;  // 最終更新時刻
+}
+```
+**理由**: ターゲット選択のDamageScoreソートキーに必要。現在DamageScoreTrackerがDictionaryで自前管理。
+
+#### C. ProjectileData（投射物データ）
+```csharp
+public struct ProjectileData
+{
+    public int ownerHash;          // 発射者ハッシュ
+    public byte moveType;          // BulletMoveType (Straight/Homing/Angle等)
+    public float speed;            // 移動速度
+    public float lifetime;         // 残り寿命
+    public float homingStrength;   // ホーミング強度
+    public byte pierceRemaining;   // 残り貫通回数
+    public float aoeRadius;        // 着弾時AoE半径
+    public int targetHash;         // ホーミング対象
+    public ushort attackInfoId;    // AttackInfo参照ID
+}
+```
+**理由**: 投射物システムは設計済み・未実装。ProjectilePoolを超えた高速な投射物管理が必要。
+
+#### D. AnimationState（アニメーション状態）
+```csharp
+public struct AnimationState
+{
+    public int currentClipHash;    // 現在再生中のアニメーションハッシュ
+    public float normalizedTime;   // 正規化時間 (0.0〜1.0)
+    public float speed;            // 再生速度
+    public byte layerIndex;        // レイヤーインデックス
+    public bool isInTransition;    // 遷移中フラグ
+}
+```
+**理由**: アニメーション状態をSoAで管理すれば、AI判定やアクション入力可否判定でAnimatorへのアクセスを減らせる。
+
+#### E. KnockbackData（ノックバック/物理反応データ）
+```csharp
+public struct KnockbackData
+{
+    public Vector2 velocity;       // 現在のノックバック速度
+    public float duration;         // 残りノックバック時間
+    public float gravityScale;     // ノックバック中の重力スケール
+    public byte hitStopFrames;     // ヒットストップ残りフレーム
+    public bool isAirborne;        // ノックバックで空中かどうか
+}
+```
+**理由**: 被弾リアクションの物理データ。DamageReceiverとBaseCharacterの間で共有が必要。
+
+#### F. InputState（入力状態）
+```csharp
+public struct InputState
+{
+    public Vector2 moveInput;      // 移動入力ベクトル
+    public ushort buttonDown;      // 今フレーム押されたボタン（ビットフラグ）
+    public ushort buttonHeld;      // 押し続けているボタン
+    public ushort buttonUp;        // 今フレーム離されたボタン
+    public float chargeTime;       // チャージ攻撃の溜め時間
+}
+```
+**理由**: AIとプレイヤーの入力を統一的にSoAで管理。AIBrainの出力もInputStateとして格納すれば、BaseCharacterは入力ソースを意識しない。
+
+#### G. WeaponState（武器状態）
+```csharp
+public struct WeaponState
+{
+    public ushort rightWeaponId;     // 右手武器ID
+    public ushort leftWeaponId;      // 左手武器ID
+    public byte activeSlot;          // アクティブスロット (0=右, 1=左)
+    public byte comboStep;           // 現在のコンボステップ
+    public float comboWindowTimer;   // コンボ入力受付残り時間
+    public byte chargeLevel;         // チャージレベル (0=なし)
+    public float chargeElapsed;      // チャージ経過時間
+}
+```
+**理由**: 武器/コンボ/チャージの状態をSoAで一元管理。ComboManagerとWeaponHolderの状態をまとめる。
+
+#### H. ActionExecutionData（アクション実行データ）
+```csharp
+public struct ActionExecutionData
+{
+    public ushort currentActionId;   // 実行中アクションID（0=なし）
+    public float elapsed;            // アクション経過時間
+    public float totalDuration;      // アクション全体時間
+    public byte phase;               // PreMotion/Active/Recovery/Complete
+    public byte cancelFlags;         // キャンセル可能条件（ビットフラグ）
+}
+```
+**理由**: アクション実行状態をSoAで管理。AI判断時に「今何をやっているか」「キャンセル可能か」を高速参照。
+
+### 2-2. システム用コンテナ（ランタイムコンテナで管理）
+
+#### I. SpawnPointContainer（スポーンポイント管理）
+```
+用途: EnemySpawnerのスポーンポイント群を管理
+型: TimedDataContainer<SpawnPointData> or PriorityPoolContainer<SpawnPointData>
+```
+**理由**: リスポーンタイマー、最大同時数、優先度を統合管理。
+
+#### J. EventQueueContainer（AIイベントキュー）
+```
+用途: BrainEventContainerの実体。キャラクター間通信イベント
+型: RingBufferContainer<BrainEvent>
+```
+**理由**: 設計書に記載の`BrainEventContainer`。「大ダメージを受けた」「仲間がやられた」等のイベントをリングバッファで管理。
+
+#### K. HitRecordContainer（ヒット記録）
+```
+用途: HitBoxの二重ヒット防止記録 + ダメージ履歴
+型: TimedDataContainer<HitRecord>
+```
+**理由**: 攻撃ごとのヒット済みターゲット記録。現在HitBoxが個別管理。
+
+#### L. TweenHandleContainer（UIアニメーション管理）
+```
+用途: HudControllerのMotionHandle群の一元管理
+型: TimedDataContainer<MotionHandle>
+```
+**理由**: LitMotionのハンドルリーク防止。期限切れで自動解放。
+
+### 2-3. ゲームプレイ用コンテナ
+
+#### M. InventoryContainer（インベントリ）
+```csharp
+public struct InventorySlot
+{
+    public ushort itemId;         // アイテムID
+    public byte count;            // 所持数
+    public byte slotType;         // 装備/消費/素材/キー
+}
+```
+**理由**: GDDにインベントリシステムが記載。固定スロット数のコンテナ管理。
+
+#### N. QuestFlagContainer（クエスト/フラグ管理）
+```csharp
+public struct QuestProgress
+{
+    public ushort questId;        // クエストID
+    public byte state;            // NotStarted/Active/Complete/Failed
+    public ushort progress;       // 進行度（討伐数等）
+    public ushort target;         // 目標値
+}
+```
+**理由**: GDDにグローバル/マップローカルフラグが設計済み。StateMapContainerで状態遷移管理。
+
+#### O. DropTableContainer（ドロップテーブル）
+```csharp
+public struct DropEntry
+{
+    public ushort itemId;         // ドロップアイテムID
+    public float probability;    // ドロップ確率
+    public byte minCount;        // 最小数
+    public byte maxCount;        // 最大数
+    public ushort conditionFlag; // 条件フラグ（特定装備時ボーナス等）
+}
+```
+**理由**: 敵撃破時のアイテムドロップ。PriorityPoolContainerで希少度管理も可能。
+
+#### P. DialogueContainer（会話データ）
+```
+用途: イベントシーンの会話進行管理
+型: RingBufferContainer<DialogueLine> （表示履歴のバックログ）
+```
+
+#### Q. CheckpointContainer（チェックポイント管理）
+```
+用途: セーブポイント/ファストトラベル地点の管理
+型: GroupContainer<CheckpointData>（エリア別グループ化）
+```
+
+#### R. ParticleEffectPool（エフェクトプール）
+```
+用途: パーティクルエフェクトの同時表示数制限
+型: PriorityPoolContainer<ParticleHandle>（低優先度から自動排出）
+```
+
+#### S. DamageNumberPool（ダメージ数値表示プール）
+```
+用途: ダメージポップアップの表示数管理
+型: PriorityPoolContainer<DamagePopupData>（古い/小さいダメージから排出）
+```
+
+#### T. CameraShakeBuffer（カメラ揺れ管理）
+```
+用途: 複数の揺れソースの合成管理
+型: TimedDataContainer<ShakeData>（時限付き、自動消失）
+```
+
+### 2-4. 全一覧サマリー
+
+| # | コンテナ名 | 種別 | 優先度 | 用途 |
+|---|-----------|------|--------|------|
+| A | CharacterColdLog | SoA構造体 | ★★★★★ | AI判定ログ |
+| B | DamageScoreEntry | SoA構造体 | ★★★★★ | ヘイト/脅威度 |
+| C | ProjectileData | SoA構造体 | ★★★★☆ | 投射物管理 |
+| D | AnimationState | SoA構造体 | ★★★☆☆ | アニメ状態キャッシュ |
+| E | KnockbackData | SoA構造体 | ★★★★☆ | 被弾リアクション |
+| F | InputState | SoA構造体 | ★★★★★ | 統一入力管理 |
+| G | WeaponState | SoA構造体 | ★★★★☆ | 武器/コンボ状態 |
+| H | ActionExecutionData | SoA構造体 | ★★★★☆ | アクション実行状態 |
+| I | SpawnPointContainer | ランタイム | ★★★☆☆ | スポーン管理 |
+| J | EventQueueContainer | ランタイム | ★★★★☆ | AIイベント通信 |
+| K | HitRecordContainer | ランタイム | ★★★☆☆ | ヒット記録 |
+| L | TweenHandleContainer | ランタイム | ★★☆☆☆ | UIアニメ管理 |
+| M | InventoryContainer | ゲームプレイ | ★★★★☆ | インベントリ |
+| N | QuestFlagContainer | ゲームプレイ | ★★★☆☆ | クエスト進行 |
+| O | DropTableContainer | ゲームプレイ | ★★★☆☆ | ドロップテーブル |
+| P | DialogueContainer | ゲームプレイ | ★★☆☆☆ | 会話バックログ |
+| Q | CheckpointContainer | ゲームプレイ | ★★☆☆☆ | チェックポイント |
+| R | ParticleEffectPool | エフェクト | ★★★☆☆ | エフェクト数制限 |
+| S | DamageNumberPool | UI | ★★★☆☆ | ダメージ表示制限 |
+| T | CameraShakeBuffer | 演出 | ★★☆☆☆ | カメラ揺れ合成 |

--- a/designs/ODCコンテナ検討.md
+++ b/designs/ODCコンテナ検討.md
@@ -412,3 +412,340 @@ public struct DropEntry
 | R | ParticleEffectPool | エフェクト | ★★★☆☆ | エフェクト数制限 |
 | S | DamageNumberPool | UI | ★★★☆☆ | ダメージ表示制限 |
 | T | CameraShakeBuffer | 演出 | ★★☆☆☆ | カメラ揺れ合成 |
+
+---
+
+## 3. ODCパッケージへの改修要望
+
+各コンテナの活用検討で判明した、パッケージ側に要望したい改修点。
+**方針**: パッケージの汎用性を損なう改変は要望しない（プロジェクト固有の処理はゲーム側で吸収する）。
+
+---
+
+### 3-1. SpatialHashContainer2D — XY平面モード対応【重要度: 高】
+
+**問題**:
+現行の `SpatialHashContainer2D` はXZ平面（3D想定）での座標操作ベースと見られる。
+本ゲームは2Dサイドスクロールで、座標はXY平面を使用する。
+このままでは近傍クエリの軸が噛み合わず、正しく機能しない恐れがある。
+
+**要望**:
+- コンストラクタ引数でXY/XZの平面モードを切り替えられるようにする
+- または `SpatialHashContainer2D` の2D版として純粋なXY平面専用クラスを提供する
+
+```csharp
+// 案1: 引数で軸指定
+new SpatialHashContainer2D<T>(cellSize, plane: Plane.XY);
+
+// 案2: 専用クラス（XY決め打ち）
+new SpatialHashContainerXY<T>(cellSize);
+```
+
+**汎用性評価**: 設定可能な構成であり、汎用性を損なわない ✓
+
+---
+
+### 3-2. TimedDataContainer — OnExpiredコールバックへのデータ受け渡し【重要度: 高】
+
+**問題**:
+`TimedDataContainer<T>` の期限切れコールバックに「何が期限切れになったか」のデータが渡らない場合、
+バフ解除時にUIへの通知や「消滅したデバフに応じたSE再生」ができない。
+
+**要望**:
+期限切れコールバックをデータ付きの `Action<T>` 形式で受け取れるようにする。
+既存の `Action`（引数なし）との両方をサポートするオーバーロードが望ましい。
+
+```csharp
+// 現状（想定）
+new TimedDataContainer<BuffData>(onExpired: () => { ... });
+
+// 要望
+new TimedDataContainer<BuffData>(onExpired: (data) => { ApplyBuffRemoval(data); });
+```
+
+**汎用性評価**: 汎用的な改善。期限切れデータの受け渡しは一般的なユースケース ✓
+
+---
+
+### 3-3. CooldownContainer — 進行率(Normalized)取得メソッド【重要度: 中】
+
+**問題**:
+スキルクールダウンUIの表示に「残り時間 / 最大時間」の正規化値(0.0〜1.0)が必要だが、
+現状は残り時間と初期値を別途管理して手動計算が必要。
+
+**要望**:
+`GetNormalized(key)` メソッドで正規化された進行率(完了に向かって0→1)を直接取得できるようにする。
+
+```csharp
+float fillAmount = cooldowns.GetNormalized("skill_fireball"); // 0.0=完了, 1.0=リセット直後
+```
+
+**汎用性評価**: UIとの連携に汎用的に使える便利メソッド ✓
+
+---
+
+### 3-4. RingBufferContainer — ReadOnlySpan一括取得【重要度: 中】
+
+**問題**:
+コマンド入力判定（例: ↓↓攻撃 = 特殊技）のために直近N件の入力履歴を一括で参照したい。
+個別インデックスアクセスを繰り返すよりも `ReadOnlySpan<T>` での一括取得が安全かつ高速。
+
+**要望**:
+バッファの現在の全内容を時系列順に `ReadOnlySpan<T>` で返すメソッドを追加。
+
+```csharp
+ReadOnlySpan<InputRecord> history = inputBuffer.AsSpan(); // 古い順に並んだスパン
+// → LINQ不要でコマンドパターンマッチング可能
+```
+
+**汎用性評価**: NativeCollections的な安全アクセスパターンで汎用的 ✓
+
+---
+
+### 3-5. StateMapContainer — OnEnter/OnExitコールバック【重要度: 中】
+
+**問題**:
+AIモード遷移時（Idle→Chase等）にアニメーション切り替え・SE再生・内部状態リセットなどの
+副作用処理が必要。現状は外部で `currentState` の変化を毎フレームポーリングするしかない。
+
+**要望**:
+状態ごとに `OnEnter` / `OnExit` コールバックを登録できるオプショナルなフック機構。
+
+```csharp
+stateMap.RegisterCallbacks(AiMode.Chase,
+    onEnter: () => animator.SetTrigger("StartChase"),
+    onExit:  () => animator.SetTrigger("StopChase")
+);
+```
+
+**汎用性評価**: FSMの標準的な機能。オプショナル登録であれば複雑さは増さない ✓
+ただし過度な機能追加になるようであれば、プロジェクト側でラッパーを作り吸収する。
+
+---
+
+### 3-6. GroupContainer — グループ移動コールバック【重要度: 低〜中】
+
+**問題**:
+混乱魔法・寝返りで `MoveToGroup()` を呼んだ後、AI状態のリセットやターゲット再選択などの
+後処理が必要。移動完了のコールバックがないと毎フレームのポーリングが必要になる。
+
+**要望**:
+`MoveToGroup()` 実行時に `OnGroupChanged` コールバックを発火するオプション。
+
+```csharp
+groupContainer.OnGroupChanged += (item, fromGroup, toGroup) => {
+    ResetAiState(item);
+};
+```
+
+**汎用性評価**: グループ移動の通知は汎用的なユースケース ✓
+
+---
+
+### 3-7. 見送り（汎用性を損なうため対象外）
+
+以下の改変はプロジェクト固有の要件であり、パッケージへの要望としない。
+ゲーム側でラッパークラス / 拡張メソッドを実装して吸収する。
+
+| 見送り要望 | 理由 |
+|-----------|------|
+| SoACharaDataDicとの直接統合 | プロジェクト固有すぎる |
+| Unity `Time.time` / `Physics2D` との直接結合 | 特定エンジン依存になる |
+| SourceGeneratorとのコード生成連携 | ODCパッケージの責務を超える |
+| キャラ特化のヘイト計算ロジック組み込み | ゲームルール依存 |
+
+---
+
+## 4. 機能提案（統合版）
+
+コンテナ活用・改修要望・プロジェクト全体の未着手課題を統合した実装優先度付き機能提案。
+
+---
+
+### フェーズ1: コアシステムへのコンテナ統合（最優先）
+
+#### 機能提案 F-01: クールダウン一元管理システム
+**使用コンテナ**: `CooldownContainer`
+**現状の問題**: CD管理が6箇所以上に分散（CoopCooldownTracker / ComboManager / JudgmentLoop / DamageReceiver等）
+**実装内容**:
+- `AbilityHolder` 内に `CooldownContainer` を1つ配置
+- 全アビリティCD・無敵時間・アーマー回復ディレイをここで一元管理
+- `GetNormalized()` でUI（スキルアイコン）の充填率を直接取得（改修要望 3-3 が実現すれば）
+
+**改変範囲**: `CoopCooldownTracker` 削除、`JudgmentLoop` のタイマー変数削除、`DamageReceiver._armorRecoveryTimer` 削除
+
+---
+
+#### 機能提案 F-02: AIモードFSM統合
+**使用コンテナ**: `StateMapContainer<AiMode>`
+**現状の問題**: `ModeController` が独自FSMを自前実装（_currentModeIndex, SetModes, SwitchMode）
+**実装内容**:
+- `ModeController` を `StateMapContainer<AiMode>` ベースに置き換え
+- OnEnter/OnExitで状態遷移副作用を記述（改修要望 3-5 が実現すれば）
+- 「Chaseモードに入って何秒経過」を `ElapsedTime` で直接取得 → 時間依存行動が簡潔に
+
+---
+
+#### 機能提案 F-03: 陣営管理システム刷新
+**使用コンテナ**: `GroupContainer<int>` (objectHash単位)
+**現状の問題**: `CharacterFlags.Belong` ビットフラグで陣営管理。全陣営スキャンがO(n)
+**実装内容**:
+- `GameManager` に `GroupContainer` を配置、Ally/Enemy/Neutral/Bossグループを管理
+- `TargetSelector` / `ConditionEvaluator` のBelongフィルタをGroupContainer経由に変更
+- 混乱魔法で `MoveToGroup()` を呼ぶだけで陣営変更が完結（O(1)）
+
+---
+
+#### 機能提案 F-04: バフ/デバフ管理リプレース
+**使用コンテナ**: `TimedDataContainer<BuffEntry>` または `NotifyTimedDataContainer<BuffEntry>`
+**現状の問題**: `StatusEffectManager` が手動タイマー管理 + swap-remove
+**実装内容**:
+- バフスロットを `TimedDataContainer` に移行
+- 期限切れ時コールバックでUI通知・SE再生（改修要望 3-2 が実現すれば）
+- `CharacterStatusEffects` 構造体のSoAデータと連携
+
+---
+
+#### 機能提案 F-05: 入力システムのSoA統合（AI/Player統一入力）
+**使用コンテナ**: SoA構造体 `InputState`（追加コンテナ F）
+**現状の問題**: AIとプレイヤー入力のパスが分離。BaseCharacterが入力ソースを意識
+**実装内容**:
+- `SoACharaDataDic` に `InputState` 構造体を追加
+- `InputHandler`（プレイヤー）と `AIBrain`（AI）がともに `InputState` に書き込む
+- `BaseCharacter` は `InputState` を読むだけ → 入力ソース非依存
+
+---
+
+### フェーズ2: パフォーマンス改善系
+
+#### 機能提案 F-06: AI近傍検索の空間ハッシュ化
+**使用コンテナ**: `SpatialHashContainer2D<int>` (objectHash格納)
+**前提条件**: 改修要望 3-1（XY平面対応）の実現、またはラッパーでXY対応を吸収
+**実装内容**:
+- `SensorSystem.UpdateDetection()` の線形スキャンを空間ハッシュクエリに置換
+- `TargetSelector.FilterCandidates()` の距離計算高速化
+- キャラ移動時に `Update()` で位置を更新 → 近傍クエリO(1)〜O(k)
+
+**注意**: XY平面への対応確認が必須。未対応の場合は独自ラッパーを実装して吸収する。
+
+---
+
+#### 機能提案 F-07: 投射物システム実装
+**使用コンテナ**: SoA構造体 `ProjectileData`（追加コンテナ C）+ `TimedDataContainer`
+**現状**: 設計書に記載があるが未実装
+**実装内容**:
+- `ProjectileData` をSoAに追加し投射物を一元管理
+- 寿命管理を `TimedDataContainer` で行い、期限切れで自動プール返却
+- ホーミング・貫通・AoE爆発を `moveType` / `pierceRemaining` / `aoeRadius` で制御
+
+---
+
+#### 機能提案 F-08: コマンド入力判定（格闘ゲーム風特殊技）
+**使用コンテナ**: `RingBufferContainer<InputRecord>`（追加コンテナ J相当）
+**実装内容**:
+- `InputBuffer` を `RingBufferContainer` に拡張し直近16〜32入力を記録
+- `AsSpan()` で履歴を一括取得してパターンマッチング（↓→攻撃 = 特殊技発動等）
+- AIの行動ログにも流用（デバッグ可視化）
+
+---
+
+#### 機能提案 F-09: 敵スポーン優先度管理
+**使用コンテナ**: `PriorityPoolContainer<EnemySpawnEntry>`
+**実装内容**:
+- `EnemySpawner` の最大同時数制限を `PriorityPoolContainer` に移行
+- 容量超過時に画面外・低脅威度の敵を自動despawn
+- ボスエリア接近時にボス関連スポーンを高優先度で保護
+
+---
+
+### フェーズ3: ゲームプレイ拡張系
+
+#### 機能提案 F-10: ヒット記録の統合管理
+**使用コンテナ**: `TimedDataContainer<HitRecord>`
+**実装内容**:
+- `HitBox` の二重ヒット防止記録を `TimedDataContainer` に移行
+- 攻撃モーション終了で自動クリア（タイムアウト）
+- 複数HitBoxが同一Attackerから管理されるよう統合
+
+---
+
+#### 機能提案 F-11: インベントリシステム
+**使用コンテナ**: SoA構造体 `InventorySlot`（追加コンテナ M）
+**現状**: GDD記載済み・未実装
+**実装内容**:
+- 固定スロット数の `InventorySlot[]` をSoAで管理
+- アイテム使用・装備変更・ドロップ取得のAPIを整備
+- UI（インベントリ画面）との連携
+
+---
+
+#### 機能提案 F-12: ドロップテーブル管理
+**使用コンテナ**: SoA構造体 `DropEntry`（追加コンテナ O）+ `PriorityPoolContainer`
+**実装内容**:
+- 敵定義に `DropEntry[]` を紐付け
+- `PriorityPoolContainer` で希少アイテムの優先度管理（ボーナス条件フラグ）
+- 乱数シード固定でデバッグ再現性を確保
+
+---
+
+#### 機能提案 F-13: UIアニメーションハンドル管理
+**使用コンテナ**: `TimedDataContainer<MotionHandle>`
+**実装内容**:
+- `HudController` のLitMotionハンドルを `TimedDataContainer` で一元管理
+- 前回ハンドルの自動キャンセル（連続呼び出し時のリーク防止）
+- HPバー・スタミナバー等のTweenを統一インターフェースで管理
+
+---
+
+### フェーズ4: 演出・デバッグ系
+
+#### 機能提案 F-14: カメラ揺れ合成システム
+**使用コンテナ**: `TimedDataContainer<ShakeData>`
+**実装内容**:
+- 複数ソース（爆発・被弾・着地）の揺れを合成して最終カメラオフセットを計算
+- 各揺れソースに減衰カーブと優先度を設定
+- 期限切れで自動消去、強い揺れが弱い揺れをマスク
+
+---
+
+#### 機能提案 F-15: ダメージポップアップ管理
+**使用コンテナ**: `PriorityPoolContainer<DamagePopupData>`
+**実装内容**:
+- 同時表示数を制限（画面が数字で埋まるのを防止）
+- 小ダメージを低優先度として大ダメージ発生時に自動排出
+- クリティカル/属性等によるフォントスタイル切り替え
+
+---
+
+### 全機能提案サマリー
+
+| # | 機能名 | フェーズ | 主コンテナ | 優先度 | 備考 |
+|---|--------|---------|-----------|--------|------|
+| F-01 | クールダウン一元管理 | 1 | CooldownContainer | ★★★★★ | 6箇所の分散CD解消 |
+| F-02 | AIモードFSM統合 | 1 | StateMapContainer | ★★★★★ | ModeController置き換え |
+| F-03 | 陣営管理刷新 | 1 | GroupContainer | ★★★★☆ | O(n)→O(1)スキャン |
+| F-04 | バフ/デバフ管理 | 1 | TimedDataContainer | ★★★★☆ | StatusEffectManager置き換え |
+| F-05 | 統一入力管理 | 1 | SoA:InputState | ★★★★★ | AI/Player入力統一 |
+| F-06 | AI近傍検索高速化 | 2 | SpatialHash2D | ★★★★☆ | XY平面対応要確認 |
+| F-07 | 投射物システム | 2 | SoA:ProjectileData | ★★★★☆ | 未実装システム |
+| F-08 | コマンド入力 | 2 | RingBufferContainer | ★★★☆☆ | 特殊技・Span取得要望 |
+| F-09 | 敵スポーン優先度 | 2 | PriorityPoolContainer | ★★★☆☆ | 自動despawn |
+| F-10 | ヒット記録統合 | 3 | TimedDataContainer | ★★★☆☆ | 二重ヒット防止 |
+| F-11 | インベントリ | 3 | SoA:InventorySlot | ★★★★☆ | GDD記載済み未実装 |
+| F-12 | ドロップテーブル | 3 | SoA:DropEntry | ★★★☆☆ | 敵撃破アイテム |
+| F-13 | UIアニメ管理 | 3 | TimedDataContainer | ★★☆☆☆ | ハンドルリーク防止 |
+| F-14 | カメラ揺れ合成 | 4 | TimedDataContainer | ★★☆☆☆ | 演出品質向上 |
+| F-15 | ダメージポップアップ | 4 | PriorityPoolContainer | ★★★☆☆ | 表示数制限 |
+
+---
+
+### ODC改修要望と機能提案の対応マップ
+
+| 改修要望 | 影響する機能提案 | 未実現時の代替 |
+|---------|----------------|--------------|
+| 3-1 XY平面対応 | F-06（AI近傍検索） | ゲーム側ラッパーでXY変換を吸収 |
+| 3-2 OnExpired引数付き | F-04（バフ管理）, F-10（ヒット記録） | ゲーム側でIDを別管理してコールバックで引く |
+| 3-3 Normalizedメソッド | F-01（CD管理） | `(remaining / total)` をゲーム側で計算 |
+| 3-4 RingBuffer Span取得 | F-08（コマンド入力） | ゲーム側で配列コピーして走査 |
+| 3-5 OnEnter/OnExit | F-02（AI FSM） | ゲーム側でStateMapをラップしてポーリング |
+| 3-6 グループ移動CB | F-03（陣営管理） | MoveToGroup後に明示的なリセット関数を呼ぶ |


### PR DESCRIPTION
## Summary

- ODC新バージョンの導入検討と既存コンテナの活用方針を整理（`ODCコンテナ検討.md`）
- 当初プロジェクト固有（P1〜P5）として設計していたカスタムコンテナを、ODCパッケージ汎用候補（G1〜G5）として全面再設計（`ODCカスタムコンテナ提案.md`）

### 追加・更新コンテナ（G1〜G5）

| # | コンテナ | 汎用パターン |
|---|---------|------------|
| G1 | `HitDeduplicationContainer` | イベント×ターゲットのGCフリー処理済み追跡 |
| G2 | `FlagComboLookupContainer<T>` | フラグ組み合わせ→エフェクトO(1)引き当てテーブル |
| G3 | `ScoredCandidateBuffer<T>` | 評価→スコアリング→最適選択フレームバッファ |
| G4 | `MultiPartySequenceContainer<T>` | 複数参加者×ステップ×タイムウィンドウのシーケンス管理 |
| G5 | `StackableEffectContainer<T>` | スタック可能・時限・Tick付きエフェクトスロット（バフ/デバフ汎用） |

各コンテナに「SisterGameでの動機」と「他プロジェクトでの適用例」を明記し、ODCの設計思想（unmanaged制約・GCフリー・ハッシュベースO(1)アクセス）に準拠した設計にしています。

## Test plan

- [ ] 設計書の内容レビュー（API設計・命名・ODC設計思想との整合性）
- [ ] G1〜G5の「汎用性を損なわないか」確認（プロジェクト固有の型が混入していないか）
- [ ] C1〜C6との役割重複がないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)