### PR TITLE
fix(combat,input,ai): エディタ実行テストで発見した複数バグを修正

### DIFF
--- a/Assets/MyAsset/Core/AI/Core/AIInfoConverter.cs
+++ b/Assets/MyAsset/Core/AI/Core/AIInfoConverter.cs
@@ -69,6 +69,7 @@ namespace Game.Core
                     ModeTransitionRule rule = new ModeTransitionRule
                     {
                         targetModeIndex = targetIdx,
+                        sourceModeIndex = i,
                         conditions = new AICondition[] { ConvertTriggerToCondition(tc) },
                     };
                     rules.Add(rule);
@@ -121,14 +122,15 @@ namespace Game.Core
 
             if (modeData.detectionRange > 0f || modeData.combatRange > 0f)
             {
-                // Primary target select: nearest enemy in detection range
+                // Primary target select: nearest hostile in detection range
+                // 敵AIから見た攻撃対象はAlly陣営（プレイヤー・仲間）
                 AITargetSelect nearestEnemy = new AITargetSelect
                 {
                     sortKey = TargetSortKey.Distance,
                     isDescending = false,
                     filter = new TargetFilter
                     {
-                        belong = CharacterBelong.Enemy,
+                        belong = CharacterBelong.Ally,
                         distanceRange = new Vector2(0f, modeData.detectionRange > 0f ? modeData.detectionRange : modeData.combatRange),
                         includeSelf = false,
                     },
@@ -161,11 +163,22 @@ namespace Game.Core
 
         private static ActionSlot ConvertActToSlot(ActData act)
         {
+            ActionExecType execType = MapActType(act.actType);
+
+            // Sustainedアクション（Wait/Guard/Move等）は適切な持続時間を設定する。
+            // coolTime > 0 ならその値を使用、なければデフォルト1秒。
+            // paramValue=0 は無限持続となり、AIの再評価でキャンセルされるまで終わらない。
+            float paramValue = 0f;
+            if (execType == ActionExecType.Sustained)
+            {
+                paramValue = act.coolTime > 0f ? act.coolTime : 1f;
+            }
+
             return new ActionSlot
             {
-                execType = MapActType(act.actType),
+                execType = execType,
                 paramId = act.attackInfoIndex,
-                paramValue = 0f,
+                paramValue = paramValue,
                 displayName = act.actName,
             };
         }

--- a/Assets/MyAsset/Core/AI/Core/JudgmentLoop.cs
+++ b/Assets/MyAsset/Core/AI/Core/JudgmentLoop.cs
@@ -32,12 +32,16 @@ namespace Game.Core
 
         /// <summary>
         /// Sets the active AI mode and resets judgment timers.
+        /// 現在実行中のアクションをキャンセルして即座に新モードの評価を可能にする。
         /// </summary>
         public void SetMode(AIMode mode)
         {
             _currentMode = mode;
             _targetJudgeTimer = mode.judgeInterval.x;
-            _actionJudgeTimer = mode.judgeInterval.y;
+            // アクション評価を即座に実行するためタイマーを0にする
+            _actionJudgeTimer = 0f;
+            // 旧モードのアクションをキャンセル（Waitが残り続ける問題を防止）
+            _executor.CancelCurrent();
         }
 
         /// <summary>

--- a/Assets/MyAsset/Core/AI/Core/ModeController.cs
+++ b/Assets/MyAsset/Core/AI/Core/ModeController.cs
@@ -4,12 +4,18 @@ namespace Game.Core
 {
     /// <summary>
     /// Rule for transitioning between AI modes based on conditions.
+    /// sourceModeIndex が -1 の場合は全モードから評価される（後方互換）。
     /// </summary>
     [Serializable]
     public struct ModeTransitionRule
     {
         public AICondition[] conditions;
         public int targetModeIndex;
+        /// <summary>
+        /// この遷移ルールが有効なソースモードのインデックス。
+        /// -1 の場合はどのモードからでも評価される。
+        /// </summary>
+        public int sourceModeIndex;
     }
 
     /// <summary>
@@ -61,6 +67,13 @@ namespace Game.Core
             for (int i = 0; i < _transitionRules.Length; i++)
             {
                 ModeTransitionRule rule = _transitionRules[i];
+
+                // sourceModeIndex が設定されている場合、現在のモードと一致しなければスキップ
+                if (rule.sourceModeIndex >= 0 && rule.sourceModeIndex != _currentModeIndex)
+                {
+                    continue;
+                }
+
                 if (ConditionEvaluator.EvaluateAll(rule.conditions, ownerHash, targetHash, data, currentTime))
                 {
                     if (rule.targetModeIndex != _currentModeIndex)

--- a/Assets/MyAsset/Core/Common/CombatDataHelper.cs.meta
+++ b/Assets/MyAsset/Core/Common/CombatDataHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 189c8e5ae1a09574cb52ce5f53ed057a

--- a/Assets/MyAsset/Core/Common/Enums.cs
+++ b/Assets/MyAsset/Core/Common/Enums.cs
@@ -58,6 +58,18 @@ namespace Game.Core
         GlideFloat = 1 << 5,
     }
 
+    // ===== 攻撃ボタン識別 =====
+
+    /// <summary>
+    /// 物理ボタンの識別子。PlayerInputHandler内部で使用。
+    /// </summary>
+    public enum AttackButtonId : byte
+    {
+        Light = 0,
+        Heavy = 1,
+        Skill = 2,
+    }
+
     // ===== 攻撃 =====
 
     public enum AttackInputType : byte

--- a/Assets/MyAsset/Core/Common/GameConstants.cs
+++ b/Assets/MyAsset/Core/Common/GameConstants.cs
@@ -17,6 +17,12 @@ namespace Game.Core
         /// <summary>クリティカル倍率の初期値。</summary>
         public const float k_DefaultCriticalMultiplier = 1.5f;
 
+        /// <summary>AI追尾時のデフォルト攻撃範囲（この距離以内で停止）。</summary>
+        public const float k_DefaultAttackRange = 1.5f;
+
+        /// <summary>AI移動時のフォールバック速度。</summary>
+        public const float k_FallbackMoveSpeed = 3f;
+
         // --- 物理レイヤー（Architect/08_物理レイヤー定義.md 参照） ---
 
         /// <summary>キャラクター通常状態（すり抜け）。</summary>

--- a/Assets/MyAsset/Core/Common/GameConstants.cs.meta
+++ b/Assets/MyAsset/Core/Common/GameConstants.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 442a03ab753766b49a6ff3d1559073dd

--- a/Assets/MyAsset/Core/Common/Structs.cs
+++ b/Assets/MyAsset/Core/Common/Structs.cs
@@ -134,7 +134,8 @@ namespace Game.Core
         public Vector2 moveDirection;
         public bool jumpPressed;
         public bool jumpHeld;
-        public bool dashPressed;
+        public bool dodgePressed;   // 単押し回避
+        public bool sprintHeld;     // 長押しスプリント
         public AttackInputType? attackInput;
         public bool guardHeld;
         public bool interactPressed;

--- a/Assets/MyAsset/Core/DataContainer/SoAStructs.cs
+++ b/Assets/MyAsset/Core/DataContainer/SoAStructs.cs
@@ -129,6 +129,9 @@ namespace Game.Core
         public float dashDuration;
         public float gravityScale;
         public float weightRatio;
+        public float jumpStaminaCost;
+        public float dodgeStaminaCost;
+        public float sprintStaminaPerSecond;
     }
 
     /// <summary>

--- a/Assets/MyAsset/Core/Input/InputConverter.cs
+++ b/Assets/MyAsset/Core/Input/InputConverter.cs
@@ -33,24 +33,23 @@ namespace Game.Core
         }
 
         /// <summary>
-        /// ボタンIDからAttackInputTypeに変換する。
+        /// AttackButtonIdからAttackInputTypeに変換する。
         /// 空中かどうかでAerial系に、チャージ中かどうかでCharge系に変換する。
-        /// buttonId: 0=Light, 1=Heavy, 2=Skill
         /// </summary>
-        public static AttackInputType? ConvertAttackInput(int buttonId, bool isAirborne, bool isCharging)
+        public static AttackInputType? ConvertAttackInput(AttackButtonId buttonId, bool isAirborne, bool isCharging)
         {
-            if (buttonId == 2)
+            if (buttonId == AttackButtonId.Skill)
             {
                 return AttackInputType.Skill;
             }
 
             if (isAirborne)
             {
-                if (buttonId == 0)
+                if (buttonId == AttackButtonId.Light)
                 {
                     return AttackInputType.AerialLight;
                 }
-                if (buttonId == 1)
+                if (buttonId == AttackButtonId.Heavy)
                 {
                     return AttackInputType.AerialHeavy;
                 }
@@ -58,22 +57,22 @@ namespace Game.Core
 
             if (isCharging)
             {
-                if (buttonId == 0)
+                if (buttonId == AttackButtonId.Light)
                 {
                     return AttackInputType.ChargeLight;
                 }
-                if (buttonId == 1)
+                if (buttonId == AttackButtonId.Heavy)
                 {
                     return AttackInputType.ChargeHeavy;
                 }
             }
 
-            if (buttonId == 0)
+            if (buttonId == AttackButtonId.Light)
             {
                 return AttackInputType.LightAttack;
             }
 
-            if (buttonId == 1)
+            if (buttonId == AttackButtonId.Heavy)
             {
                 return AttackInputType.HeavyAttack;
             }

--- a/Assets/MyAsset/Core/Movement/GroundMovementLogic.cs
+++ b/Assets/MyAsset/Core/Movement/GroundMovementLogic.cs
@@ -5,53 +5,74 @@ namespace Game.Core
     /// <summary>
     /// 地上移動のピュアロジック。MonoBehaviour非依存。
     /// MoveParamsとMovementInfoから移動結果を計算する。
+    /// スタミナコストはMoveParams（CharacterInfo由来）から取得する。
     /// </summary>
     public class GroundMovementLogic
     {
         public const float k_MinJumpHoldTime = 0.05f;
         public const float k_MaxJumpHoldTime = 0.3f;
-        public const float k_DashStaminaCost = 15f;
+        public const float k_DodgeDuration = 0.25f;
+        public const float k_DodgeSpeedMultiplier = 2.5f;
+        public const float k_SprintSpeedMultiplier = 1.6f;
+
+        // テスト互換用デフォルト値
+        public const float k_DodgeStaminaCost = 15f;
 
         private bool _isJumping;
         private float _jumpHoldTimer;
-        private bool _isDashing;
-        private float _dashTimer;
+        private bool _isDodging;
+        private float _dodgeTimer;
+        private bool _isSprinting;
 
         public bool IsJumping => _isJumping;
-        public bool IsDashing => _isDashing;
+        public bool IsDodging => _isDodging;
+        public bool IsSprinting => _isSprinting;
+        public bool IsDashing => _isDodging || _isSprinting;
 
-        /// <summary>
-        /// 水平移動速度を計算する。
-        /// moveDirection.x * moveSpeed。ダッシュ中はdashSpeedを使用。
-        /// </summary>
-        public float CalculateHorizontalSpeed(float inputX, MoveParams moveParams)
+        /// <summary>水平移動速度を計算する。facingDir は回避時の方向（1=右, -1=左）。</summary>
+        public float CalculateHorizontalSpeed(float inputX, MoveParams moveParams, float facingDir = 1f)
         {
-            float speed = _isDashing ? moveParams.dashSpeed : moveParams.moveSpeed;
+            if (_isDodging)
+            {
+                // 入力方向が無い場合は向いている方向に回避
+                float dodgeDir = Mathf.Abs(inputX) > 0.1f ? Mathf.Sign(inputX) : facingDir;
+                return dodgeDir * moveParams.dashSpeed;
+            }
+
+            float speed = _isSprinting
+                ? moveParams.moveSpeed * k_SprintSpeedMultiplier
+                : moveParams.moveSpeed;
             return inputX * speed;
         }
 
-        /// <summary>
-        /// ジャンプ開始判定。接地中にjumpPressedならジャンプ開始。
-        /// 戻り値: ジャンプ初速（jumpForce）。ジャンプしない場合は0。
-        /// </summary>
-        public float TryStartJump(bool jumpPressed, bool isGrounded, MoveParams moveParams)
+        /// <summary>ジャンプ開始判定。スタミナ消費あり。</summary>
+        public float TryStartJump(bool jumpPressed, bool isGrounded, MoveParams moveParams,
+            ref float currentStamina)
         {
             if (!jumpPressed || !isGrounded)
             {
                 return 0f;
             }
 
+            if (moveParams.jumpStaminaCost > 0f && currentStamina < moveParams.jumpStaminaCost)
+            {
+                return 0f;
+            }
+
+            currentStamina -= moveParams.jumpStaminaCost;
             _isJumping = true;
             _jumpHoldTimer = 0f;
             return moveParams.jumpForce;
         }
 
-        /// <summary>
-        /// 可変高度ジャンプの更新。jumpHeld中はジャンプ力を維持。
-        /// 離すか最大時間に達すると減衰開始。
-        /// 戻り値: 現フレームのジャンプ速度係数（0.0~1.0）。
-        /// 1.0 = フルジャンプ維持中、0.0 = ジャンプ終了。
-        /// </summary>
+        /// <summary>旧API互換（スタミナ消費なし版）。テスト用。</summary>
+        public float TryStartJump(bool jumpPressed, bool isGrounded, MoveParams moveParams)
+        {
+            float dummy = float.MaxValue;
+            return TryStartJump(jumpPressed, isGrounded, moveParams, ref dummy);
+        }
+
+        /// <summary>可変高度ジャンプの更新。</summary>
         public float UpdateJumpHold(bool jumpHeld, float deltaTime)
         {
             if (!_isJumping)
@@ -61,14 +82,12 @@ namespace Game.Core
 
             _jumpHoldTimer += deltaTime;
 
-            // 最大ホールド時間超過 → ジャンプ終了
             if (_jumpHoldTimer >= k_MaxJumpHoldTime)
             {
                 _isJumping = false;
                 return 0f;
             }
 
-            // ボタン離した & 最小ホールド時間経過 → ジャンプ終了
             if (!jumpHeld && _jumpHoldTimer >= k_MinJumpHoldTime)
             {
                 _isJumping = false;
@@ -78,49 +97,90 @@ namespace Game.Core
             return 1f;
         }
 
-        /// <summary>
-        /// ダッシュ開始判定。dashPressed かつ スタミナ十分 かつ ダッシュ中でない。
-        /// 戻り値: ダッシュ開始したか。
-        /// </summary>
+        /// <summary>回避開始（単押し）。スタミナコストはMoveParamsから取得。</summary>
+        public bool TryStartDodge(bool dodgePressed, ref float currentStamina, MoveParams moveParams)
+        {
+            float cost = moveParams.dodgeStaminaCost > 0f
+                ? moveParams.dodgeStaminaCost
+                : k_DodgeStaminaCost;
+
+            if (!dodgePressed || _isDodging || currentStamina < cost)
+            {
+                return false;
+            }
+
+            currentStamina -= cost;
+            _isDodging = true;
+            _dodgeTimer = 0f;
+            return true;
+        }
+
+        /// <summary>回避の時間経過処理。</summary>
+        public bool UpdateDodge(float deltaTime, MoveParams moveParams)
+        {
+            if (!_isDodging)
+            {
+                return false;
+            }
+
+            _dodgeTimer += deltaTime;
+
+            if (_dodgeTimer >= k_DodgeDuration)
+            {
+                _isDodging = false;
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>スプリント更新（長押し）。スタミナコストはMoveParamsから取得。</summary>
+        public void UpdateSprint(bool sprintHeld, ref float currentStamina,
+            float deltaTime, MoveParams moveParams)
+        {
+            if (_isDodging)
+            {
+                _isSprinting = false;
+                return;
+            }
+
+            if (!sprintHeld || currentStamina <= 0f)
+            {
+                _isSprinting = false;
+                return;
+            }
+
+            float costPerSecond = moveParams.sprintStaminaPerSecond > 0f
+                ? moveParams.sprintStaminaPerSecond
+                : 10f;
+
+            _isSprinting = true;
+            currentStamina -= costPerSecond * deltaTime;
+            if (currentStamina < 0f)
+            {
+                currentStamina = 0f;
+                _isSprinting = false;
+            }
+        }
+
+        /// <summary>旧API互換。</summary>
+        public void UpdateSprint(bool sprintHeld, ref float currentStamina, float deltaTime)
+        {
+            MoveParams defaultParams = default;
+            UpdateSprint(sprintHeld, ref currentStamina, deltaTime, defaultParams);
+        }
+
+        // --- 旧API互換 ---
         public bool TryStartDash(bool dashPressed, ref float currentStamina, MoveParams moveParams)
         {
-            if (!dashPressed || _isDashing || currentStamina < k_DashStaminaCost)
-            {
-                return false;
-            }
-
-            currentStamina -= k_DashStaminaCost;
-            _isDashing = true;
-            _dashTimer = 0f;
-            return true;
+            return TryStartDodge(dashPressed, ref currentStamina, moveParams);
         }
 
-        /// <summary>
-        /// ダッシュの時間経過処理。
-        /// 戻り値: ダッシュ中か。
-        /// </summary>
         public bool UpdateDash(float deltaTime, MoveParams moveParams)
         {
-            if (!_isDashing)
-            {
-                return false;
-            }
-
-            _dashTimer += deltaTime;
-
-            if (_dashTimer >= moveParams.dashDuration)
-            {
-                _isDashing = false;
-                return false;
-            }
-
-            return true;
+            return UpdateDodge(deltaTime, moveParams);
         }
 
-        /// <summary>
-        /// 簡易接地判定ロジック。位置ベース（Y座標がgroundLevel以下かどうか）。
-        /// 実際のRaycast接地判定はMonoBehaviour側で行い、ここは判定ロジックのテスト用。
-        /// </summary>
         public static bool CheckGrounded(float positionY, float groundLevel, float threshold)
         {
             return positionY <= groundLevel + threshold;

--- a/Assets/MyAsset/Core/ScriptableObjects/AttackInfo.cs
+++ b/Assets/MyAsset/Core/ScriptableObjects/AttackInfo.cs
@@ -67,6 +67,40 @@ namespace Game.Core
         [TitleGroup("攻撃移動")]
         public AttackContactType contactType;
 
+        [TitleGroup("攻撃移動")]
+        [Tooltip("空中攻撃時の移動方向（正規化済み）。yを正にすると上昇")]
+        public Vector2 aerialMoveDirection;
+
+        [TitleGroup("空中攻撃")]
+        [Tooltip("空中攻撃中の浮遊時間（秒）")]
+        [MinValue(0)]
+        public float airHangDuration = 0.3f;
+
+        [TitleGroup("空中攻撃")]
+        [Tooltip("空中攻撃中の重力スケール（通常に対する倍率）")]
+        [MinValue(0)]
+        public float airHangGravityScale = 0.1f;
+
+        [TitleGroup("空中攻撃")]
+        [Tooltip("空中移動速度のデフォルト値（attackMoveDistance未設定時）")]
+        [MinValue(0)]
+        public float aerialMoveSpeedDefault = 3f;
+
+        [TitleGroup("落下攻撃")]
+        [Tooltip("落下攻撃として使用する場合の重力倍率")]
+        [MinValue(1)]
+        public float divingGravityMultiplier = 3f;
+
+        [TitleGroup("落下攻撃")]
+        [Tooltip("落下攻撃中の前方移動速度")]
+        [MinValue(0)]
+        public float divingForwardSpeed = 1f;
+
+        [TitleGroup("落下攻撃")]
+        [Tooltip("落下攻撃の着地後リカバリー時間（秒）。0なら即完了")]
+        [MinValue(0)]
+        public float divingLandingRecoveryDuration = 0.3f;
+
         [TitleGroup("パリィ・ガード")]
         public bool isParriable;
 
@@ -148,6 +182,9 @@ namespace Game.Core
         public AudioClip chargeSound;
         [FoldoutGroup("サウンド")]
         public AudioClip chargeCompleteSound;
+        [FoldoutGroup("サウンド")]
+        [Tooltip("落下攻撃着地時のSE")]
+        public AudioClip landingSound;
     }
 
     [Serializable]

--- a/Assets/MyAsset/Core/ScriptableObjects/CharacterInfo.cs
+++ b/Assets/MyAsset/Core/ScriptableObjects/CharacterInfo.cs
@@ -98,6 +98,24 @@ namespace Game.Core
         public float jumpHeight;
 
         // ─────────────────────────────────────────────
+        //  行動スタミナコスト
+        // ─────────────────────────────────────────────
+        [TitleGroup("行動スタミナコスト")]
+        [Tooltip("ジャンプ時のスタミナ消費")]
+        [MinValue(0)]
+        public float jumpStaminaCost;
+
+        [TitleGroup("行動スタミナコスト")]
+        [Tooltip("回避（単押し）時のスタミナ消費")]
+        [MinValue(0)]
+        public float dodgeStaminaCost = 15f;
+
+        [TitleGroup("行動スタミナコスト")]
+        [Tooltip("スプリント時のスタミナ消費（/秒）")]
+        [MinValue(0)]
+        public float sprintStaminaPerSecond = 10f;
+
+        // ─────────────────────────────────────────────
         //  アーマー
         // ─────────────────────────────────────────────
         [TitleGroup("アーマー")]
@@ -125,6 +143,55 @@ namespace Game.Core
 
         [TitleGroup("耐性")]
         public PhysicalResistance physicalResistance;
+
+        // ─────────────────────────────────────────────
+        //  スタミナ詳細
+        // ─────────────────────────────────────────────
+        [TitleGroup("スタミナ詳細")]
+        [Tooltip("スタミナ0時の追加回復遅延（秒）")]
+        [MinValue(0)]
+        public float staminaExhaustionPenalty = 2f;
+
+        [TitleGroup("スタミナ詳細")]
+        [Tooltip("スタミナ枯渇解除閾値（最大スタミナに対する割合 0-1）")]
+        [Range(0f, 1f)]
+        public float staminaExhaustionRecoveryRatio = 0.3f;
+
+        // ─────────────────────────────────────────────
+        //  ジャンプ詳細
+        // ─────────────────────────────────────────────
+        [TitleGroup("ジャンプ詳細")]
+        [Tooltip("ジャンプ入力バッファ時間（秒）")]
+        [MinValue(0)]
+        public float jumpBufferTime = 0.1f;
+
+        [TitleGroup("ジャンプ詳細")]
+        [Tooltip("ジャンプ早期リリース時のY速度減衰率（0-1）")]
+        [Range(0f, 1f)]
+        public float jumpReleaseVelocityDamping = 0.5f;
+
+        // ─────────────────────────────────────────────
+        //  入力設定
+        // ─────────────────────────────────────────────
+        [TitleGroup("入力設定")]
+        [Tooltip("移動入力デッドゾーン")]
+        [Range(0f, 0.5f)]
+        public float moveInputDeadzone = 0.1f;
+
+        [TitleGroup("入力設定")]
+        [Tooltip("入力バッファ持続時間（秒）")]
+        [MinValue(0)]
+        public float inputBufferDuration = 0.15f;
+
+        [TitleGroup("入力設定")]
+        [Tooltip("ため攻撃判定のホールド閾値（秒）")]
+        [MinValue(0)]
+        public float chargeThreshold = 0.3f;
+
+        [TitleGroup("入力設定")]
+        [Tooltip("スプリント/回避を分離するホールド閾値（秒）")]
+        [MinValue(0)]
+        public float sprintHoldThreshold = 0.25f;
 
         // ─────────────────────────────────────────────
         //  初期状態

--- a/Assets/MyAsset/Data/PLACEHOLDER_BasicEnemyAI.asset
+++ b/Assets/MyAsset/Data/PLACEHOLDER_BasicEnemyAI.asset
@@ -1,0 +1,106 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f732d17df7bb7354880a10fae6d9de9f, type: 3}
+  m_Name: PLACEHOLDER_BasicEnemyAI
+  m_EditorClassIdentifier: Game.Core::Game.Core.AIInfo
+  modes:
+  - mode: 0
+    detectionRange: 15
+    combatRange: 2
+    retreatHpThreshold: 0
+    availableActIndices: 01000000
+    transitions:
+    - targetMode: 3
+      trigger: 0
+      threshold: 12
+  - mode: 3
+    detectionRange: 15
+    combatRange: 2
+    retreatHpThreshold: 0
+    availableActIndices: 0000000001000000
+    transitions:
+    - targetMode: 0
+      trigger: 1
+      threshold: 18
+  actDataList:
+  - actName: BasicAttack
+    actType: 0
+    attackInfoIndex: 0
+    weight: 80
+    coolTime: 2
+    maxUseCount: 0
+    triggerJudge:
+      condition: 1
+      value: 2
+      comparison: 1
+    targetJudge:
+      selectionType: 0
+      maxRange: 0
+      minRange: 0
+      targetBelong: 0
+      targetFilter:
+        filterFlags: 0
+        belong: 0
+        feature: 0
+        weakPoint: 0
+        distanceRange: {x: 0, y: 0}
+        includeSelf: 0
+    actJudge:
+      requiredMp: 0
+      requiredStamina: 0
+      minHpRatio: 0
+      maxHpRatio: 0
+      requireLineOfSight: 0
+      requireGrounded: 0
+  - actName: Wait
+    actType: 6
+    attackInfoIndex: 0
+    weight: 10
+    coolTime: 0
+    maxUseCount: 0
+    triggerJudge:
+      condition: 0
+      value: 0
+      comparison: 0
+    targetJudge:
+      selectionType: 0
+      maxRange: 0
+      minRange: 0
+      targetBelong: 0
+      targetFilter:
+        filterFlags: 0
+        belong: 0
+        feature: 0
+        weakPoint: 0
+        distanceRange: {x: 0, y: 0}
+        includeSelf: 0
+    actJudge:
+      requiredMp: 0
+      requiredStamina: 0
+      minHpRatio: 0
+      maxHpRatio: 0
+      requireLineOfSight: 0
+      requireGrounded: 0
+  coolTimeData:
+    globalCoolTime: 0.5
+    attackCoolTime: 2
+    skillCoolTime: 0
+    guardCoolTime: 0
+    dodgeCoolTime: 0
+    healCoolTime: 0
+  companionSetting:
+    followDistance: 0
+    maxLeashDistance: 0
+    supportHpThreshold: 0
+    autoHeal: 0
+    prioritizePlayerTarget: 0
+    defaultStance: 0

--- a/Assets/MyAsset/Data/PLACEHOLDER_BasicEnemyAI.asset.meta
+++ b/Assets/MyAsset/Data/PLACEHOLDER_BasicEnemyAI.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2dbdfd87139aecc449fa951b8ac6d808
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Data/PLACEHOLDER_BossAI.asset
+++ b/Assets/MyAsset/Data/PLACEHOLDER_BossAI.asset
@@ -1,0 +1,94 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f732d17df7bb7354880a10fae6d9de9f, type: 3}
+  m_Name: PLACEHOLDER_BossAI
+  m_EditorClassIdentifier: Game.Core::Game.Core.AIInfo
+  modes:
+  - mode: 3
+    detectionRange: 20
+    combatRange: 2.5
+    retreatHpThreshold: 0
+    availableActIndices: 0000000001000000
+    transitions: []
+  actDataList:
+  - actName: BossSlam
+    actType: 0
+    attackInfoIndex: 0
+    weight: 90
+    coolTime: 1.5
+    maxUseCount: 0
+    triggerJudge:
+      condition: 1
+      value: 2
+      comparison: 1
+    targetJudge:
+      selectionType: 0
+      maxRange: 0
+      minRange: 0
+      targetBelong: 0
+      targetFilter:
+        filterFlags: 0
+        belong: 0
+        feature: 0
+        weakPoint: 0
+        distanceRange: {x: 0, y: 0}
+        includeSelf: 0
+    actJudge:
+      requiredMp: 0
+      requiredStamina: 0
+      minHpRatio: 0
+      maxHpRatio: 0
+      requireLineOfSight: 0
+      requireGrounded: 0
+  - actName: Wait
+    actType: 6
+    attackInfoIndex: 0
+    weight: 10
+    coolTime: 0
+    maxUseCount: 0
+    triggerJudge:
+      condition: 0
+      value: 0
+      comparison: 0
+    targetJudge:
+      selectionType: 0
+      maxRange: 0
+      minRange: 0
+      targetBelong: 0
+      targetFilter:
+        filterFlags: 0
+        belong: 0
+        feature: 0
+        weakPoint: 0
+        distanceRange: {x: 0, y: 0}
+        includeSelf: 0
+    actJudge:
+      requiredMp: 0
+      requiredStamina: 0
+      minHpRatio: 0
+      maxHpRatio: 0
+      requireLineOfSight: 0
+      requireGrounded: 0
+  coolTimeData:
+    globalCoolTime: 0.3
+    attackCoolTime: 1.5
+    skillCoolTime: 0
+    guardCoolTime: 0
+    dodgeCoolTime: 0
+    healCoolTime: 0
+  companionSetting:
+    followDistance: 0
+    maxLeashDistance: 0
+    supportHpThreshold: 0
+    autoHeal: 0
+    prioritizePlayerTarget: 0
+    defaultStance: 0

--- a/Assets/MyAsset/Data/PLACEHOLDER_BossAI.asset.meta
+++ b/Assets/MyAsset/Data/PLACEHOLDER_BossAI.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5736316596303794db12e59ad93a4c8e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Data/PLACEHOLDER_BossSlam.asset
+++ b/Assets/MyAsset/Data/PLACEHOLDER_BossSlam.asset
@@ -1,0 +1,102 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55a1ec93ce0944c47887ddab2ae86a7a, type: 3}
+  m_Name: PLACEHOLDER_BossSlam
+  m_EditorClassIdentifier: Game.Core::Game.Core.AttackInfo
+  attackName: PLACEHOLDER_BossSlam
+  category: 0
+  motionInfo:
+    preMotionDuration: 0.4
+    activeMotionDuration: 0.3
+    recoveryDuration: 0.5
+    chargeTimeMin: 0
+    chargeTimeMax: 0
+    chargeDamageMultiplier: 0
+    preMotionClip: {fileID: 0}
+    activeClip: {fileID: 0}
+    chargeLoopClip: {fileID: 0}
+    recoveryClip: {fileID: 0}
+    actionEffects: []
+  baseDamage:
+    slash: 0
+    strike: 15
+    pierce: 0
+    fire: 0
+    thunder: 0
+    light: 0
+    dark: 0
+  damageMultiplier: 2
+  effectSoundInfo:
+    hitEffect: {fileID: 0}
+    castEffect: {fileID: 0}
+    chargeEffect: {fileID: 0}
+    trailEffect: {fileID: 0}
+    attackSound: {fileID: 0}
+    hitSound: {fileID: 0}
+    chargeSound: {fileID: 0}
+    chargeCompleteSound: {fileID: 0}
+    landingSound: {fileID: 0}
+  projectileInfo:
+    hasProjectile: 0
+    projectilePrefab: {fileID: 0}
+    trajectory: 0
+    speed: 0
+    lifetime: 0
+    homingStrength: 0
+    pierceCount: 0
+    aoeRadius: 0
+    projectileCount: 0
+    spreadAngle: 0
+  knockbackInfo:
+    hasKnockback: 1
+    force: {x: 5, y: 2}
+    stunDuration: 0.5
+    groundBounce: 0
+    wallBounce: 0
+    gravityScale: 0
+  statusEffectInfo:
+    effect: 0
+    accumulateValue: 0
+    duration: 0
+    tickDamage: 0
+    tickInterval: 0
+    modifier: 0
+    maxStack: 0
+  mpCost: 0
+  staminaCost: 0
+  aiEvaluation:
+    effectiveRangeMin: 0
+    effectiveRangeMax: 0
+    threatLevel: 0
+    isBlockable: 0
+    isParriable: 0
+    totalWindupTime: 0
+    preferredUseHpThreshold: 0
+    priority: 0
+  attackMoveDistance: 0
+  attackMoveDuration: 0
+  contactType: 0
+  aerialMoveDirection: {x: 0, y: 0}
+  airHangDuration: 0.3
+  airHangGravityScale: 0.1
+  aerialMoveSpeedDefault: 3
+  divingGravityMultiplier: 3
+  divingForwardSpeed: 1
+  divingLandingRecoveryDuration: 0.3
+  isParriable: 0
+  armorBreakValue: 30
+  feature: 0
+  attackElement: 2
+  isAutoChain: 0
+  isChainEndPoint: 0
+  inputWindow: 0
+  justGuardResistance: 0

--- a/Assets/MyAsset/Data/PLACEHOLDER_BossSlam.asset.meta
+++ b/Assets/MyAsset/Data/PLACEHOLDER_BossSlam.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b2fbfb737dfe37246b7a19cc89dae813
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Data/PLACEHOLDER_CharacterAnimator.controller
+++ b/Assets/MyAsset/Data/PLACEHOLDER_CharacterAnimator.controller
@@ -1,0 +1,43 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1107 &-6630001523993625250
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates: []
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 0}
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PLACEHOLDER_CharacterAnimator
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -6630001523993625250}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}

--- a/Assets/MyAsset/Data/PLACEHOLDER_CharacterAnimator.controller.meta
+++ b/Assets/MyAsset/Data/PLACEHOLDER_CharacterAnimator.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 34dd98adbbc5db542b1bda6ba8c2d3c3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Data/PLACEHOLDER_CompanionAI.asset
+++ b/Assets/MyAsset/Data/PLACEHOLDER_CompanionAI.asset
@@ -1,0 +1,106 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f732d17df7bb7354880a10fae6d9de9f, type: 3}
+  m_Name: PLACEHOLDER_CompanionAI
+  m_EditorClassIdentifier: Game.Core::Game.Core.AIInfo
+  modes:
+  - mode: 0
+    detectionRange: 12
+    combatRange: 2
+    retreatHpThreshold: 0
+    availableActIndices: 01000000
+    transitions:
+    - targetMode: 3
+      trigger: 0
+      threshold: 10
+  - mode: 3
+    detectionRange: 15
+    combatRange: 2
+    retreatHpThreshold: 0
+    availableActIndices: 0000000001000000
+    transitions:
+    - targetMode: 0
+      trigger: 1
+      threshold: 15
+  actDataList:
+  - actName: CompanionAttack
+    actType: 0
+    attackInfoIndex: 0
+    weight: 70
+    coolTime: 1.5
+    maxUseCount: 0
+    triggerJudge:
+      condition: 1
+      value: 1.5
+      comparison: 1
+    targetJudge:
+      selectionType: 0
+      maxRange: 0
+      minRange: 0
+      targetBelong: 0
+      targetFilter:
+        filterFlags: 0
+        belong: 0
+        feature: 0
+        weakPoint: 0
+        distanceRange: {x: 0, y: 0}
+        includeSelf: 0
+    actJudge:
+      requiredMp: 0
+      requiredStamina: 0
+      minHpRatio: 0
+      maxHpRatio: 0
+      requireLineOfSight: 0
+      requireGrounded: 0
+  - actName: Wait
+    actType: 6
+    attackInfoIndex: 0
+    weight: 20
+    coolTime: 0
+    maxUseCount: 0
+    triggerJudge:
+      condition: 0
+      value: 0
+      comparison: 0
+    targetJudge:
+      selectionType: 0
+      maxRange: 0
+      minRange: 0
+      targetBelong: 0
+      targetFilter:
+        filterFlags: 0
+        belong: 0
+        feature: 0
+        weakPoint: 0
+        distanceRange: {x: 0, y: 0}
+        includeSelf: 0
+    actJudge:
+      requiredMp: 0
+      requiredStamina: 0
+      minHpRatio: 0
+      maxHpRatio: 0
+      requireLineOfSight: 0
+      requireGrounded: 0
+  coolTimeData:
+    globalCoolTime: 0.3
+    attackCoolTime: 1.5
+    skillCoolTime: 0
+    guardCoolTime: 0
+    dodgeCoolTime: 0
+    healCoolTime: 0
+  companionSetting:
+    followDistance: 0
+    maxLeashDistance: 0
+    supportHpThreshold: 0
+    autoHeal: 0
+    prioritizePlayerTarget: 0
+    defaultStance: 0

--- a/Assets/MyAsset/Data/PLACEHOLDER_CompanionAI.asset.meta
+++ b/Assets/MyAsset/Data/PLACEHOLDER_CompanionAI.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cef35b33624281047b15e30c3a896222
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Data/PLACEHOLDER_CompanionAttack.asset
+++ b/Assets/MyAsset/Data/PLACEHOLDER_CompanionAttack.asset
@@ -1,0 +1,102 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55a1ec93ce0944c47887ddab2ae86a7a, type: 3}
+  m_Name: PLACEHOLDER_CompanionAttack
+  m_EditorClassIdentifier: Game.Core::Game.Core.AttackInfo
+  attackName: PLACEHOLDER_CompanionAttack
+  category: 0
+  motionInfo:
+    preMotionDuration: 0.1
+    activeMotionDuration: 0.15
+    recoveryDuration: 0.15
+    chargeTimeMin: 0
+    chargeTimeMax: 0
+    chargeDamageMultiplier: 0
+    preMotionClip: {fileID: 0}
+    activeClip: {fileID: 0}
+    chargeLoopClip: {fileID: 0}
+    recoveryClip: {fileID: 0}
+    actionEffects: []
+  baseDamage:
+    slash: 6
+    strike: 0
+    pierce: 0
+    fire: 0
+    thunder: 0
+    light: 0
+    dark: 0
+  damageMultiplier: 1
+  effectSoundInfo:
+    hitEffect: {fileID: 0}
+    castEffect: {fileID: 0}
+    chargeEffect: {fileID: 0}
+    trailEffect: {fileID: 0}
+    attackSound: {fileID: 0}
+    hitSound: {fileID: 0}
+    chargeSound: {fileID: 0}
+    chargeCompleteSound: {fileID: 0}
+    landingSound: {fileID: 0}
+  projectileInfo:
+    hasProjectile: 0
+    projectilePrefab: {fileID: 0}
+    trajectory: 0
+    speed: 0
+    lifetime: 0
+    homingStrength: 0
+    pierceCount: 0
+    aoeRadius: 0
+    projectileCount: 0
+    spreadAngle: 0
+  knockbackInfo:
+    hasKnockback: 0
+    force: {x: 0, y: 0}
+    stunDuration: 0
+    groundBounce: 0
+    wallBounce: 0
+    gravityScale: 0
+  statusEffectInfo:
+    effect: 0
+    accumulateValue: 0
+    duration: 0
+    tickDamage: 0
+    tickInterval: 0
+    modifier: 0
+    maxStack: 0
+  mpCost: 0
+  staminaCost: 0
+  aiEvaluation:
+    effectiveRangeMin: 0
+    effectiveRangeMax: 0
+    threatLevel: 0
+    isBlockable: 0
+    isParriable: 0
+    totalWindupTime: 0
+    preferredUseHpThreshold: 0
+    priority: 0
+  attackMoveDistance: 0
+  attackMoveDuration: 0
+  contactType: 0
+  aerialMoveDirection: {x: 0, y: 0}
+  airHangDuration: 0.3
+  airHangGravityScale: 0.1
+  aerialMoveSpeedDefault: 3
+  divingGravityMultiplier: 3
+  divingForwardSpeed: 1
+  divingLandingRecoveryDuration: 0.3
+  isParriable: 0
+  armorBreakValue: 0
+  feature: 0
+  attackElement: 1
+  isAutoChain: 0
+  isChainEndPoint: 0
+  inputWindow: 0
+  justGuardResistance: 0

--- a/Assets/MyAsset/Data/PLACEHOLDER_CompanionAttack.asset.meta
+++ b/Assets/MyAsset/Data/PLACEHOLDER_CompanionAttack.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d6cfdb17113aec94bb0bad55adeaf1b3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Data/PLACEHOLDER_EnemyAttack.asset
+++ b/Assets/MyAsset/Data/PLACEHOLDER_EnemyAttack.asset
@@ -1,0 +1,102 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55a1ec93ce0944c47887ddab2ae86a7a, type: 3}
+  m_Name: PLACEHOLDER_EnemyAttack
+  m_EditorClassIdentifier: Game.Core::Game.Core.AttackInfo
+  attackName: PLACEHOLDER_EnemyAttack
+  category: 0
+  motionInfo:
+    preMotionDuration: 0.15
+    activeMotionDuration: 0.2
+    recoveryDuration: 0.2
+    chargeTimeMin: 0
+    chargeTimeMax: 0
+    chargeDamageMultiplier: 0
+    preMotionClip: {fileID: 0}
+    activeClip: {fileID: 0}
+    chargeLoopClip: {fileID: 0}
+    recoveryClip: {fileID: 0}
+    actionEffects: []
+  baseDamage:
+    slash: 8
+    strike: 0
+    pierce: 0
+    fire: 0
+    thunder: 0
+    light: 0
+    dark: 0
+  damageMultiplier: 1
+  effectSoundInfo:
+    hitEffect: {fileID: 0}
+    castEffect: {fileID: 0}
+    chargeEffect: {fileID: 0}
+    trailEffect: {fileID: 0}
+    attackSound: {fileID: 0}
+    hitSound: {fileID: 0}
+    chargeSound: {fileID: 0}
+    chargeCompleteSound: {fileID: 0}
+    landingSound: {fileID: 0}
+  projectileInfo:
+    hasProjectile: 0
+    projectilePrefab: {fileID: 0}
+    trajectory: 0
+    speed: 0
+    lifetime: 0
+    homingStrength: 0
+    pierceCount: 0
+    aoeRadius: 0
+    projectileCount: 0
+    spreadAngle: 0
+  knockbackInfo:
+    hasKnockback: 0
+    force: {x: 0, y: 0}
+    stunDuration: 0
+    groundBounce: 0
+    wallBounce: 0
+    gravityScale: 0
+  statusEffectInfo:
+    effect: 0
+    accumulateValue: 0
+    duration: 0
+    tickDamage: 0
+    tickInterval: 0
+    modifier: 0
+    maxStack: 0
+  mpCost: 0
+  staminaCost: 0
+  aiEvaluation:
+    effectiveRangeMin: 0
+    effectiveRangeMax: 0
+    threatLevel: 0
+    isBlockable: 0
+    isParriable: 0
+    totalWindupTime: 0
+    preferredUseHpThreshold: 0
+    priority: 0
+  attackMoveDistance: 0
+  attackMoveDuration: 0
+  contactType: 0
+  aerialMoveDirection: {x: 0, y: 0}
+  airHangDuration: 0.3
+  airHangGravityScale: 0.1
+  aerialMoveSpeedDefault: 3
+  divingGravityMultiplier: 3
+  divingForwardSpeed: 1
+  divingLandingRecoveryDuration: 0.3
+  isParriable: 0
+  armorBreakValue: 0
+  feature: 0
+  attackElement: 1
+  isAutoChain: 0
+  isChainEndPoint: 0
+  inputWindow: 0
+  justGuardResistance: 0

--- a/Assets/MyAsset/Data/PLACEHOLDER_EnemyAttack.asset.meta
+++ b/Assets/MyAsset/Data/PLACEHOLDER_EnemyAttack.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 37c664d32e75e93439f3e6ec6a0da093
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo1.asset
+++ b/Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo1.asset
@@ -1,0 +1,102 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55a1ec93ce0944c47887ddab2ae86a7a, type: 3}
+  m_Name: PLACEHOLDER_PlayerCombo1
+  m_EditorClassIdentifier: Game.Core::Game.Core.AttackInfo
+  attackName: Light_Combo1
+  category: 0
+  motionInfo:
+    preMotionDuration: 0.05
+    activeMotionDuration: 0.2
+    recoveryDuration: 0.1
+    chargeTimeMin: 0
+    chargeTimeMax: 0
+    chargeDamageMultiplier: 0
+    preMotionClip: {fileID: 0}
+    activeClip: {fileID: 0}
+    chargeLoopClip: {fileID: 0}
+    recoveryClip: {fileID: 0}
+    actionEffects: []
+  baseDamage:
+    slash: 10
+    strike: 0
+    pierce: 0
+    fire: 0
+    thunder: 0
+    light: 0
+    dark: 0
+  damageMultiplier: 1
+  effectSoundInfo:
+    hitEffect: {fileID: 0}
+    castEffect: {fileID: 0}
+    chargeEffect: {fileID: 0}
+    trailEffect: {fileID: 0}
+    attackSound: {fileID: 0}
+    hitSound: {fileID: 0}
+    chargeSound: {fileID: 0}
+    chargeCompleteSound: {fileID: 0}
+    landingSound: {fileID: 0}
+  projectileInfo:
+    hasProjectile: 0
+    projectilePrefab: {fileID: 0}
+    trajectory: 0
+    speed: 0
+    lifetime: 0
+    homingStrength: 0
+    pierceCount: 0
+    aoeRadius: 0
+    projectileCount: 0
+    spreadAngle: 0
+  knockbackInfo:
+    hasKnockback: 1
+    force: {x: 2, y: 0.5}
+    stunDuration: 0
+    groundBounce: 0
+    wallBounce: 0
+    gravityScale: 0
+  statusEffectInfo:
+    effect: 0
+    accumulateValue: 0
+    duration: 0
+    tickDamage: 0
+    tickInterval: 0
+    modifier: 0
+    maxStack: 0
+  mpCost: 0
+  staminaCost: 5
+  aiEvaluation:
+    effectiveRangeMin: 0
+    effectiveRangeMax: 0
+    threatLevel: 0
+    isBlockable: 0
+    isParriable: 0
+    totalWindupTime: 0
+    preferredUseHpThreshold: 0
+    priority: 0
+  attackMoveDistance: 1
+  attackMoveDuration: 0.12
+  contactType: 1
+  aerialMoveDirection: {x: 0, y: 0.3}
+  airHangDuration: 0.3
+  airHangGravityScale: 0.1
+  aerialMoveSpeedDefault: 3
+  divingGravityMultiplier: 3
+  divingForwardSpeed: 1
+  divingLandingRecoveryDuration: 0.3
+  isParriable: 1
+  armorBreakValue: 10
+  feature: 1
+  attackElement: 1
+  isAutoChain: 0
+  isChainEndPoint: 0
+  inputWindow: 0.6
+  justGuardResistance: 0

--- a/Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo1.asset.meta
+++ b/Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a47f6fff1fb315419e6eafefa62a55d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo2.asset
+++ b/Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo2.asset
@@ -1,0 +1,102 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55a1ec93ce0944c47887ddab2ae86a7a, type: 3}
+  m_Name: PLACEHOLDER_PlayerCombo2
+  m_EditorClassIdentifier: Game.Core::Game.Core.AttackInfo
+  attackName: Light_Combo2
+  category: 0
+  motionInfo:
+    preMotionDuration: 0.05
+    activeMotionDuration: 0.2
+    recoveryDuration: 0.12
+    chargeTimeMin: 0
+    chargeTimeMax: 0
+    chargeDamageMultiplier: 0
+    preMotionClip: {fileID: 0}
+    activeClip: {fileID: 0}
+    chargeLoopClip: {fileID: 0}
+    recoveryClip: {fileID: 0}
+    actionEffects: []
+  baseDamage:
+    slash: 12
+    strike: 0
+    pierce: 0
+    fire: 0
+    thunder: 0
+    light: 0
+    dark: 0
+  damageMultiplier: 1.2
+  effectSoundInfo:
+    hitEffect: {fileID: 0}
+    castEffect: {fileID: 0}
+    chargeEffect: {fileID: 0}
+    trailEffect: {fileID: 0}
+    attackSound: {fileID: 0}
+    hitSound: {fileID: 0}
+    chargeSound: {fileID: 0}
+    chargeCompleteSound: {fileID: 0}
+    landingSound: {fileID: 0}
+  projectileInfo:
+    hasProjectile: 0
+    projectilePrefab: {fileID: 0}
+    trajectory: 0
+    speed: 0
+    lifetime: 0
+    homingStrength: 0
+    pierceCount: 0
+    aoeRadius: 0
+    projectileCount: 0
+    spreadAngle: 0
+  knockbackInfo:
+    hasKnockback: 1
+    force: {x: 3, y: 0.5}
+    stunDuration: 0
+    groundBounce: 0
+    wallBounce: 0
+    gravityScale: 0
+  statusEffectInfo:
+    effect: 0
+    accumulateValue: 0
+    duration: 0
+    tickDamage: 0
+    tickInterval: 0
+    modifier: 0
+    maxStack: 0
+  mpCost: 0
+  staminaCost: 7
+  aiEvaluation:
+    effectiveRangeMin: 0
+    effectiveRangeMax: 0
+    threatLevel: 0
+    isBlockable: 0
+    isParriable: 0
+    totalWindupTime: 0
+    preferredUseHpThreshold: 0
+    priority: 0
+  attackMoveDistance: 1.2
+  attackMoveDuration: 0.12
+  contactType: 1
+  aerialMoveDirection: {x: 0, y: 0.2}
+  airHangDuration: 0.3
+  airHangGravityScale: 0.1
+  aerialMoveSpeedDefault: 3
+  divingGravityMultiplier: 3
+  divingForwardSpeed: 1
+  divingLandingRecoveryDuration: 0.3
+  isParriable: 1
+  armorBreakValue: 12
+  feature: 1
+  attackElement: 1
+  isAutoChain: 0
+  isChainEndPoint: 0
+  inputWindow: 0.6
+  justGuardResistance: 0

--- a/Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo2.asset.meta
+++ b/Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e12385893578bf2499c1f2288df26bc2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo3.asset
+++ b/Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo3.asset
@@ -1,0 +1,102 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55a1ec93ce0944c47887ddab2ae86a7a, type: 3}
+  m_Name: PLACEHOLDER_PlayerCombo3
+  m_EditorClassIdentifier: Game.Core::Game.Core.AttackInfo
+  attackName: Light_Combo3_Finish
+  category: 0
+  motionInfo:
+    preMotionDuration: 0.08
+    activeMotionDuration: 0.25
+    recoveryDuration: 0.2
+    chargeTimeMin: 0
+    chargeTimeMax: 0
+    chargeDamageMultiplier: 0
+    preMotionClip: {fileID: 0}
+    activeClip: {fileID: 0}
+    chargeLoopClip: {fileID: 0}
+    recoveryClip: {fileID: 0}
+    actionEffects: []
+  baseDamage:
+    slash: 15
+    strike: 5
+    pierce: 0
+    fire: 0
+    thunder: 0
+    light: 0
+    dark: 0
+  damageMultiplier: 1.8
+  effectSoundInfo:
+    hitEffect: {fileID: 0}
+    castEffect: {fileID: 0}
+    chargeEffect: {fileID: 0}
+    trailEffect: {fileID: 0}
+    attackSound: {fileID: 0}
+    hitSound: {fileID: 0}
+    chargeSound: {fileID: 0}
+    chargeCompleteSound: {fileID: 0}
+    landingSound: {fileID: 0}
+  projectileInfo:
+    hasProjectile: 0
+    projectilePrefab: {fileID: 0}
+    trajectory: 0
+    speed: 0
+    lifetime: 0
+    homingStrength: 0
+    pierceCount: 0
+    aoeRadius: 0
+    projectileCount: 0
+    spreadAngle: 0
+  knockbackInfo:
+    hasKnockback: 1
+    force: {x: 6, y: 2}
+    stunDuration: 0.3
+    groundBounce: 0
+    wallBounce: 0
+    gravityScale: 0
+  statusEffectInfo:
+    effect: 0
+    accumulateValue: 0
+    duration: 0
+    tickDamage: 0
+    tickInterval: 0
+    modifier: 0
+    maxStack: 0
+  mpCost: 0
+  staminaCost: 12
+  aiEvaluation:
+    effectiveRangeMin: 0
+    effectiveRangeMax: 0
+    threatLevel: 0
+    isBlockable: 0
+    isParriable: 0
+    totalWindupTime: 0
+    preferredUseHpThreshold: 0
+    priority: 0
+  attackMoveDistance: 1.8
+  attackMoveDuration: 0.15
+  contactType: 1
+  aerialMoveDirection: {x: 0.3, y: -0.5}
+  airHangDuration: 0.3
+  airHangGravityScale: 0.1
+  aerialMoveSpeedDefault: 3
+  divingGravityMultiplier: 3
+  divingForwardSpeed: 1
+  divingLandingRecoveryDuration: 0.3
+  isParriable: 1
+  armorBreakValue: 20
+  feature: 2
+  attackElement: 1
+  isAutoChain: 0
+  isChainEndPoint: 1
+  inputWindow: 0
+  justGuardResistance: 0

--- a/Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo3.asset.meta
+++ b/Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 69bff095b05f0044f9b34e29cb5c3ac4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Data/PLACEHOLDER_PlayerHeavy.asset
+++ b/Assets/MyAsset/Data/PLACEHOLDER_PlayerHeavy.asset
@@ -1,0 +1,94 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55a1ec93ce0944c47887ddab2ae86a7a, type: 3}
+  m_Name: PLACEHOLDER_PlayerHeavy
+  m_EditorClassIdentifier: Game.Core::Game.Core.AttackInfo
+  attackName: PLACEHOLDER_PlayerHeavy
+  category: 0
+  motionInfo:
+    preMotionDuration: 0.3
+    activeMotionDuration: 0.25
+    recoveryDuration: 0.3
+    chargeTimeMin: 0
+    chargeTimeMax: 0
+    chargeDamageMultiplier: 0
+    preMotionClip: {fileID: 0}
+    activeClip: {fileID: 0}
+    chargeLoopClip: {fileID: 0}
+    recoveryClip: {fileID: 0}
+    actionEffects: []
+  baseDamage:
+    slash: 0
+    strike: 20
+    pierce: 0
+    fire: 0
+    thunder: 0
+    light: 0
+    dark: 0
+  damageMultiplier: 1.5
+  effectSoundInfo:
+    hitEffect: {fileID: 0}
+    castEffect: {fileID: 0}
+    chargeEffect: {fileID: 0}
+    trailEffect: {fileID: 0}
+    attackSound: {fileID: 0}
+    hitSound: {fileID: 0}
+    chargeSound: {fileID: 0}
+    chargeCompleteSound: {fileID: 0}
+  projectileInfo:
+    hasProjectile: 0
+    projectilePrefab: {fileID: 0}
+    trajectory: 0
+    speed: 0
+    lifetime: 0
+    homingStrength: 0
+    pierceCount: 0
+    aoeRadius: 0
+    projectileCount: 0
+    spreadAngle: 0
+  knockbackInfo:
+    hasKnockback: 1
+    force: {x: 3, y: 1}
+    stunDuration: 0.3
+    groundBounce: 0
+    wallBounce: 0
+    gravityScale: 0
+  statusEffectInfo:
+    effect: 0
+    accumulateValue: 0
+    duration: 0
+    tickDamage: 0
+    tickInterval: 0
+    modifier: 0
+    maxStack: 0
+  mpCost: 0
+  staminaCost: 25
+  aiEvaluation:
+    effectiveRangeMin: 0
+    effectiveRangeMax: 0
+    threatLevel: 0
+    isBlockable: 0
+    isParriable: 0
+    totalWindupTime: 0
+    preferredUseHpThreshold: 0
+    priority: 0
+  attackMoveDistance: 0
+  attackMoveDuration: 0
+  contactType: 0
+  isParriable: 1
+  armorBreakValue: 0
+  feature: 0
+  attackElement: 2
+  isAutoChain: 0
+  isChainEndPoint: 1
+  inputWindow: 0
+  justGuardResistance: 0

--- a/Assets/MyAsset/Data/PLACEHOLDER_PlayerHeavy.asset.meta
+++ b/Assets/MyAsset/Data/PLACEHOLDER_PlayerHeavy.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eafba6068d60c2e40957f0bb394a0f89
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Data/PLACEHOLDER_PlayerSlash.asset
+++ b/Assets/MyAsset/Data/PLACEHOLDER_PlayerSlash.asset
@@ -1,0 +1,94 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55a1ec93ce0944c47887ddab2ae86a7a, type: 3}
+  m_Name: PLACEHOLDER_PlayerSlash
+  m_EditorClassIdentifier: Game.Core::Game.Core.AttackInfo
+  attackName: PLACEHOLDER_PlayerSlash
+  category: 0
+  motionInfo:
+    preMotionDuration: 0.1
+    activeMotionDuration: 0.2
+    recoveryDuration: 0.15
+    chargeTimeMin: 0
+    chargeTimeMax: 0
+    chargeDamageMultiplier: 0
+    preMotionClip: {fileID: 0}
+    activeClip: {fileID: 0}
+    chargeLoopClip: {fileID: 0}
+    recoveryClip: {fileID: 0}
+    actionEffects: []
+  baseDamage:
+    slash: 10
+    strike: 0
+    pierce: 0
+    fire: 0
+    thunder: 0
+    light: 0
+    dark: 0
+  damageMultiplier: 1
+  effectSoundInfo:
+    hitEffect: {fileID: 0}
+    castEffect: {fileID: 0}
+    chargeEffect: {fileID: 0}
+    trailEffect: {fileID: 0}
+    attackSound: {fileID: 0}
+    hitSound: {fileID: 0}
+    chargeSound: {fileID: 0}
+    chargeCompleteSound: {fileID: 0}
+  projectileInfo:
+    hasProjectile: 0
+    projectilePrefab: {fileID: 0}
+    trajectory: 0
+    speed: 0
+    lifetime: 0
+    homingStrength: 0
+    pierceCount: 0
+    aoeRadius: 0
+    projectileCount: 0
+    spreadAngle: 0
+  knockbackInfo:
+    hasKnockback: 0
+    force: {x: 0, y: 0}
+    stunDuration: 0
+    groundBounce: 0
+    wallBounce: 0
+    gravityScale: 0
+  statusEffectInfo:
+    effect: 0
+    accumulateValue: 0
+    duration: 0
+    tickDamage: 0
+    tickInterval: 0
+    modifier: 0
+    maxStack: 0
+  mpCost: 0
+  staminaCost: 10
+  aiEvaluation:
+    effectiveRangeMin: 0
+    effectiveRangeMax: 0
+    threatLevel: 0
+    isBlockable: 0
+    isParriable: 0
+    totalWindupTime: 0
+    preferredUseHpThreshold: 0
+    priority: 0
+  attackMoveDistance: 0
+  attackMoveDuration: 0
+  contactType: 0
+  isParriable: 1
+  armorBreakValue: 0
+  feature: 0
+  attackElement: 1
+  isAutoChain: 0
+  isChainEndPoint: 0
+  inputWindow: 0.3
+  justGuardResistance: 0

--- a/Assets/MyAsset/Data/PLACEHOLDER_PlayerSlash.asset.meta
+++ b/Assets/MyAsset/Data/PLACEHOLDER_PlayerSlash.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c5a0625aaf84a3446a91977bf3d08602
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Editor/TestSceneBuilder.cs
+++ b/Assets/MyAsset/Editor/TestSceneBuilder.cs
@@ -1,0 +1,1172 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEditor;
+using UnityEditor.Animations;
+using UnityEditor.SceneManagement;
+using Game.Core;
+using Game.Runtime;
+using CharacterInfo = Game.Core.CharacterInfo;
+
+namespace Game.Editor
+{
+    /// <summary>
+    /// 全機能テスト用シーンを自動構築するエディタツール。
+    /// Section1-4の主要機能を手動プレイテストできるレイアウト。
+    ///
+    /// エリア構成:
+    ///   1. スタートエリア (x:-8 ~ 0)   — 安全地帯、仲間と合流
+    ///   2. 戦闘エリア (x:0 ~ 15)       — 敵x3、攻撃・コンボ・ガードをテスト
+    ///   3. 機動テストエリア (x:15 ~ 35) — 段差、ギャップ、高台でジャンプ・ダッシュ
+    ///   4. ボスエリア (x:35 ~ 50)      — 強敵、壁で囲まれた擬似ボスルーム
+    /// </summary>
+    public static class TestSceneBuilder
+    {
+        private const int k_SquareSize = 128;
+        private const float k_Ppu = 128f;
+
+        [MenuItem("Tools/Build Test Scene")]
+        public static void BuildTestScene()
+        {
+            if (!EditorUtility.DisplayDialog(
+                "テストシーン構築",
+                "現在のシーンを破棄してテストシーンを新規作成します。よろしいですか？",
+                "構築する", "キャンセル"))
+            {
+                return;
+            }
+
+            BuildTestSceneInternal();
+        }
+
+        /// <summary>
+        /// ダイアログなしでテストシーンを構築する。MCP/自動化ツール向け。
+        /// </summary>
+        [MenuItem("Tools/MCP Internal/Build Test Scene Silent")]
+        public static void BuildTestSceneNoDialog()
+        {
+            BuildTestSceneInternal();
+        }
+
+        private static void BuildTestSceneInternal()
+        {
+            EditorSceneManager.NewScene(NewSceneSetup.DefaultGameObjects, NewSceneMode.Single);
+
+            // レイヤー
+            SetupLayers();
+
+            // SO読み込み
+            CharacterInfo playerInfo = LoadOrWarnCharacterInfo("Assets/MyAsset/Data/PlayerInfo.asset");
+            CharacterInfo enemyInfo = LoadOrWarnCharacterInfo("Assets/MyAsset/Data/BasicEnemyInfo.asset");
+            CharacterInfo companionInfo = LoadOrWarnCharacterInfo("Assets/MyAsset/Data/CompanionInfo.asset");
+
+            // アセット自動生成
+            AttackInfo[] playerAttacks = CreatePlayerAttackInfos();
+            AttackInfo[] enemyAttacks = CreateEnemyAttackInfos();
+            AttackInfo[] bossAttacks = CreateBossAttackInfos();
+            AnimatorController placeholderAnimController = CreateOrLoadPlaceholderAnimatorController();
+            AttackInfo[] companionAttacks = CreateCompanionAttackInfos();
+            AIInfo basicEnemyAI = CreateBasicEnemyAIInfo();
+            AIInfo bossAI = CreateBossAIInfo();
+            AIInfo companionAI = CreateCompanionAIInfo();
+
+            // ===== システム =====
+            GameObject gmObj = new GameObject("GameManager");
+            gmObj.AddComponent<GameManager>();
+
+            // GameManager 子マネージャー
+            GameObject projectileMgrObj = new GameObject("ProjectileManager");
+            projectileMgrObj.transform.SetParent(gmObj.transform);
+            projectileMgrObj.AddComponent<ProjectileManager>();
+
+            GameObject spawnerMgrObj = new GameObject("EnemySpawnerManager");
+            spawnerMgrObj.transform.SetParent(gmObj.transform);
+            spawnerMgrObj.AddComponent<EnemySpawnerManager>();
+
+            GameObject levelStreamObj = new GameObject("LevelStreamingController");
+            levelStreamObj.transform.SetParent(gmObj.transform);
+            levelStreamObj.AddComponent<LevelStreamingController>();
+
+            // ===== 環境: スタートエリア =====
+            CreateGround(new Vector3(21f, -1f, 0f), 70f);    // 全体の床
+            CreateWall("Wall_Left", new Vector3(-14.5f, 4f, 0f), new Vector2(1f, 12f));
+
+            // ===== 環境: 戦闘エリア =====
+            CreatePlatform("CombatPlatform_Low", new Vector3(5f, 1.5f, 0f), new Vector2(5f, 0.5f));
+            CreatePlatform("CombatPlatform_High", new Vector3(10f, 3.5f, 0f), new Vector2(4f, 0.5f));
+
+            // ===== 環境: 機動テストエリア =====
+            // 段差ジャンプ (高さ1, 2, 3.5タイル)
+            CreatePlatform("Step_1", new Vector3(17f, 1f, 0f), new Vector2(2f, 0.5f));
+            CreatePlatform("Step_2", new Vector3(20f, 2f, 0f), new Vector2(2f, 0.5f));
+            CreatePlatform("Step_3", new Vector3(23f, 3.5f, 0f), new Vector2(2f, 0.5f));
+            // ジャンプ最大高度チェック用 (3.5タイル)
+            CreatePlatform("JumpCeiling", new Vector3(23f, 7f, 0f), new Vector2(3f, 0.3f));
+
+            // ダッシュ用ギャップ (3タイルの穴)
+            CreateGap(new Vector3(27f, -1f, 0f), 3f);
+            CreatePlatform("PostGap", new Vector3(30f, -0.25f, 0f), new Vector2(4f, 1.5f));
+
+            // ジャンプ距離テスト (5タイルの穴)
+            CreateGap(new Vector3(33.5f, -1f, 0f), 5f);
+            CreatePlatform("LongJumpLanding", new Vector3(37f, -0.25f, 0f), new Vector2(2f, 1.5f));
+
+            // ===== 環境: ボスエリア =====
+            CreateWall("BossWall_Left", new Vector3(39f, 4f, 0f), new Vector2(0.5f, 10f));
+            CreateWall("BossWall_Right", new Vector3(54.5f, 4f, 0f), new Vector2(1f, 12f));
+            CreatePlatform("BossPlatform_L", new Vector3(43f, 2.5f, 0f), new Vector2(3f, 0.5f));
+            CreatePlatform("BossPlatform_R", new Vector3(51f, 2.5f, 0f), new Vector2(3f, 0.5f));
+
+            // ===== キャラクター =====
+            GameObject player = CreatePlayer(playerInfo, placeholderAnimController, playerAttacks);
+            CreateCompanion(companionInfo, player.transform, placeholderAnimController, companionAttacks, companionAI);
+
+            // 戦闘エリア: 敵x3
+            CreateEnemy(enemyInfo, "Enemy_Melee_1", new Vector3(4f, 2f, 0f),
+                placeholderAnimController, enemyAttacks, basicEnemyAI);
+            CreateEnemy(enemyInfo, "Enemy_Melee_2", new Vector3(8f, 2f, 0f),
+                placeholderAnimController, enemyAttacks, basicEnemyAI);
+            CreateEnemy(enemyInfo, "Enemy_Platform", new Vector3(10f, 5f, 0f),
+                placeholderAnimController, enemyAttacks, basicEnemyAI);
+
+            // ボスエリア: 強敵 (大きめ)
+            CreateBossEnemy(enemyInfo, "BossEnemy", new Vector3(47f, 2f, 0f),
+                placeholderAnimController, bossAttacks, bossAI);
+
+            // ===== カメラ =====
+            SetupCamera(player.transform);
+
+            // ===== UI =====
+            SetupHUD();
+            SetupDamagePopups();
+
+            // ===== デバッグオーバーレイ =====
+            GameObject debugOverlay = new GameObject("[DEBUG]StatusOverlay");
+            debugOverlay.AddComponent<DebugStatusOverlay>();
+
+            // ===== 自動入力テスター =====
+            AutoInputTester tester = gmObj.AddComponent<AutoInputTester>();
+            tester.EnableOnStart = true;
+            tester.LoopCount = 3;
+
+            // ===== エリアラベル =====
+            CreateAreaLabel("スタート", new Vector3(-6f, 6f, 0f));
+            CreateAreaLabel("戦闘エリア", new Vector3(7f, 6f, 0f));
+            CreateAreaLabel("機動テスト", new Vector3(22f, 6f, 0f));
+            CreateAreaLabel("ボスルーム", new Vector3(47f, 6f, 0f));
+
+            // ===== 物理レイヤー衝突設定 =====
+            SetupPhysicsLayers();
+
+            // ===== 保存 =====
+            EnsureDirectoryExists("Assets/Scenes");
+            EditorSceneManager.SaveScene(
+                EditorSceneManager.GetActiveScene(),
+                "Assets/Scenes/CoreTestScene.unity");
+
+            Debug.Log("[TestSceneBuilder] テストシーン構築完了！");
+            Debug.Log("[TestSceneBuilder] エリア構成:");
+            Debug.Log("  1. スタート (x:-8~0) — 安全地帯、仲間合流");
+            Debug.Log("  2. 戦闘 (x:0~15) — 敵x3、コンボ・ガードテスト");
+            Debug.Log("  3. 機動テスト (x:15~35) — 段差・ギャップ・ジャンプ距離");
+            Debug.Log("  4. ボスルーム (x:39~55) — 強敵、壁囲いアリーナ");
+        }
+
+        // ===== アセット自動生成 =====
+
+        private static AttackInfo[] CreatePlayerAttackInfos()
+        {
+            // 3段コンボ: 弱1 → 弱2 → 弱3（フィニッシュ）
+            AttackInfo combo1 = CreateOrLoadAttackInfo(
+                "Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo1.asset",
+                info =>
+                {
+                    info.attackName = "Light_Combo1";
+                    info.category = AttackCategory.Melee;
+                    info.motionInfo = new MotionInfo
+                    {
+                        preMotionDuration = 0.05f,
+                        activeMotionDuration = 0.2f,
+                        recoveryDuration = 0.1f
+                    };
+                    info.baseDamage = new ElementalStatus { slash = 10 };
+                    info.damageMultiplier = 1.0f;
+                    info.attackElement = Element.Slash;
+                    info.feature = AttackFeature.Light;
+                    info.contactType = AttackContactType.StopOnHit;
+                    info.attackMoveDistance = 1.0f;
+                    info.attackMoveDuration = 0.12f;
+                    info.aerialMoveDirection = new Vector2(0f, 0.3f);
+                    info.isParriable = true;
+                    info.staminaCost = 5f;
+                    info.armorBreakValue = 10f;
+                    info.inputWindow = 0.6f;
+                    info.knockbackInfo = new KnockbackInfo
+                    {
+                        hasKnockback = true,
+                        force = new Vector2(2f, 0.5f)
+                    };
+                });
+
+            AttackInfo combo2 = CreateOrLoadAttackInfo(
+                "Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo2.asset",
+                info =>
+                {
+                    info.attackName = "Light_Combo2";
+                    info.category = AttackCategory.Melee;
+                    info.motionInfo = new MotionInfo
+                    {
+                        preMotionDuration = 0.05f,
+                        activeMotionDuration = 0.2f,
+                        recoveryDuration = 0.12f
+                    };
+                    info.baseDamage = new ElementalStatus { slash = 12 };
+                    info.damageMultiplier = 1.2f;
+                    info.attackElement = Element.Slash;
+                    info.feature = AttackFeature.Light;
+                    info.contactType = AttackContactType.StopOnHit;
+                    info.attackMoveDistance = 1.2f;
+                    info.attackMoveDuration = 0.12f;
+                    info.aerialMoveDirection = new Vector2(0f, 0.2f);
+                    info.isParriable = true;
+                    info.staminaCost = 7f;
+                    info.armorBreakValue = 12f;
+                    info.inputWindow = 0.6f;
+                    info.knockbackInfo = new KnockbackInfo
+                    {
+                        hasKnockback = true,
+                        force = new Vector2(3f, 0.5f)
+                    };
+                });
+
+            AttackInfo combo3 = CreateOrLoadAttackInfo(
+                "Assets/MyAsset/Data/PLACEHOLDER_PlayerCombo3.asset",
+                info =>
+                {
+                    info.attackName = "Light_Combo3_Finish";
+                    info.category = AttackCategory.Melee;
+                    info.motionInfo = new MotionInfo
+                    {
+                        preMotionDuration = 0.08f,
+                        activeMotionDuration = 0.25f,
+                        recoveryDuration = 0.2f
+                    };
+                    info.baseDamage = new ElementalStatus { slash = 15, strike = 5 };
+                    info.damageMultiplier = 1.8f;
+                    info.attackElement = Element.Slash;
+                    info.feature = AttackFeature.Heavy;
+                    info.contactType = AttackContactType.StopOnHit;
+                    info.attackMoveDistance = 1.8f;
+                    info.attackMoveDuration = 0.15f;
+                    info.aerialMoveDirection = new Vector2(0.3f, -0.5f);
+                    info.isParriable = true;
+                    info.staminaCost = 12f;
+                    info.armorBreakValue = 20f;
+                    info.isChainEndPoint = true;
+                    info.inputWindow = 0f; // フィニッシュ: コンボ継続なし
+                    info.knockbackInfo = new KnockbackInfo
+                    {
+                        hasKnockback = true,
+                        force = new Vector2(6f, 2f),
+                        stunDuration = 0.3f
+                    };
+                });
+
+            return new AttackInfo[] { combo1, combo2, combo3 };
+        }
+
+        private static AttackInfo[] CreateEnemyAttackInfos()
+        {
+            AttackInfo attack = CreateOrLoadAttackInfo(
+                "Assets/MyAsset/Data/PLACEHOLDER_EnemyAttack.asset",
+                info =>
+                {
+                    info.attackName = "PLACEHOLDER_EnemyAttack";
+                    info.category = AttackCategory.Melee;
+                    info.motionInfo = new MotionInfo
+                    {
+                        preMotionDuration = 0.15f,
+                        activeMotionDuration = 0.2f,
+                        recoveryDuration = 0.2f
+                    };
+                    info.baseDamage = new ElementalStatus { slash = 8 };
+                    info.damageMultiplier = 1.0f;
+                    info.attackElement = Element.Slash;
+                    info.contactType = AttackContactType.PassThrough;
+                });
+
+            return new AttackInfo[] { attack };
+        }
+
+        private static AttackInfo[] CreateBossAttackInfos()
+        {
+            AttackInfo slam = CreateOrLoadAttackInfo(
+                "Assets/MyAsset/Data/PLACEHOLDER_BossSlam.asset",
+                info =>
+                {
+                    info.attackName = "PLACEHOLDER_BossSlam";
+                    info.category = AttackCategory.Melee;
+                    info.motionInfo = new MotionInfo
+                    {
+                        preMotionDuration = 0.4f,
+                        activeMotionDuration = 0.3f,
+                        recoveryDuration = 0.5f
+                    };
+                    info.baseDamage = new ElementalStatus { strike = 15 };
+                    info.damageMultiplier = 2.0f;
+                    info.attackElement = Element.Strike;
+                    info.contactType = AttackContactType.PassThrough;
+                    info.armorBreakValue = 30f;
+                    info.knockbackInfo = new KnockbackInfo
+                    {
+                        hasKnockback = true,
+                        force = new Vector2(5f, 2f),
+                        stunDuration = 0.5f
+                    };
+                });
+
+            return new AttackInfo[] { slam };
+        }
+
+        private static AttackInfo[] CreateCompanionAttackInfos()
+        {
+            AttackInfo attack = CreateOrLoadAttackInfo(
+                "Assets/MyAsset/Data/PLACEHOLDER_CompanionAttack.asset",
+                info =>
+                {
+                    info.attackName = "PLACEHOLDER_CompanionAttack";
+                    info.category = AttackCategory.Melee;
+                    info.motionInfo = new MotionInfo
+                    {
+                        preMotionDuration = 0.1f,
+                        activeMotionDuration = 0.15f,
+                        recoveryDuration = 0.15f
+                    };
+                    info.baseDamage = new ElementalStatus { slash = 6 };
+                    info.damageMultiplier = 1.0f;
+                    info.attackElement = Element.Slash;
+                    info.contactType = AttackContactType.PassThrough;
+                });
+
+            return new AttackInfo[] { attack };
+        }
+
+        private static AttackInfo CreateOrLoadAttackInfo(string path, System.Action<AttackInfo> configure)
+        {
+            AttackInfo existing = AssetDatabase.LoadAssetAtPath<AttackInfo>(path);
+            if (existing != null)
+            {
+                // 既存アセットにも設定を再適用（新フィールド追加時にデフォルト値を確実に反映）
+                configure(existing);
+                EditorUtility.SetDirty(existing);
+                return existing;
+            }
+
+            AttackInfo info = ScriptableObject.CreateInstance<AttackInfo>();
+            configure(info);
+            EnsureDirectoryExists(System.IO.Path.GetDirectoryName(path).Replace("\\", "/"));
+            AssetDatabase.CreateAsset(info, path);
+            return info;
+        }
+
+        // ===== AIInfo アセット自動生成 =====
+
+        private static AIInfo CreateBasicEnemyAIInfo()
+        {
+            string path = "Assets/MyAsset/Data/PLACEHOLDER_BasicEnemyAI.asset";
+            // 常に再生成（パラメータ変更を反映するため）
+            AIInfo existing = AssetDatabase.LoadAssetAtPath<AIInfo>(path);
+            if (existing != null)
+            {
+                AssetDatabase.DeleteAsset(path);
+            }
+
+            AIInfo ai = ScriptableObject.CreateInstance<AIInfo>();
+
+            // 行動定義: Attack, Wait
+            ai.actDataList = new ActData[]
+            {
+                new ActData
+                {
+                    actName = "BasicAttack",
+                    actType = ActType.Attack,
+                    attackInfoIndex = 0,
+                    weight = 80f,
+                    coolTime = 2f,
+                    triggerJudge = new TriggerJudgeData
+                    {
+                        condition = TriggerConditionType.EnemyInRange,
+                        value = 2.0f,
+                        comparison = ComparisonOperator.LessOrEqual,
+                    },
+                },
+                new ActData
+                {
+                    actName = "Wait",
+                    actType = ActType.Wait,
+                    weight = 10f,
+                },
+            };
+
+            // モード定義: Idle, Combat
+            ai.modes = new CharacterModeData[]
+            {
+                // Idle: 検出範囲外で待機（プレイヤー初期距離=10なので15に拡大）
+                new CharacterModeData
+                {
+                    mode = CharacterMode.Idle,
+                    detectionRange = 15f,
+                    combatRange = 2.0f,
+                    availableActIndices = new int[] { 1 }, // Wait のみ
+                    transitions = new TransitionCondition[]
+                    {
+                        new TransitionCondition
+                        {
+                            targetMode = CharacterMode.Combat,
+                            trigger = TriggerType.EnemyDetected,
+                            threshold = 12f,
+                        },
+                    },
+                },
+                // Combat: 追尾+攻撃
+                new CharacterModeData
+                {
+                    mode = CharacterMode.Combat,
+                    detectionRange = 15f,
+                    combatRange = 2.0f,
+                    availableActIndices = new int[] { 0, 1 }, // Attack, Wait
+                    transitions = new TransitionCondition[]
+                    {
+                        new TransitionCondition
+                        {
+                            targetMode = CharacterMode.Idle,
+                            trigger = TriggerType.EnemyLost,
+                            threshold = 18f,
+                        },
+                    },
+                },
+            };
+
+            ai.coolTimeData = new CoolTimeData
+            {
+                globalCoolTime = 0.5f,
+                attackCoolTime = 2f,
+            };
+
+            EnsureDirectoryExists("Assets/MyAsset/Data");
+            AssetDatabase.CreateAsset(ai, path);
+            return ai;
+        }
+
+        private static AIInfo CreateBossAIInfo()
+        {
+            string path = "Assets/MyAsset/Data/PLACEHOLDER_BossAI.asset";
+            AIInfo existing = AssetDatabase.LoadAssetAtPath<AIInfo>(path);
+            if (existing != null)
+            {
+                AssetDatabase.DeleteAsset(path);
+            }
+
+            AIInfo ai = ScriptableObject.CreateInstance<AIInfo>();
+
+            // 行動定義: SlamAttack, Wait
+            ai.actDataList = new ActData[]
+            {
+                new ActData
+                {
+                    actName = "BossSlam",
+                    actType = ActType.Attack,
+                    attackInfoIndex = 0,
+                    weight = 90f,
+                    coolTime = 1.5f,
+                    triggerJudge = new TriggerJudgeData
+                    {
+                        condition = TriggerConditionType.EnemyInRange,
+                        value = 2f,
+                        comparison = ComparisonOperator.LessOrEqual,
+                    },
+                },
+                new ActData
+                {
+                    actName = "Wait",
+                    actType = ActType.Wait,
+                    weight = 10f,
+                },
+            };
+
+            // モード定義: Combat のみ（常時戦闘）
+            ai.modes = new CharacterModeData[]
+            {
+                new CharacterModeData
+                {
+                    mode = CharacterMode.Combat,
+                    detectionRange = 20f,
+                    combatRange = 2.5f,
+                    availableActIndices = new int[] { 0, 1 }, // BossSlam, Wait
+                    transitions = null, // 遷移なし（常時Combat）
+                },
+            };
+
+            ai.coolTimeData = new CoolTimeData
+            {
+                globalCoolTime = 0.3f,
+                attackCoolTime = 1.5f,
+            };
+
+            EnsureDirectoryExists("Assets/MyAsset/Data");
+            AssetDatabase.CreateAsset(ai, path);
+            return ai;
+        }
+
+        private static AIInfo CreateCompanionAIInfo()
+        {
+            string path = "Assets/MyAsset/Data/PLACEHOLDER_CompanionAI.asset";
+            AIInfo existing = AssetDatabase.LoadAssetAtPath<AIInfo>(path);
+            if (existing != null)
+            {
+                AssetDatabase.DeleteAsset(path);
+            }
+
+            AIInfo ai = ScriptableObject.CreateInstance<AIInfo>();
+
+            // 行動定義: Attack, Wait
+            ai.actDataList = new ActData[]
+            {
+                new ActData
+                {
+                    actName = "CompanionAttack",
+                    actType = ActType.Attack,
+                    attackInfoIndex = 0,
+                    weight = 70f,
+                    coolTime = 1.5f,
+                    triggerJudge = new TriggerJudgeData
+                    {
+                        condition = TriggerConditionType.EnemyInRange,
+                        value = 1.5f,
+                        comparison = ComparisonOperator.LessOrEqual,
+                    },
+                },
+                new ActData
+                {
+                    actName = "Wait",
+                    actType = ActType.Wait,
+                    weight = 20f,
+                },
+            };
+
+            // モード定義: Follow（追従）, Combat（戦闘）
+            ai.modes = new CharacterModeData[]
+            {
+                // Follow: 敵未検出時はプレイヤーに追従
+                new CharacterModeData
+                {
+                    mode = CharacterMode.Idle,
+                    detectionRange = 12f,
+                    combatRange = 2.0f,
+                    availableActIndices = new int[] { 1 }, // Wait のみ
+                    transitions = new TransitionCondition[]
+                    {
+                        new TransitionCondition
+                        {
+                            targetMode = CharacterMode.Combat,
+                            trigger = TriggerType.EnemyDetected,
+                            threshold = 10f,
+                        },
+                    },
+                },
+                // Combat: 敵検出時は攻撃
+                new CharacterModeData
+                {
+                    mode = CharacterMode.Combat,
+                    detectionRange = 15f,
+                    combatRange = 2.0f,
+                    availableActIndices = new int[] { 0, 1 }, // Attack, Wait
+                    transitions = new TransitionCondition[]
+                    {
+                        new TransitionCondition
+                        {
+                            targetMode = CharacterMode.Idle,
+                            trigger = TriggerType.EnemyLost,
+                            threshold = 15f,
+                        },
+                    },
+                },
+            };
+
+            ai.coolTimeData = new CoolTimeData
+            {
+                globalCoolTime = 0.3f,
+                attackCoolTime = 1.5f,
+            };
+
+            EnsureDirectoryExists("Assets/MyAsset/Data");
+            AssetDatabase.CreateAsset(ai, path);
+            return ai;
+        }
+
+        private static AnimatorController CreateOrLoadPlaceholderAnimatorController()
+        {
+            string path = "Assets/MyAsset/Data/PLACEHOLDER_CharacterAnimator.controller";
+            AnimatorController existing = AssetDatabase.LoadAssetAtPath<AnimatorController>(path);
+            if (existing != null)
+            {
+                return existing;
+            }
+
+            EnsureDirectoryExists("Assets/MyAsset/Data");
+            AnimatorController controller = AnimatorController.CreateAnimatorControllerAtPath(path);
+            return controller;
+        }
+
+        // ===== 環境 =====
+
+        private static void CreateGround(Vector3 position, float width)
+        {
+            GameObject ground = new GameObject("[PLACEHOLDER]Ground");
+            ground.layer = 6;
+            ground.transform.position = position;
+
+            BoxCollider2D col = ground.AddComponent<BoxCollider2D>();
+            col.size = new Vector2(width, 2f);
+
+            SpriteRenderer sr = ground.AddComponent<SpriteRenderer>();
+            sr.sprite = CreateSquareSprite(new Color(0.25f, 0.55f, 0.25f));
+            sr.drawMode = SpriteDrawMode.Tiled;
+            sr.size = new Vector2(width, 2f);
+            sr.sortingOrder = -10;
+        }
+
+        private static void CreateGap(Vector3 centerPos, float gapWidth)
+        {
+            // ギャップ可視化 (赤い半透明の危険マーカー)
+            GameObject marker = new GameObject($"[PLACEHOLDER]Gap_{gapWidth}m");
+            marker.transform.position = centerPos + Vector3.down * 1.5f;
+
+            SpriteRenderer sr = marker.AddComponent<SpriteRenderer>();
+            sr.sprite = CreateSquareSprite(new Color(0.8f, 0.2f, 0.2f, 0.3f));
+            sr.drawMode = SpriteDrawMode.Tiled;
+            sr.size = new Vector2(gapWidth, 0.5f);
+            sr.sortingOrder = -8;
+
+            // 穴の左右の地面端にコライダーブロック（地面を分断）
+            // ※ メインの地面コライダーをそのまま使い、穴はキルゾーンで対応
+            GameObject killZone = new GameObject($"KillZone_{gapWidth}m");
+            killZone.transform.position = centerPos + Vector3.down * 4f;
+            BoxCollider2D killCol = killZone.AddComponent<BoxCollider2D>();
+            killCol.isTrigger = true;
+            killCol.size = new Vector2(gapWidth, 4f);
+        }
+
+        private static void CreatePlatform(string name, Vector3 position, Vector2 size)
+        {
+            GameObject platform = new GameObject($"[PLACEHOLDER]{name}");
+            platform.layer = 6;
+            platform.transform.position = position;
+
+            BoxCollider2D col = platform.AddComponent<BoxCollider2D>();
+            col.size = size;
+
+            SpriteRenderer sr = platform.AddComponent<SpriteRenderer>();
+            sr.sprite = CreateSquareSprite(new Color(0.45f, 0.45f, 0.45f));
+            sr.drawMode = SpriteDrawMode.Tiled;
+            sr.size = size;
+            sr.sortingOrder = -9;
+        }
+
+        private static void CreateWall(string name, Vector3 position, Vector2 size)
+        {
+            GameObject wall = new GameObject($"[PLACEHOLDER]{name}");
+            wall.layer = 6;
+            wall.transform.position = position;
+
+            BoxCollider2D col = wall.AddComponent<BoxCollider2D>();
+            col.size = size;
+
+            SpriteRenderer sr = wall.AddComponent<SpriteRenderer>();
+            sr.sprite = CreateSquareSprite(new Color(0.35f, 0.35f, 0.35f));
+            sr.drawMode = SpriteDrawMode.Tiled;
+            sr.size = size;
+            sr.sortingOrder = -9;
+        }
+
+        // ===== キャラクター =====
+
+        /// <summary>
+        /// 摩擦ゼロのPhysicsMaterial2Dを生成する。
+        /// 壁タイル継ぎ目への引っかかりを防止する。
+        /// </summary>
+        private static PhysicsMaterial2D CreateNoFrictionMaterial()
+        {
+            PhysicsMaterial2D mat = new PhysicsMaterial2D("NoFriction");
+            mat.friction = 0f;
+            mat.bounciness = 0f;
+            return mat;
+        }
+
+        private static GameObject CreatePlayer(CharacterInfo info,
+            AnimatorController animController, AttackInfo[] attacks)
+        {
+            GameObject player = new GameObject("[PLACEHOLDER]Player");
+            player.tag = "Player";
+            player.layer = GameConstants.k_LayerCharaPassThrough;
+            player.transform.position = new Vector3(-6f, 2f, 0f);
+
+            // 物理
+            Rigidbody2D rb = player.AddComponent<Rigidbody2D>();
+            rb.gravityScale = GameConstants.k_GravityScale;
+            rb.constraints = RigidbodyConstraints2D.FreezeRotation;
+            rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+
+            BoxCollider2D col = player.AddComponent<BoxCollider2D>();
+            col.size = new Vector2(0.6f, 0.9f);
+            col.offset = new Vector2(0f, 0.45f);
+            col.sharedMaterial = CreateNoFrictionMaterial();
+
+            // ビジュアル（白スクエア＝プレイヤー）
+            SpriteRenderer sr = player.AddComponent<SpriteRenderer>();
+            sr.sprite = CreateSquareSprite(Color.white);
+            sr.drawMode = SpriteDrawMode.Tiled;
+            sr.size = new Vector2(0.6f, 0.9f);
+            sr.sortingOrder = 10;
+
+            // Animator + AnimationController
+            Animator animator = player.AddComponent<Animator>();
+            animator.runtimeAnimatorController = animController;
+            player.AddComponent<CharacterAnimationController>();
+
+            // InputSystem
+            UnityEngine.InputSystem.PlayerInput pi = player.AddComponent<UnityEngine.InputSystem.PlayerInput>();
+            pi.notificationBehavior = UnityEngine.InputSystem.PlayerNotifications.SendMessages;
+            UnityEngine.InputSystem.InputActionAsset inputActions =
+                AssetDatabase.LoadAssetAtPath<UnityEngine.InputSystem.InputActionAsset>(
+                    "Assets/InputSystem_Actions.inputactions");
+            if (inputActions != null)
+            {
+                pi.actions = inputActions;
+                pi.defaultActionMap = "Player";
+            }
+
+            // コンポーネント
+            player.AddComponent<PlayerInputHandler>();
+            PlayerCharacter pc = player.AddComponent<PlayerCharacter>();
+            player.AddComponent<DamageReceiver>();
+            player.AddComponent<CharacterCollisionController>();
+            player.AddComponent<AudioSource>(); // 落下攻撃着地SE等に使用
+
+            // ActionExecutorController（攻撃実行の正規ルート）
+            ActionExecutorController actionExec = player.AddComponent<ActionExecutorController>();
+            SetPrivateField(actionExec, "_attackInfos", attacks);
+
+            // PlayerCharacterにコンボ段数管理用データ参照をセット
+            SetPrivateField(pc, "_lightAttacks", attacks);
+
+            SetCharacterInfoField(pc, info);
+
+            // 攻撃ヒットボックス（子オブジェクト）
+            CreateHitbox(player, "[PLACEHOLDER]PlayerHitbox",
+                new Vector3(0.7f, 0.5f, 0f), new Vector2(0.8f, 0.6f),
+                10, new Color(1f, 1f, 0f, 0.3f));
+
+            return player;
+        }
+
+        private static GameObject CreateCompanion(CharacterInfo info,
+            Transform playerTransform, AnimatorController animController,
+            AttackInfo[] attacks, AIInfo aiInfo)
+        {
+            GameObject companion = new GameObject("[PLACEHOLDER]Companion");
+            companion.layer = GameConstants.k_LayerCharaPassThrough;
+            companion.transform.position = new Vector3(-8f, 2f, 0f);
+
+            // 物理
+            Rigidbody2D rb = companion.AddComponent<Rigidbody2D>();
+            rb.gravityScale = GameConstants.k_GravityScale;
+            rb.constraints = RigidbodyConstraints2D.FreezeRotation;
+            rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+
+            BoxCollider2D col = companion.AddComponent<BoxCollider2D>();
+            col.size = new Vector2(0.5f, 0.8f);
+            col.offset = new Vector2(0f, 0.4f);
+            col.sharedMaterial = CreateNoFrictionMaterial();
+
+            // ビジュアル（水色スクエア＝仲間）
+            SpriteRenderer sr = companion.AddComponent<SpriteRenderer>();
+            sr.sprite = CreateSquareSprite(new Color(0.3f, 0.7f, 1f));
+            sr.drawMode = SpriteDrawMode.Tiled;
+            sr.size = new Vector2(0.5f, 0.8f);
+            sr.sortingOrder = 9;
+
+            // Animator + AnimationController
+            Animator animator = companion.AddComponent<Animator>();
+            animator.runtimeAnimatorController = animController;
+            companion.AddComponent<CharacterAnimationController>();
+
+            // コンポーネント
+            CompanionCharacter cc = companion.AddComponent<CompanionCharacter>();
+            companion.AddComponent<DamageReceiver>();
+            companion.AddComponent<CharacterCollisionController>();
+
+            // AI: CompanionController（フルAIシステム）で駆動
+            cc.SetAIInfo(aiInfo);
+
+            // CompanionMpSettings（デフォルト値）
+            CompanionMpSettings mpSettings = new CompanionMpSettings
+            {
+                baseRecoveryRate = 3f,
+                mpRecoverActionRate = 8f,
+                vanishRecoveryMultiplier = 1.3f,
+                returnThresholdRatio = 0.5f,
+                maxReserveMp = 100,
+            };
+            cc.SetMpSettings(mpSettings);
+
+            // ActionExecutorController（ヒットボックス・アニメーション駆動）
+            ActionExecutorController actionExec = companion.AddComponent<ActionExecutorController>();
+            SetPrivateField(actionExec, "_attackInfos", attacks);
+
+            SetCharacterInfoField(cc, info);
+
+            // _playerTransformをリフレクションで設定
+            System.Type type = typeof(CompanionCharacter);
+            System.Reflection.FieldInfo playerField = type.GetField("_playerTransform",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            if (playerField != null)
+            {
+                playerField.SetValue(cc, playerTransform);
+            }
+
+            // 攻撃ヒットボックス
+            CreateHitbox(companion, "[PLACEHOLDER]CompanionHitbox",
+                new Vector3(0.5f, 0.4f, 0f), new Vector2(0.6f, 0.5f),
+                10, new Color(0.3f, 0.7f, 1f, 0.2f));
+
+            return companion;
+        }
+
+        private static GameObject CreateEnemy(CharacterInfo info, string name, Vector3 position,
+            AnimatorController animController, AttackInfo[] attacks, AIInfo aiInfo)
+        {
+            GameObject enemy = new GameObject($"[PLACEHOLDER]{name}");
+            enemy.layer = GameConstants.k_LayerCharaPassThrough;
+            enemy.transform.position = position;
+
+            // 物理
+            Rigidbody2D rb = enemy.AddComponent<Rigidbody2D>();
+            rb.gravityScale = GameConstants.k_GravityScale;
+            rb.constraints = RigidbodyConstraints2D.FreezeRotation;
+            rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+
+            BoxCollider2D col = enemy.AddComponent<BoxCollider2D>();
+            col.size = new Vector2(0.5f, 0.8f);
+            col.offset = new Vector2(0f, 0.4f);
+            col.sharedMaterial = CreateNoFrictionMaterial();
+
+            // ビジュアル（赤スクエア＝敵）
+            SpriteRenderer sr = enemy.AddComponent<SpriteRenderer>();
+            sr.sprite = CreateSquareSprite(new Color(0.9f, 0.2f, 0.2f));
+            sr.drawMode = SpriteDrawMode.Tiled;
+            sr.size = new Vector2(0.5f, 0.8f);
+            sr.sortingOrder = 8;
+
+            // Animator + AnimationController
+            Animator animator = enemy.AddComponent<Animator>();
+            animator.runtimeAnimatorController = animController;
+            enemy.AddComponent<CharacterAnimationController>();
+
+            // コンポーネント
+            EnemyCharacter ec = enemy.AddComponent<EnemyCharacter>();
+            enemy.AddComponent<DamageReceiver>();
+            enemy.AddComponent<CharacterCollisionController>();
+
+            // AI: EnemyController（ピュアロジック）で駆動
+            ec.SetAIInfo(aiInfo);
+
+            // ActionExecutorController（ヒットボックス・アニメーション駆動）
+            ActionExecutorController actionExec = enemy.AddComponent<ActionExecutorController>();
+            SetPrivateField(actionExec, "_attackInfos", attacks);
+
+            SetCharacterInfoField(ec, info);
+
+            // 攻撃ヒットボックス
+            CreateHitbox(enemy, $"[PLACEHOLDER]{name}Hitbox",
+                new Vector3(0.5f, 0.4f, 0f), new Vector2(0.6f, 0.5f),
+                11, new Color(1f, 0.3f, 0.3f, 0.2f));
+
+            return enemy;
+        }
+
+        private static GameObject CreateBossEnemy(CharacterInfo info, string name, Vector3 position,
+            AnimatorController animController, AttackInfo[] attacks, AIInfo aiInfo)
+        {
+            GameObject boss = new GameObject($"[PLACEHOLDER]{name}");
+            boss.layer = GameConstants.k_LayerCharaPassThrough;
+            boss.transform.position = position;
+
+            // 物理
+            Rigidbody2D rb = boss.AddComponent<Rigidbody2D>();
+            rb.gravityScale = GameConstants.k_GravityScale;
+            rb.constraints = RigidbodyConstraints2D.FreezeRotation;
+            rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+
+            BoxCollider2D col = boss.AddComponent<BoxCollider2D>();
+            col.size = new Vector2(1.2f, 1.6f);
+            col.offset = new Vector2(0f, 0.8f);
+            col.sharedMaterial = CreateNoFrictionMaterial();
+
+            // ビジュアル（濃い赤＝ボス、大きめ）
+            SpriteRenderer sr = boss.AddComponent<SpriteRenderer>();
+            sr.sprite = CreateSquareSprite(new Color(0.7f, 0.1f, 0.15f));
+            sr.drawMode = SpriteDrawMode.Tiled;
+            sr.size = new Vector2(1.2f, 1.6f);
+            sr.sortingOrder = 8;
+
+            // Animator + AnimationController
+            Animator animator = boss.AddComponent<Animator>();
+            animator.runtimeAnimatorController = animController;
+            boss.AddComponent<CharacterAnimationController>();
+
+            // コンポーネント
+            EnemyCharacter ec = boss.AddComponent<EnemyCharacter>();
+            boss.AddComponent<DamageReceiver>();
+            boss.AddComponent<CharacterCollisionController>();
+
+            // AI: EnemyController（ピュアロジック）で駆動（検出範囲はAIInfoで設定）
+            ec.SetAIInfo(aiInfo);
+
+            // ActionExecutorController（ヒットボックス・アニメーション駆動）
+            ActionExecutorController actionExec = boss.AddComponent<ActionExecutorController>();
+            SetPrivateField(actionExec, "_attackInfos", attacks);
+
+            SetCharacterInfoField(ec, info);
+
+            // 攻撃ヒットボックス（大きめ）
+            CreateHitbox(boss, $"[PLACEHOLDER]{name}Hitbox",
+                new Vector3(0.8f, 0.8f, 0f), new Vector2(1.0f, 0.8f),
+                11, new Color(1f, 0.2f, 0.2f, 0.25f));
+
+            return boss;
+        }
+
+        private static void CreateHitbox(GameObject parent, string name,
+            Vector3 localPos, Vector2 size, int layer, Color debugColor)
+        {
+            GameObject hitbox = new GameObject(name);
+            hitbox.transform.SetParent(parent.transform);
+            hitbox.transform.localPosition = localPos;
+            hitbox.layer = layer;
+
+            BoxCollider2D hitCol = hitbox.AddComponent<BoxCollider2D>();
+            hitCol.isTrigger = true;
+            hitCol.size = size;
+
+            hitbox.AddComponent<HitBox>();
+            hitbox.AddComponent<DamageDealer>();
+
+            // デバッグ可視化
+            SpriteRenderer hitSr = hitbox.AddComponent<SpriteRenderer>();
+            hitSr.sprite = CreateSquareSprite(debugColor);
+            hitSr.drawMode = SpriteDrawMode.Tiled;
+            hitSr.size = size;
+            hitSr.sortingOrder = 11;
+        }
+
+        // ===== カメラ =====
+
+        private static void SetupCamera(Transform playerTransform)
+        {
+            Camera mainCam = Camera.main;
+            if (mainCam == null)
+            {
+                return;
+            }
+
+            mainCam.orthographic = true;
+            mainCam.orthographicSize = 7f;
+            mainCam.backgroundColor = new Color(0.12f, 0.12f, 0.18f);
+            mainCam.transform.position = new Vector3(0f, 3f, -10f);
+
+            CameraController cc = mainCam.gameObject.AddComponent<CameraController>();
+
+            // EditorモードではAwake()が走らないため、SerializedObjectでフィールドを設定
+            SerializedObject so = new SerializedObject(cc);
+            SerializedProperty targetProp = so.FindProperty("_target");
+            targetProp.objectReferenceValue = playerTransform;
+            so.ApplyModifiedPropertiesWithoutUndo();
+        }
+
+        // ===== UI =====
+
+        private static void SetupHUD()
+        {
+            GameObject hudObj = new GameObject("[PLACEHOLDER]HUD");
+
+            UIDocument uiDoc = hudObj.AddComponent<UIDocument>();
+
+            // UXML
+            VisualTreeAsset hudUxml = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(
+                "Assets/MyAsset/UI/HUD/HUD.uxml");
+            if (hudUxml != null)
+            {
+                uiDoc.visualTreeAsset = hudUxml;
+            }
+            else
+            {
+                Debug.LogWarning("[TestSceneBuilder] HUD.uxml が見つかりません。HUDは空になります。");
+            }
+
+            // PanelSettings
+            PanelSettings panelSettings = AssetDatabase.LoadAssetAtPath<PanelSettings>(
+                "Assets/MyAsset/UI/GamePanelSettings.asset");
+            if (panelSettings != null)
+            {
+                uiDoc.panelSettings = panelSettings;
+            }
+
+            hudObj.AddComponent<HudController>();
+        }
+
+        private static void SetupDamagePopups()
+        {
+            GameObject popupObj = new GameObject("[PLACEHOLDER]DamagePopups");
+            popupObj.AddComponent<DamagePopupController>();
+        }
+
+        // ===== エリアラベル =====
+
+        private static void CreateAreaLabel(string text, Vector3 position)
+        {
+            GameObject label = new GameObject($"Label_{text}");
+            label.transform.position = position;
+
+            TextMesh tm = label.AddComponent<TextMesh>();
+            tm.text = text;
+            tm.fontSize = 24;
+            tm.characterSize = 0.15f;
+            tm.anchor = TextAnchor.MiddleCenter;
+            tm.alignment = TextAlignment.Center;
+            tm.color = new Color(1f, 1f, 1f, 0.5f);
+
+            // SortingOrderが効くようにMeshRendererを設定
+            MeshRenderer mr = label.GetComponent<MeshRenderer>();
+            if (mr != null)
+            {
+                mr.sortingOrder = 20;
+            }
+        }
+
+        // ===== 物理レイヤー衝突設定 =====
+
+        private static void SetupPhysicsLayers()
+        {
+            // CollisionMatrixSetup の正規設定を適用
+            // 全キャラクターは CharaPassThrough(12) / CharaCollide(13) / CharaInvincible(14) を使用
+            // 味方/敵の区別はレイヤーではなくHitBox内の陣営チェック(CharacterBelong)で行う
+            CollisionMatrixSetup.SetupCollisionMatrix();
+
+            // 追加: Hitbox同士はGround(6)と衝突しない
+            Physics2D.IgnoreLayerCollision(10, 6, true);
+            Physics2D.IgnoreLayerCollision(11, 6, true);
+            // PlayerHitbox(10) と EnemyHitbox(11) は衝突しない
+            Physics2D.IgnoreLayerCollision(10, 11, true);
+        }
+
+        // ===== ユーティリティ =====
+
+        private static void SetupLayers()
+        {
+            SerializedObject tagManager = new SerializedObject(
+                AssetDatabase.LoadMainAssetAtPath("ProjectSettings/TagManager.asset"));
+            SerializedProperty layers = tagManager.FindProperty("layers");
+
+            SetLayerIfEmpty(layers, 6, "Ground");
+            SetLayerIfEmpty(layers, 7, "Player");
+            SetLayerIfEmpty(layers, 8, "Enemy");
+            SetLayerIfEmpty(layers, 9, "Companion");
+            SetLayerIfEmpty(layers, 10, "PlayerHitbox");
+            SetLayerIfEmpty(layers, 11, "EnemyHitbox");
+            SetLayerIfEmpty(layers, 12, "CharaPassThrough");
+            SetLayerIfEmpty(layers, 13, "CharaCollide");
+            SetLayerIfEmpty(layers, 14, "CharaInvincible");
+
+            tagManager.ApplyModifiedProperties();
+        }
+
+        private static void SetLayerIfEmpty(SerializedProperty layers, int index, string name)
+        {
+            SerializedProperty layer = layers.GetArrayElementAtIndex(index);
+            if (string.IsNullOrEmpty(layer.stringValue))
+            {
+                layer.stringValue = name;
+            }
+        }
+
+        private static Sprite CreateSquareSprite(Color color)
+        {
+            Texture2D tex = new Texture2D(k_SquareSize, k_SquareSize);
+            Color[] pixels = new Color[k_SquareSize * k_SquareSize];
+            for (int i = 0; i < pixels.Length; i++)
+            {
+                pixels[i] = color;
+            }
+            tex.SetPixels(pixels);
+            tex.Apply();
+            tex.filterMode = FilterMode.Point;
+            tex.wrapMode = TextureWrapMode.Repeat;
+
+            return Sprite.Create(tex,
+                new Rect(0, 0, k_SquareSize, k_SquareSize),
+                new Vector2(0.5f, 0f),
+                k_Ppu);
+        }
+
+        private static void SetCharacterInfoField(BaseCharacter character, CharacterInfo info)
+        {
+            if (info == null)
+            {
+                return;
+            }
+
+            System.Type type = typeof(BaseCharacter);
+            System.Reflection.FieldInfo field = type.GetField("_characterInfo",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            if (field != null)
+            {
+                field.SetValue(character, info);
+            }
+        }
+
+        private static void SetPrivateField<T>(object target, string fieldName, T value)
+        {
+            System.Type type = target.GetType();
+            System.Reflection.FieldInfo field = type.GetField(fieldName,
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            if (field != null)
+            {
+                field.SetValue(target, value);
+            }
+        }
+
+        private static CharacterInfo LoadOrWarnCharacterInfo(string path)
+        {
+            CharacterInfo info = AssetDatabase.LoadAssetAtPath<CharacterInfo>(path);
+            if (info == null)
+            {
+                Debug.LogWarning($"[TestSceneBuilder] {path} が見つかりません。シーン構築後に手動で設定してください。");
+            }
+            return info;
+        }
+
+        private static void EnsureDirectoryExists(string path)
+        {
+            if (!AssetDatabase.IsValidFolder(path))
+            {
+                string parent = System.IO.Path.GetDirectoryName(path).Replace("\\", "/");
+                string folder = System.IO.Path.GetFileName(path);
+                if (!AssetDatabase.IsValidFolder(parent))
+                {
+                    EnsureDirectoryExists(parent);
+                }
+                AssetDatabase.CreateFolder(parent, folder);
+            }
+        }
+    }
+}

--- a/Assets/MyAsset/Editor/TestSceneBuilder.cs.meta
+++ b/Assets/MyAsset/Editor/TestSceneBuilder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c0afbb801f1e42349b5e40b9f7b98dfe

--- a/Assets/MyAsset/Runtime/Animation/CharacterAnimationController.cs
+++ b/Assets/MyAsset/Runtime/Animation/CharacterAnimationController.cs
@@ -31,12 +31,18 @@ namespace Game.Runtime
 
         private void OnEnable()
         {
-            _bridge.OnPhaseChanged += HandlePhaseChanged;
+            if (_bridge != null)
+            {
+                _bridge.OnPhaseChanged += HandlePhaseChanged;
+            }
         }
 
         private void OnDisable()
         {
-            _bridge.OnPhaseChanged -= HandlePhaseChanged;
+            if (_bridge != null)
+            {
+                _bridge.OnPhaseChanged -= HandlePhaseChanged;
+            }
         }
 
         /// <summary>
@@ -78,7 +84,7 @@ namespace Game.Runtime
 
         private void Update()
         {
-            if (!_isInitialized)
+            if (!_isInitialized || _bridge == null)
             {
                 return;
             }

--- a/Assets/MyAsset/Runtime/Camera/CameraController.cs
+++ b/Assets/MyAsset/Runtime/Camera/CameraController.cs
@@ -40,7 +40,7 @@ namespace Game.Runtime
 
         private void LateUpdate()
         {
-            if (_target == null)
+            if (_target == null || _logic == null)
             {
                 return;
             }

--- a/Assets/MyAsset/Runtime/Character/BaseCharacter.cs
+++ b/Assets/MyAsset/Runtime/Character/BaseCharacter.cs
@@ -27,6 +27,7 @@ namespace Game.Runtime
 
         public int ObjectHash => _objectHash;
         public bool IsGrounded => _isGrounded;
+        public CharacterInfo CharacterInfoRef => _characterInfo;
         public bool IsAlive
         {
             get
@@ -94,6 +95,13 @@ namespace Game.Runtime
                     _characterInfo.maxArmor,
                     _characterInfo.armorRecoveryRate,
                     _characterInfo.armorRecoveryDelay);
+            }
+
+            // CharacterAnimationControllerの初期化（ownerHashとの紐付け）
+            CharacterAnimationController animController = GetComponent<CharacterAnimationController>();
+            if (animController != null)
+            {
+                animController.Initialize(_objectHash);
             }
         }
 

--- a/Assets/MyAsset/Runtime/Character/BaseCharacter.cs
+++ b/Assets/MyAsset/Runtime/Character/BaseCharacter.cs
@@ -171,6 +171,61 @@ namespace Game.Runtime
         }
 
         /// <summary>
+        /// AI内部ExecutorのAttack/Castアクションを
+        /// ActionExecutorController（MonoBehaviour側）に橋渡しする共通ヘルパー。
+        /// 橋渡し成功後にAI側のアクションをForceCompleteして二重実行を防ぐ。
+        /// </summary>
+        protected static void BridgeAIActionToExecutor(
+            ActionExecutor aiExecutor, ActionExecutorController monoExecutor, int targetHash)
+        {
+            if (aiExecutor == null || !aiExecutor.IsExecuting)
+            {
+                return;
+            }
+
+            if (monoExecutor.IsExecuting)
+            {
+                return;
+            }
+
+            ActionBase current = aiExecutor.CurrentAction;
+            if (current == null)
+            {
+                return;
+            }
+
+            ActionSlot slot;
+            if (current is AttackActionHandler attackHandler)
+            {
+                slot = new ActionSlot
+                {
+                    execType = ActionExecType.Attack,
+                    paramId = attackHandler.LastParamId,
+                    paramValue = 1f
+                };
+            }
+            else if (current is CastActionHandler castHandler)
+            {
+                slot = new ActionSlot
+                {
+                    execType = ActionExecType.Cast,
+                    paramId = castHandler.LastParamId,
+                    paramValue = 1f
+                };
+            }
+            else
+            {
+                return;
+            }
+
+            bool result = monoExecutor.ExecuteAction(slot, targetHash);
+            if (result)
+            {
+                current.ForceComplete();
+            }
+        }
+
+        /// <summary>
         /// キャラクターの向きを設定する。localScale.xの符号で方向を表現。
         /// </summary>
         protected bool _isFacingRight = true;

--- a/Assets/MyAsset/Runtime/Character/CompanionCharacter.cs
+++ b/Assets/MyAsset/Runtime/Character/CompanionCharacter.cs
@@ -25,12 +25,13 @@ namespace Game.Runtime
         [SerializeField] private Transform _playerTransform;
 
         private ActionExecutorController _actionExecutorController;
+        private SpriteRenderer _spriteRenderer;
 
         // AI（ピュアロジック）
         private CompanionController _aiController;
 
-        // 候補リスト再利用（GC回避）
-        private static readonly List<int> s_Candidates = new List<int>(8);
+        // 候補リスト再利用（GC回避、インスタンスごとに保持）
+        private readonly List<int> _candidates = new List<int>(8);
 
         public CompanionController AIController => _aiController;
 
@@ -44,6 +45,7 @@ namespace Game.Runtime
         {
             base.Awake();
             _actionExecutorController = GetComponent<ActionExecutorController>();
+            _spriteRenderer = GetComponent<SpriteRenderer>();
         }
 
         protected override void Start()
@@ -117,18 +119,18 @@ namespace Game.Runtime
             if (_aiController != null)
             {
                 // 候補リスト構築（敵ハッシュ）
-                s_Candidates.Clear();
+                _candidates.Clear();
                 List<int> enemies = CharacterRegistry.EnemyHashes;
                 if (enemies != null)
                 {
                     for (int i = 0; i < enemies.Count; i++)
                     {
-                        s_Candidates.Add(enemies[i]);
+                        _candidates.Add(enemies[i]);
                     }
                 }
 
                 // AI Tick（MP回復 → 追従判定 → モード遷移 → 行動判定）
-                _aiController.Tick(Time.fixedDeltaTime, s_Candidates, Time.time);
+                _aiController.Tick(Time.fixedDeltaTime, _candidates, Time.time);
 
                 // AI が選択したアクションを ActionExecutorController に橋渡し
                 BridgeAIAction();
@@ -145,10 +147,6 @@ namespace Game.Runtime
             SyncPositionToData();
         }
 
-        /// <summary>
-        /// CompanionController内部のActionExecutorがAttack/Castを実行した場合、
-        /// ActionExecutorController（MonoBehaviour側）に橋渡しする。
-        /// </summary>
         private void BridgeAIAction()
         {
             if (_actionExecutorController == null || _aiController == null)
@@ -157,53 +155,8 @@ namespace Game.Runtime
             }
 
             ActionExecutor aiExecutor = _aiController.JudgmentLoop?.Executor;
-            if (aiExecutor == null || !aiExecutor.IsExecuting)
-            {
-                return;
-            }
-
-            // MonoBehaviour側が既に実行中なら橋渡ししない
-            if (_actionExecutorController.IsExecuting)
-            {
-                return;
-            }
-
-            ActionBase current = aiExecutor.CurrentAction;
-            if (current == null)
-            {
-                return;
-            }
-
-            if (current is AttackActionHandler attackHandler)
-            {
-                ActionSlot slot = new ActionSlot
-                {
-                    execType = ActionExecType.Attack,
-                    paramId = attackHandler.LastParamId,
-                    paramValue = 1f
-                };
-                int targetHash = _aiController.JudgmentLoop.CurrentTargetHash;
-                bool result = _actionExecutorController.ExecuteAction(slot, targetHash);
-                if (result)
-                {
-                    current.ForceComplete();
-                }
-            }
-            else if (current is CastActionHandler castHandler)
-            {
-                ActionSlot slot = new ActionSlot
-                {
-                    execType = ActionExecType.Cast,
-                    paramId = castHandler.LastParamId,
-                    paramValue = 1f
-                };
-                int targetHash = _aiController.JudgmentLoop.CurrentTargetHash;
-                bool result = _actionExecutorController.ExecuteAction(slot, targetHash);
-                if (result)
-                {
-                    current.ForceComplete();
-                }
-            }
+            int targetHash = _aiController.JudgmentLoop?.CurrentTargetHash ?? 0;
+            BridgeAIActionToExecutor(aiExecutor, _actionExecutorController, targetHash);
         }
 
         /// <summary>
@@ -270,12 +223,10 @@ namespace Game.Runtime
 
             float diff = targetVitals.position.x - myVitals.position.x;
             float absDist = Mathf.Abs(diff);
-            float attackRange = 1.5f;
-
-            if (absDist > attackRange)
+            if (absDist > GameConstants.k_DefaultAttackRange)
             {
                 float dir = diff > 0f ? 1f : -1f;
-                float speed = moveParams.moveSpeed > 0f ? moveParams.moveSpeed : 3f;
+                float speed = moveParams.moveSpeed > 0f ? moveParams.moveSpeed : GameConstants.k_FallbackMoveSpeed;
                 _rb.linearVelocity = new Vector2(dir * speed, _rb.linearVelocity.y);
                 SetFacing(dir > 0f);
             }
@@ -313,17 +264,16 @@ namespace Game.Runtime
         {
             Vector2 myPos = (Vector2)transform.position;
             Vector2 playerPos = (Vector2)_playerTransform.position;
-            float dist = Vector2.Distance(myPos, playerPos);
+            float sqrDist = (myPos - playerPos).sqrMagnitude;
 
-            if (dist > _maxLeashDistance)
+            if (sqrDist > _maxLeashDistance * _maxLeashDistance)
             {
-                // テレポート
                 Vector2 teleportPos = playerPos + new Vector2(
                     _isFacingRight ? -_followDistance : _followDistance, 0f);
                 transform.position = (Vector3)teleportPos;
                 _rb.linearVelocity = Vector2.zero;
             }
-            else if (dist > _followDistance)
+            else if (sqrDist > _followDistance * _followDistance)
             {
                 // 追従
                 ref MoveParams moveParams = ref GameManager.Data.GetMoveParams(ObjectHash);
@@ -340,7 +290,7 @@ namespace Game.Runtime
         private void OnCompanionVanish()
         {
             // MP=0消滅: 半透明化
-            SpriteRenderer sr = GetComponent<SpriteRenderer>();
+            SpriteRenderer sr = _spriteRenderer;
             if (sr != null)
             {
                 Color c = sr.color;
@@ -352,7 +302,7 @@ namespace Game.Runtime
         private void OnCompanionReturn()
         {
             // 復帰: 不透明に戻す
-            SpriteRenderer sr = GetComponent<SpriteRenderer>();
+            SpriteRenderer sr = _spriteRenderer;
             if (sr != null)
             {
                 Color c = sr.color;

--- a/Assets/MyAsset/Runtime/Character/CompanionCharacter.cs
+++ b/Assets/MyAsset/Runtime/Character/CompanionCharacter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using Game.Core;
 
@@ -5,21 +6,44 @@ namespace Game.Runtime
 {
     /// <summary>
     /// 仲間キャラクターMonoBehaviour。
-    /// FollowBehavior純ロジックでプレイヤーを追従する。
+    /// CompanionController（ピュアロジック）を保持してフルAIを駆動する。
+    /// FollowBehavior + JudgmentLoop + ModeController + StanceManager + CompanionMpManager を統合。
+    ///
+    /// AI判定フロー:
+    ///   CompanionController.Tick() → MP回復 → FollowBehavior → ModeController → JudgmentLoop
+    ///   → 内部ActionExecutor.Execute() → BridgeAIAction() で ActionExecutorController に橋渡し
     /// </summary>
     public class CompanionCharacter : BaseCharacter
     {
+        [Header("AI設定")]
+        [SerializeField] private AIInfo _aiInfo;
+        [SerializeField] private CompanionMpSettings _mpSettings;
+
         [Header("追従設定")]
         [SerializeField] private float _followDistance = 2.0f;
         [SerializeField] private float _maxLeashDistance = 15.0f;
         [SerializeField] private Transform _playerTransform;
 
-        private FollowBehavior _followBehavior;
+        private ActionExecutorController _actionExecutorController;
+
+        // AI（ピュアロジック）
+        private CompanionController _aiController;
+
+        // 候補リスト再利用（GC回避）
+        private static readonly List<int> s_Candidates = new List<int>(8);
+
+        public CompanionController AIController => _aiController;
+
+        /// <summary>テスト/エディタ用: AIInfoを設定する。</summary>
+        public void SetAIInfo(AIInfo aiInfo) { _aiInfo = aiInfo; }
+
+        /// <summary>テスト/エディタ用: CompanionMpSettingsを設定する。</summary>
+        public void SetMpSettings(CompanionMpSettings settings) { _mpSettings = settings; }
 
         protected override void Awake()
         {
             base.Awake();
-            _followBehavior = new FollowBehavior(_followDistance, _maxLeashDistance);
+            _actionExecutorController = GetComponent<ActionExecutorController>();
         }
 
         protected override void Start()
@@ -36,6 +60,49 @@ namespace Game.Runtime
                     _playerTransform = player.transform;
                 }
             }
+
+            InitializeAI();
+        }
+
+        private void InitializeAI()
+        {
+            if (_playerTransform == null || GameManager.Data == null)
+            {
+                return;
+            }
+
+            BaseCharacter playerBase = _playerTransform.GetComponent<BaseCharacter>();
+            int playerHash = playerBase != null ? playerBase.ObjectHash : 0;
+            if (playerHash == 0)
+            {
+                return;
+            }
+
+            // CharacterInfo から maxMp 取得
+            float maxMp = CharacterInfoRef != null ? CharacterInfoRef.maxMp : 50f;
+            int initialReserveMp = _mpSettings.maxReserveMp > 0 ? _mpSettings.maxReserveMp : 100;
+
+            _aiController = new CompanionController(
+                ObjectHash, playerHash, GameManager.Data,
+                maxMp, initialReserveMp, _mpSettings);
+
+            // AIモード設定
+            if (_aiInfo != null)
+            {
+                AIMode[] modes = AIInfoConverter.ConvertModes(_aiInfo);
+                ModeTransitionRule[] transitions = AIInfoConverter.ConvertTransitions(_aiInfo);
+
+                // AIInfoConverterは敵AI用（belong=Ally）なので、
+                // 仲間AI用にターゲットフィルタをEnemy陣営に反転する
+                FlipTargetBelongToEnemy(modes);
+
+                _aiController.SetAIModes(modes, transitions);
+                _aiController.FollowBehavior.SetDistances(_followDistance, _maxLeashDistance);
+            }
+
+            // イベント購読
+            _aiController.MpManager.OnVanish += OnCompanionVanish;
+            _aiController.MpManager.OnReturn += OnCompanionReturn;
         }
 
         private void FixedUpdate()
@@ -47,42 +114,281 @@ namespace Game.Runtime
 
             UpdateGroundCheck();
 
-            Vector2 myPos = (Vector2)transform.position;
-            Vector2 playerPos = (Vector2)_playerTransform.position;
-
-            FollowState state = _followBehavior.Evaluate(myPos, playerPos);
-
-            switch (state)
+            if (_aiController != null)
             {
-                case FollowState.Waiting:
-                    _rb.linearVelocity = new Vector2(0f, _rb.linearVelocity.y);
-                    break;
+                // 候補リスト構築（敵ハッシュ）
+                s_Candidates.Clear();
+                List<int> enemies = CharacterRegistry.EnemyHashes;
+                if (enemies != null)
+                {
+                    for (int i = 0; i < enemies.Count; i++)
+                    {
+                        s_Candidates.Add(enemies[i]);
+                    }
+                }
 
-                case FollowState.Following:
-                    Vector2 target = _followBehavior.GetFollowTarget(myPos, playerPos);
-                    ref MoveParams moveParams = ref GameManager.Data.GetMoveParams(ObjectHash);
+                // AI Tick（MP回復 → 追従判定 → モード遷移 → 行動判定）
+                _aiController.Tick(Time.fixedDeltaTime, s_Candidates, Time.time);
 
-                    float dir = target.x > myPos.x ? 1f : -1f;
-                    _rb.linearVelocity = new Vector2(dir * moveParams.moveSpeed * 0.8f, _rb.linearVelocity.y);
+                // AI が選択したアクションを ActionExecutorController に橋渡し
+                BridgeAIAction();
 
-                    // 向き更新
-                    SetFacing(dir > 0f);
-                    break;
-
-                case FollowState.Teleporting:
-                    Vector2 teleportPos = playerPos + new Vector2(_isFacingRight ? -_followDistance : _followDistance, 0f);
-                    transform.position = (Vector3)teleportPos;
-                    _rb.linearVelocity = Vector2.zero;
-                    break;
+                // 追従移動
+                ApplyFollowMovement();
+            }
+            else
+            {
+                // AI未初期化時はシンプル追従のみ
+                ApplySimpleFollow();
             }
 
             SyncPositionToData();
         }
 
+        /// <summary>
+        /// CompanionController内部のActionExecutorがAttack/Castを実行した場合、
+        /// ActionExecutorController（MonoBehaviour側）に橋渡しする。
+        /// </summary>
+        private void BridgeAIAction()
+        {
+            if (_actionExecutorController == null || _aiController == null)
+            {
+                return;
+            }
+
+            ActionExecutor aiExecutor = _aiController.JudgmentLoop?.Executor;
+            if (aiExecutor == null || !aiExecutor.IsExecuting)
+            {
+                return;
+            }
+
+            // MonoBehaviour側が既に実行中なら橋渡ししない
+            if (_actionExecutorController.IsExecuting)
+            {
+                return;
+            }
+
+            ActionBase current = aiExecutor.CurrentAction;
+            if (current == null)
+            {
+                return;
+            }
+
+            if (current is AttackActionHandler attackHandler)
+            {
+                ActionSlot slot = new ActionSlot
+                {
+                    execType = ActionExecType.Attack,
+                    paramId = attackHandler.LastParamId,
+                    paramValue = 1f
+                };
+                int targetHash = _aiController.JudgmentLoop.CurrentTargetHash;
+                bool result = _actionExecutorController.ExecuteAction(slot, targetHash);
+                if (result)
+                {
+                    current.ForceComplete();
+                }
+            }
+            else if (current is CastActionHandler castHandler)
+            {
+                ActionSlot slot = new ActionSlot
+                {
+                    execType = ActionExecType.Cast,
+                    paramId = castHandler.LastParamId,
+                    paramValue = 1f
+                };
+                int targetHash = _aiController.JudgmentLoop.CurrentTargetHash;
+                bool result = _actionExecutorController.ExecuteAction(slot, targetHash);
+                if (result)
+                {
+                    current.ForceComplete();
+                }
+            }
+        }
+
+        /// <summary>
+        /// FollowBehaviorの状態に基づいてRigidbody移動を適用する。
+        /// ActionExecutorControllerが攻撃中は移動しない。
+        /// </summary>
+        private void ApplyFollowMovement()
+        {
+            // 攻撃中は移動しない
+            if (_actionExecutorController != null && _actionExecutorController.IsExecuting)
+            {
+                _rb.linearVelocity = new Vector2(0f, _rb.linearVelocity.y);
+                return;
+            }
+
+            FollowState followState = _aiController.FollowBehavior.CurrentState;
+            Vector2 myPos = (Vector2)transform.position;
+            Vector2 playerPos = (Vector2)_playerTransform.position;
+
+            switch (followState)
+            {
+                case FollowState.Waiting:
+                    // ターゲットがいる場合はターゲットに向かって移動
+                    int targetHash = _aiController.JudgmentLoop?.CurrentTargetHash ?? 0;
+                    if (targetHash != 0 && GameManager.IsCharacterValid(targetHash))
+                    {
+                        MoveTowardTarget(targetHash);
+                    }
+                    else
+                    {
+                        _rb.linearVelocity = new Vector2(0f, _rb.linearVelocity.y);
+                    }
+                    break;
+
+                case FollowState.Following:
+                {
+                    Vector2 target = _aiController.FollowBehavior.GetFollowTarget(myPos, playerPos);
+                    ref MoveParams moveParams = ref GameManager.Data.GetMoveParams(ObjectHash);
+                    float dir = target.x > myPos.x ? 1f : -1f;
+                    _rb.linearVelocity = new Vector2(dir * moveParams.moveSpeed * 0.8f, _rb.linearVelocity.y);
+                    SetFacing(dir > 0f);
+                    break;
+                }
+
+                case FollowState.Teleporting:
+                {
+                    Vector2 teleportPos = playerPos + new Vector2(
+                        _isFacingRight ? -_followDistance : _followDistance, 0f);
+                    transform.position = (Vector3)teleportPos;
+                    _rb.linearVelocity = Vector2.zero;
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// ターゲットに向かって移動する（戦闘時）。
+        /// </summary>
+        private void MoveTowardTarget(int targetHash)
+        {
+            ref CharacterVitals targetVitals = ref GameManager.Data.GetVitals(targetHash);
+            ref CharacterVitals myVitals = ref GameManager.Data.GetVitals(ObjectHash);
+            ref MoveParams moveParams = ref GameManager.Data.GetMoveParams(ObjectHash);
+
+            float diff = targetVitals.position.x - myVitals.position.x;
+            float absDist = Mathf.Abs(diff);
+            float attackRange = 1.5f;
+
+            if (absDist > attackRange)
+            {
+                float dir = diff > 0f ? 1f : -1f;
+                float speed = moveParams.moveSpeed > 0f ? moveParams.moveSpeed : 3f;
+                _rb.linearVelocity = new Vector2(dir * speed, _rb.linearVelocity.y);
+                SetFacing(dir > 0f);
+            }
+            else
+            {
+                _rb.linearVelocity = new Vector2(0f, _rb.linearVelocity.y);
+                // 向きをターゲットに合わせる
+                SetFacing(diff > 0f);
+            }
+        }
+
+        /// <summary>
+        /// AIInfoConverterが生成したモードのターゲットフィルタを
+        /// Enemy陣営に差し替える（仲間AIは敵をターゲットにする）。
+        /// </summary>
+        private static void FlipTargetBelongToEnemy(AIMode[] modes)
+        {
+            for (int i = 0; i < modes.Length; i++)
+            {
+                if (modes[i].targetSelects == null)
+                {
+                    continue;
+                }
+                for (int j = 0; j < modes[i].targetSelects.Length; j++)
+                {
+                    modes[i].targetSelects[j].filter.belong = CharacterBelong.Enemy;
+                }
+            }
+        }
+
+        /// <summary>
+        /// AI未初期化時のシンプル追従（フォールバック）。
+        /// </summary>
+        private void ApplySimpleFollow()
+        {
+            Vector2 myPos = (Vector2)transform.position;
+            Vector2 playerPos = (Vector2)_playerTransform.position;
+            float dist = Vector2.Distance(myPos, playerPos);
+
+            if (dist > _maxLeashDistance)
+            {
+                // テレポート
+                Vector2 teleportPos = playerPos + new Vector2(
+                    _isFacingRight ? -_followDistance : _followDistance, 0f);
+                transform.position = (Vector3)teleportPos;
+                _rb.linearVelocity = Vector2.zero;
+            }
+            else if (dist > _followDistance)
+            {
+                // 追従
+                ref MoveParams moveParams = ref GameManager.Data.GetMoveParams(ObjectHash);
+                float dir = playerPos.x > myPos.x ? 1f : -1f;
+                _rb.linearVelocity = new Vector2(dir * moveParams.moveSpeed * 0.8f, _rb.linearVelocity.y);
+                SetFacing(dir > 0f);
+            }
+            else
+            {
+                _rb.linearVelocity = new Vector2(0f, _rb.linearVelocity.y);
+            }
+        }
+
+        private void OnCompanionVanish()
+        {
+            // MP=0消滅: 半透明化
+            SpriteRenderer sr = GetComponent<SpriteRenderer>();
+            if (sr != null)
+            {
+                Color c = sr.color;
+                c.a = 0.3f;
+                sr.color = c;
+            }
+        }
+
+        private void OnCompanionReturn()
+        {
+            // 復帰: 不透明に戻す
+            SpriteRenderer sr = GetComponent<SpriteRenderer>();
+            if (sr != null)
+            {
+                Color c = sr.color;
+                c.a = 1f;
+                sr.color = c;
+            }
+        }
+
         protected override void OnDestroy()
         {
+            if (_aiController?.MpManager != null)
+            {
+                _aiController.MpManager.OnVanish -= OnCompanionVanish;
+                _aiController.MpManager.OnReturn -= OnCompanionReturn;
+                _aiController.MpManager.Dispose();
+            }
+
+            if (_aiController?.StanceManager != null)
+            {
+                _aiController.StanceManager.Dispose();
+            }
+
             CharacterRegistry.Unregister(ObjectHash);
             base.OnDestroy();
+        }
+
+        public override void OnPoolReturn()
+        {
+            CharacterRegistry.Unregister(ObjectHash);
+            base.OnPoolReturn();
+        }
+
+        public override void OnPoolAcquire()
+        {
+            base.OnPoolAcquire();
+            CharacterRegistry.RegisterAlly(ObjectHash);
         }
     }
 }

--- a/Assets/MyAsset/Runtime/Character/EnemyCharacter.cs
+++ b/Assets/MyAsset/Runtime/Character/EnemyCharacter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using Game.Core;
 
@@ -5,25 +6,66 @@ namespace Game.Runtime
 {
     /// <summary>
     /// 敵キャラクターMonoBehaviour。
-    /// AI行動はEnemyControllerが担当する。
-    /// このクラスはSoA登録・接地判定・位置同期のみを行う。
+    /// SoA登録・接地判定・位置同期に加え、
+    /// EnemyController（ピュアロジック）を保持してAI行動を駆動する。
+    ///
+    /// AI判定フロー:
+    ///   EnemyController → JudgmentLoop → 内部ActionExecutor.Execute()
+    ///   → AttackActionHandler.LastParamId を検出
+    ///   → ActionExecutorController.ExecuteAction() でアニメ・ヒットボックスを駆動
     /// </summary>
     public class EnemyCharacter : BaseCharacter
     {
+        [SerializeField] private AIInfo _aiInfo;
+
         private DamageDealer _damageDealer;
+        private ActionExecutorController _actionExecutorController;
+
+        // AI（ピュアロジック）
+        private EnemyController _enemyController;
+
+        // 候補リスト再利用（GC回避）
+        private static readonly List<int> s_Candidates = new List<int>(8);
+
+        // AI → ActionExecutorController 橋渡し用
+        private int _lastAIParamId = -1;
+        private ActionExecType _lastAIExecType;
+        private bool _aiActionPending;
 
         public DamageDealer DamageDealer => _damageDealer;
+
+        /// <summary>テスト/エディタ用: AIInfoを設定する。</summary>
+        public void SetAIInfo(AIInfo aiInfo) { _aiInfo = aiInfo; }
 
         protected override void Awake()
         {
             base.Awake();
             _damageDealer = GetComponentInChildren<DamageDealer>();
+            _actionExecutorController = GetComponent<ActionExecutorController>();
         }
 
         protected override void Start()
         {
             base.Start();
             CharacterRegistry.RegisterEnemy(ObjectHash);
+            InitializeAI();
+        }
+
+        private void InitializeAI()
+        {
+            if (_aiInfo == null || GameManager.Data == null)
+            {
+                return;
+            }
+
+            _enemyController = new EnemyController(ObjectHash, GameManager.Data);
+
+            AIMode[] modes = AIInfoConverter.ConvertModes(_aiInfo);
+            ModeTransitionRule[] transitions = AIInfoConverter.ConvertTransitions(_aiInfo);
+            _enemyController.SetAIModes(modes, transitions);
+
+            // AI内部Executorのアクション実行を検知するために
+            // AttackActionHandlerを監視する
         }
 
         private void FixedUpdate()
@@ -34,7 +76,179 @@ namespace Game.Runtime
             }
 
             UpdateGroundCheck();
+
+            // AI Tick
+            if (_enemyController != null)
+            {
+                // 候補リスト構築（プレイヤー + 味方）
+                s_Candidates.Clear();
+                int playerHash = CharacterRegistry.PlayerHash;
+                if (playerHash != 0)
+                {
+                    s_Candidates.Add(playerHash);
+                }
+                List<int> allies = CharacterRegistry.AllyHashes;
+                if (allies != null)
+                {
+                    for (int i = 0; i < allies.Count; i++)
+                    {
+                        s_Candidates.Add(allies[i]);
+                    }
+                }
+
+                _enemyController.Tick(Time.fixedDeltaTime, s_Candidates, Time.time);
+
+                // AI が選択したアクションを ActionExecutorController に橋渡し
+                BridgeAIAction();
+
+                // 簡易移動: ターゲットへ追尾（Sustained/MoveアクションはAI側で別途処理）
+                UpdateMovement();
+            }
+
+            // 向き更新（ターゲット方向を向く）
+            UpdateFacingToTarget();
+
             SyncPositionToData();
+        }
+
+        /// <summary>
+        /// EnemyController内部のActionExecutorがAttack/Castを実行した場合、
+        /// ActionExecutorController（MonoBehaviour側）に橋渡しする。
+        /// 橋渡し成功後にAI側のアクションをForceCompleteして、
+        /// AI再評価との二重実行を防ぐ。
+        /// </summary>
+        private void BridgeAIAction()
+        {
+            if (_actionExecutorController == null || _enemyController == null)
+            {
+                return;
+            }
+
+            ActionExecutor aiExecutor = _enemyController.JudgmentLoop?.Executor;
+            if (aiExecutor == null || !aiExecutor.IsExecuting)
+            {
+                return;
+            }
+
+            // MonoBehaviour側が既に実行中なら橋渡ししない
+            if (_actionExecutorController.IsExecuting)
+            {
+                return;
+            }
+
+            ActionBase current = aiExecutor.CurrentAction;
+            if (current == null)
+            {
+                return;
+            }
+
+            // AttackActionHandler の場合、LastParamId で ActionSlot を再構築
+            if (current is AttackActionHandler attackHandler)
+            {
+                ActionSlot slot = new ActionSlot
+                {
+                    execType = ActionExecType.Attack,
+                    paramId = attackHandler.LastParamId,
+                    paramValue = 1f
+                };
+                int targetHash = _enemyController.JudgmentLoop.CurrentTargetHash;
+                bool result = _actionExecutorController.ExecuteAction(slot, targetHash);
+                if (result)
+                {
+                    // AI側のアクションを完了としてマーク
+                    // これにより次のAI評価で新しいアクションを選択可能になる
+                    current.ForceComplete();
+                }
+            }
+            else if (current is CastActionHandler castHandler)
+            {
+                ActionSlot slot = new ActionSlot
+                {
+                    execType = ActionExecType.Cast,
+                    paramId = castHandler.LastParamId,
+                    paramValue = 1f
+                };
+                int targetHash = _enemyController.JudgmentLoop.CurrentTargetHash;
+                bool result = _actionExecutorController.ExecuteAction(slot, targetHash);
+                if (result)
+                {
+                    current.ForceComplete();
+                }
+            }
+        }
+
+        /// <summary>
+        /// ターゲット方向に向く。
+        /// </summary>
+        private void UpdateFacingToTarget()
+        {
+            if (_enemyController == null || _enemyController.JudgmentLoop == null)
+            {
+                return;
+            }
+
+            int targetHash = _enemyController.JudgmentLoop.CurrentTargetHash;
+            if (targetHash == 0 || !GameManager.IsCharacterValid(targetHash))
+            {
+                return;
+            }
+
+            ref CharacterVitals targetVitals = ref GameManager.Data.GetVitals(targetHash);
+            ref CharacterVitals myVitals = ref GameManager.Data.GetVitals(ObjectHash);
+            float diff = targetVitals.position.x - myVitals.position.x;
+
+            if (diff > 0.1f)
+            {
+                SetFacing(true);
+            }
+            else if (diff < -0.1f)
+            {
+                SetFacing(false);
+            }
+        }
+
+        /// <summary>
+        /// ターゲットへの簡易追尾移動。
+        /// AI側がSustainedAction(Move)を選択した場合に対応。
+        /// ActionExecutorControllerが攻撃中は移動しない。
+        /// </summary>
+        private void UpdateMovement()
+        {
+            // 攻撃中は移動しない
+            if (_actionExecutorController != null && _actionExecutorController.IsExecuting)
+            {
+                _rb.linearVelocity = new Vector2(0f, _rb.linearVelocity.y);
+                return;
+            }
+
+            int targetHash = _enemyController.JudgmentLoop?.CurrentTargetHash ?? 0;
+            if (targetHash == 0 || !GameManager.IsCharacterValid(targetHash))
+            {
+                _rb.linearVelocity = new Vector2(0f, _rb.linearVelocity.y);
+                return;
+            }
+
+            ref CharacterVitals targetVitals = ref GameManager.Data.GetVitals(targetHash);
+            ref CharacterVitals myVitals = ref GameManager.Data.GetVitals(ObjectHash);
+            ref MoveParams moveParams = ref GameManager.Data.GetMoveParams(ObjectHash);
+
+            float diff = targetVitals.position.x - myVitals.position.x;
+            float absDist = Mathf.Abs(diff);
+
+            // 攻撃範囲の外ならターゲットへ移動
+            // AIInfoの検出範囲内かつ攻撃範囲外の場合に追尾
+            float attackRange = 1.5f; // デフォルト攻撃範囲
+
+            if (absDist > attackRange)
+            {
+                float dir = diff > 0f ? 1f : -1f;
+                float speed = moveParams.moveSpeed > 0f ? moveParams.moveSpeed : 3f;
+                _rb.linearVelocity = new Vector2(dir * speed, _rb.linearVelocity.y);
+            }
+            else
+            {
+                _rb.linearVelocity = new Vector2(0f, _rb.linearVelocity.y);
+            }
         }
 
         protected override void OnDestroy()
@@ -45,6 +259,10 @@ namespace Game.Runtime
 
         public override void OnPoolReturn()
         {
+            if (_enemyController != null)
+            {
+                _enemyController.Deactivate();
+            }
             CharacterRegistry.Unregister(ObjectHash);
             base.OnPoolReturn();
         }
@@ -53,6 +271,14 @@ namespace Game.Runtime
         {
             base.OnPoolAcquire();
             CharacterRegistry.RegisterEnemy(ObjectHash);
+            if (_enemyController != null)
+            {
+                _enemyController.Activate();
+            }
+            else
+            {
+                InitializeAI();
+            }
         }
     }
 }

--- a/Assets/MyAsset/Runtime/Character/EnemyCharacter.cs
+++ b/Assets/MyAsset/Runtime/Character/EnemyCharacter.cs
@@ -24,13 +24,8 @@ namespace Game.Runtime
         // AI（ピュアロジック）
         private EnemyController _enemyController;
 
-        // 候補リスト再利用（GC回避）
-        private static readonly List<int> s_Candidates = new List<int>(8);
-
-        // AI → ActionExecutorController 橋渡し用
-        private int _lastAIParamId = -1;
-        private ActionExecType _lastAIExecType;
-        private bool _aiActionPending;
+        // 候補リスト再利用（GC回避、インスタンスごとに保持）
+        private readonly List<int> _candidates = new List<int>(8);
 
         public DamageDealer DamageDealer => _damageDealer;
 
@@ -81,22 +76,22 @@ namespace Game.Runtime
             if (_enemyController != null)
             {
                 // 候補リスト構築（プレイヤー + 味方）
-                s_Candidates.Clear();
+                _candidates.Clear();
                 int playerHash = CharacterRegistry.PlayerHash;
                 if (playerHash != 0)
                 {
-                    s_Candidates.Add(playerHash);
+                    _candidates.Add(playerHash);
                 }
                 List<int> allies = CharacterRegistry.AllyHashes;
                 if (allies != null)
                 {
                     for (int i = 0; i < allies.Count; i++)
                     {
-                        s_Candidates.Add(allies[i]);
+                        _candidates.Add(allies[i]);
                     }
                 }
 
-                _enemyController.Tick(Time.fixedDeltaTime, s_Candidates, Time.time);
+                _enemyController.Tick(Time.fixedDeltaTime, _candidates, Time.time);
 
                 // AI が選択したアクションを ActionExecutorController に橋渡し
                 BridgeAIAction();
@@ -111,12 +106,6 @@ namespace Game.Runtime
             SyncPositionToData();
         }
 
-        /// <summary>
-        /// EnemyController内部のActionExecutorがAttack/Castを実行した場合、
-        /// ActionExecutorController（MonoBehaviour側）に橋渡しする。
-        /// 橋渡し成功後にAI側のアクションをForceCompleteして、
-        /// AI再評価との二重実行を防ぐ。
-        /// </summary>
         private void BridgeAIAction()
         {
             if (_actionExecutorController == null || _enemyController == null)
@@ -125,56 +114,8 @@ namespace Game.Runtime
             }
 
             ActionExecutor aiExecutor = _enemyController.JudgmentLoop?.Executor;
-            if (aiExecutor == null || !aiExecutor.IsExecuting)
-            {
-                return;
-            }
-
-            // MonoBehaviour側が既に実行中なら橋渡ししない
-            if (_actionExecutorController.IsExecuting)
-            {
-                return;
-            }
-
-            ActionBase current = aiExecutor.CurrentAction;
-            if (current == null)
-            {
-                return;
-            }
-
-            // AttackActionHandler の場合、LastParamId で ActionSlot を再構築
-            if (current is AttackActionHandler attackHandler)
-            {
-                ActionSlot slot = new ActionSlot
-                {
-                    execType = ActionExecType.Attack,
-                    paramId = attackHandler.LastParamId,
-                    paramValue = 1f
-                };
-                int targetHash = _enemyController.JudgmentLoop.CurrentTargetHash;
-                bool result = _actionExecutorController.ExecuteAction(slot, targetHash);
-                if (result)
-                {
-                    // AI側のアクションを完了としてマーク
-                    // これにより次のAI評価で新しいアクションを選択可能になる
-                    current.ForceComplete();
-                }
-            }
-            else if (current is CastActionHandler castHandler)
-            {
-                ActionSlot slot = new ActionSlot
-                {
-                    execType = ActionExecType.Cast,
-                    paramId = castHandler.LastParamId,
-                    paramValue = 1f
-                };
-                int targetHash = _enemyController.JudgmentLoop.CurrentTargetHash;
-                bool result = _actionExecutorController.ExecuteAction(slot, targetHash);
-                if (result)
-                {
-                    current.ForceComplete();
-                }
-            }
+            int targetHash = _enemyController.JudgmentLoop?.CurrentTargetHash ?? 0;
+            BridgeAIActionToExecutor(aiExecutor, _actionExecutorController, targetHash);
         }
 
         /// <summary>
@@ -237,12 +178,10 @@ namespace Game.Runtime
 
             // 攻撃範囲の外ならターゲットへ移動
             // AIInfoの検出範囲内かつ攻撃範囲外の場合に追尾
-            float attackRange = 1.5f; // デフォルト攻撃範囲
-
-            if (absDist > attackRange)
+            if (absDist > GameConstants.k_DefaultAttackRange)
             {
                 float dir = diff > 0f ? 1f : -1f;
-                float speed = moveParams.moveSpeed > 0f ? moveParams.moveSpeed : 3f;
+                float speed = moveParams.moveSpeed > 0f ? moveParams.moveSpeed : GameConstants.k_FallbackMoveSpeed;
                 _rb.linearVelocity = new Vector2(dir * speed, _rb.linearVelocity.y);
             }
             else

--- a/Assets/MyAsset/Runtime/Character/PlayerCharacter.cs
+++ b/Assets/MyAsset/Runtime/Character/PlayerCharacter.cs
@@ -1,30 +1,118 @@
 using UnityEngine;
 using Game.Core;
+using CharacterInfo = Game.Core.CharacterInfo;
 
 namespace Game.Runtime
 {
     /// <summary>
     /// プレイヤーキャラクターMonoBehaviour。
     /// PlayerInputHandler → GroundMovementLogic → Rigidbody2D を橋渡しする。
+    /// 攻撃は ActionExecutorController.ExecuteAction(ActionSlot) 経由で実行する。
+    /// コンボ段数管理は AttackInfo[] の inputWindow を参照して PlayerCharacter 側で行う。
     /// </summary>
     public class PlayerCharacter : BaseCharacter
     {
+        [SerializeField] private AttackInfo[] _lightAttacks;
+
         private GroundMovementLogic _movementLogic;
         private PlayerInputHandler _inputHandler;
-        private DamageDealer _damageDealer;
+        private ActionExecutorController _actionExecutor;
+        private DamageReceiver _damageReceiver;
+        private CharacterCollisionController _collisionController;
+        private SpriteRenderer _spriteRenderer;
+        private AudioSource _audioSource;
 
-        // 攻撃タイミング
-        private float _attackTimer;
-        private const float k_AttackDuration = 0.3f;
-        private const float k_AttackCooldown = 0.5f;
-        private float _attackCooldownTimer;
+        // CharacterInfoからキャッシュする値
+        private float _jumpBufferTime;
+        private float _jumpReleaseVelocityDamping;
+        private float _moveInputDeadzone;
+        private float _staminaExhaustionPenalty;
+        private float _staminaExhaustionRecoveryRatio;
+
+        // ジャンプ入力バッファ
+        private float _jumpBufferTimer;
+
+        // --- コンボ（paramId管理。実行はActionExecutorController経由）---
+        private int _comboStep;           // 0=なし、1~N
+        private float _comboWindowTimer;  // コンボ受付タイマー
+        private bool _comboQueued;        // コンボ次段の先行入力
+
+        // --- 攻撃入力消費 ---
+        private bool _attackConsumed;     // 今回のFixedUpdateで攻撃入力を消費済みか
+
+        // --- 攻撃移動 ---
+        private float _attackMoveTimer;
+        private float _attackMoveSpeed;
+        private float _attackMoveDir;
+
+        // --- フラッシュ（デバッグUI補助）---
+        private const float k_AttackFlashDuration = 0.12f;
+        private float _flashTimer;
+        private Color _originalColor;
+        private static readonly Color[] k_ComboColors = {
+            Color.yellow,
+            new Color(1f, 0.5f, 0f),
+            new Color(1f, 0.2f, 0.2f),
+            new Color(1f, 0f, 1f)
+        };
+
+        // --- 空中攻撃浮遊 ---
+        private float _airHangTimer;
+        private bool _isAirAttacking;
+        private Vector2 _aerialMoveDir;
+        private float _aerialMoveSpeed;
+
+        // --- 空中攻撃パラメータ（現在の攻撃のAttackInfoからキャッシュ）---
+        private float _currentAirHangDuration;
+        private float _currentAirHangGravityScale;
+
+        // --- 空中攻撃制限 ---
+        private bool _aerialComboUsed;    // 空中コンボを使い切ったら着地までロック
+
+        // --- 空中強攻撃（落下攻撃）---
+        private bool _isDivingAttack;     // 落下攻撃中（接地まで攻撃継続）
+        private AttackInfo _divingAttackInfo; // 落下攻撃に使用したAttackInfo（着地処理用）
+        private float _divingLandingTimer;   // 着地リカバリータイマー
+        private bool _isDivingLanding;       // 着地リカバリー中
+
+        // --- スタミナ回復遅延 ---
+        private float _staminaRecoveryDelayTimer;
+
+        // --- スタミナ枯渇ペナルティ ---
+        private bool _isExhausted;        // スタミナ枯渇状態
+
+        // --- チャージ中フラグ ---
+        private bool _isCharging;
+
+        // --- 回避無敵追跡 ---
+        private bool _wasDodging;
+
+#if UNITY_INCLUDE_TESTS
+        public void SetLightAttacksForTest(AttackInfo[] attacks) { _lightAttacks = attacks; }
+#endif
 
         protected override void Awake()
         {
             base.Awake();
             _movementLogic = new GroundMovementLogic();
             _inputHandler = GetComponent<PlayerInputHandler>();
-            _damageDealer = GetComponentInChildren<DamageDealer>();
+            _actionExecutor = GetComponent<ActionExecutorController>();
+            _damageReceiver = GetComponent<DamageReceiver>();
+            _collisionController = GetComponent<CharacterCollisionController>();
+            _spriteRenderer = GetComponent<SpriteRenderer>();
+            _audioSource = GetComponent<AudioSource>();
+            if (_spriteRenderer != null)
+            {
+                _originalColor = _spriteRenderer.color;
+            }
+
+            // CharacterInfoからキャッシュ
+            CharacterInfo info = _characterInfo;
+            _jumpBufferTime = info != null ? info.jumpBufferTime : 0.1f;
+            _jumpReleaseVelocityDamping = info != null ? info.jumpReleaseVelocityDamping : 0.5f;
+            _moveInputDeadzone = info != null ? info.moveInputDeadzone : 0.1f;
+            _staminaExhaustionPenalty = info != null ? info.staminaExhaustionPenalty : 2f;
+            _staminaExhaustionRecoveryRatio = info != null ? info.staminaExhaustionRecoveryRatio : 0.3f;
         }
 
         protected override void Start()
@@ -32,6 +120,8 @@ namespace Game.Runtime
             base.Start();
             CharacterRegistry.RegisterPlayer(ObjectHash);
         }
+
+        private int MaxCombo => _lightAttacks != null ? _lightAttacks.Length : 0;
 
         private void FixedUpdate()
         {
@@ -46,16 +136,120 @@ namespace Game.Runtime
             ref MoveParams moveParams = ref GameManager.Data.GetMoveParams(ObjectHash);
             ref CharacterVitals vitals = ref GameManager.Data.GetVitals(ObjectHash);
 
-            // ジャンプ
-            float jumpForce = _movementLogic.TryStartJump(input.jumpPressed, IsGrounded, moveParams);
+            // 着地時に空中攻撃制限をリセット
+            if (IsGrounded)
+            {
+                if (_aerialComboUsed)
+                {
+                    _aerialComboUsed = false;
+                }
+
+                // 落下攻撃着地 → リカバリーフェーズへ遷移
+                if (_isDivingAttack && !_isDivingLanding)
+                {
+                    BeginDivingLanding();
+                }
+            }
+
+            // 落下攻撃着地リカバリー中
+            if (_isDivingLanding)
+            {
+                UpdateDivingLanding();
+                // リカバリー中は他の入力を受け付けない
+                SyncPositionToData();
+                return;
+            }
+
+            // チャージ状態更新（InputHandlerのボタンホールド状態を参照）
+            _isCharging = _inputHandler != null && _inputHandler.IsCharging;
+
+            // ジャンプ入力バッファ
+            if (input.jumpPressed)
+            {
+                _jumpBufferTimer = _jumpBufferTime;
+            }
+            else
+            {
+                _jumpBufferTimer -= Time.fixedDeltaTime;
+            }
+
+            bool bufferedJump = _jumpBufferTimer > 0f;
+
+            // ジャンプ（スタミナ消費あり）
+            float prevStamina = vitals.currentStamina;
+            float jumpForce = _movementLogic.TryStartJump(
+                bufferedJump, IsGrounded, moveParams, ref vitals.currentStamina);
+            if (jumpForce > 0f)
+            {
+                _jumpBufferTimer = 0f;
+                if (vitals.currentStamina < prevStamina)
+                {
+                    ResetStaminaRecoveryDelay(ref vitals);
+                }
+            }
             float jumpHoldFactor = _movementLogic.UpdateJumpHold(input.jumpHeld, Time.fixedDeltaTime);
 
-            // ダッシュ
-            _movementLogic.TryStartDash(input.dashPressed, ref vitals.currentStamina, moveParams);
-            _movementLogic.UpdateDash(Time.fixedDeltaTime, moveParams);
+            // 回避（単押し）+ 無敵連動
+            prevStamina = vitals.currentStamina;
+            bool dodgeStarted = _movementLogic.TryStartDodge(
+                input.dodgePressed, ref vitals.currentStamina, moveParams);
+            if (dodgeStarted)
+            {
+                _wasDodging = true;
+                if (_collisionController != null)
+                {
+                    _collisionController.SetInvincible(true);
+                }
+                if (vitals.currentStamina < prevStamina)
+                {
+                    ResetStaminaRecoveryDelay(ref vitals);
+                }
+            }
+            _movementLogic.UpdateDodge(Time.fixedDeltaTime, moveParams);
 
-            // 水平速度
-            float horizontalSpeed = _movementLogic.CalculateHorizontalSpeed(input.moveDirection.x, moveParams);
+            // 回避終了時に無敵解除
+            if (_wasDodging && !_movementLogic.IsDodging)
+            {
+                _wasDodging = false;
+                if (_collisionController != null)
+                {
+                    _collisionController.SetInvincible(false);
+                }
+            }
+
+            // 攻撃中は通常移動・スプリントを無効化（攻撃移動のみ許可）
+            bool actionBusy = IsActionExecutorBusy();
+
+            // スプリント（長押し・継続スタミナ消費、移動入力がある場合のみ）
+            bool hasMovement = Mathf.Abs(input.moveDirection.x) > _moveInputDeadzone;
+            prevStamina = vitals.currentStamina;
+            _movementLogic.UpdateSprint(
+                input.sprintHeld && hasMovement && !actionBusy,
+                ref vitals.currentStamina, Time.fixedDeltaTime, moveParams);
+            if (vitals.currentStamina < prevStamina)
+            {
+                ResetStaminaRecoveryDelay(ref vitals);
+            }
+
+            // 水平速度（回避時はfacingDir使用）
+            float facingDir = _isFacingRight ? 1f : -1f;
+            float horizontalSpeed;
+            if (_attackMoveTimer > 0f)
+            {
+                // 攻撃移動（AttackInfoのデータ駆動）
+                _attackMoveTimer -= Time.fixedDeltaTime;
+                horizontalSpeed = _attackMoveDir * _attackMoveSpeed;
+            }
+            else if (actionBusy)
+            {
+                // 攻撃中は停止（攻撃移動終了後）
+                horizontalSpeed = 0f;
+            }
+            else
+            {
+                horizontalSpeed = _movementLogic.CalculateHorizontalSpeed(
+                    input.moveDirection.x, moveParams, facingDir);
+            }
 
             // Rigidbody2Dに適用
             Vector2 velocity = _rb.linearVelocity;
@@ -67,68 +261,417 @@ namespace Game.Runtime
             }
             else if (_movementLogic.IsJumping && jumpHoldFactor <= 0f && velocity.y > 0f)
             {
-                // ジャンプ終了時、上昇中なら速度をカット
-                velocity.y *= 0.5f;
+                velocity.y *= _jumpReleaseVelocityDamping;
+            }
+
+            // 空中攻撃: 移動方向ベクトル適用
+            if (_isAirAttacking && _airHangTimer > 0f && !_isDivingAttack)
+            {
+                velocity.x += _aerialMoveDir.x * _aerialMoveSpeed;
+                velocity.y = _aerialMoveDir.y * _aerialMoveSpeed;
+            }
+
+            // 落下攻撃: 高速落下
+            if (_isDivingAttack)
+            {
+                float fwdSpeed = _divingAttackInfo != null ? _divingAttackInfo.divingForwardSpeed : 1f;
+                velocity.x = facingDir * fwdSpeed;
+                // y速度はgravityScaleによる自然落下（高重力）
             }
 
             _rb.linearVelocity = velocity;
 
+            // 空中攻撃浮遊の重力制御
+            UpdateAirHang();
+
             // 向き更新
-            if (input.moveDirection.x > 0.1f)
+            if (input.moveDirection.x > _moveInputDeadzone)
             {
                 SetFacing(true);
             }
-            else if (input.moveDirection.x < -0.1f)
+            else if (input.moveDirection.x < -_moveInputDeadzone)
             {
                 SetFacing(false);
             }
 
-            // スタミナ回復
-            if (vitals.currentStamina < vitals.maxStamina && !_movementLogic.IsDashing)
+            // スタミナ回復（回避中・スプリント中・チャージ中は回復しない、遅延考慮）
+            _staminaRecoveryDelayTimer -= Time.fixedDeltaTime;
+
+            // スタミナ枯渇判定
+            if (vitals.currentStamina <= 0f && !_isExhausted)
+            {
+                _isExhausted = true;
+                _staminaRecoveryDelayTimer = _staminaExhaustionPenalty;
+            }
+            if (_isExhausted && vitals.currentStamina > vitals.maxStamina * _staminaExhaustionRecoveryRatio)
+            {
+                _isExhausted = false;
+            }
+
+            if (vitals.currentStamina < vitals.maxStamina
+                && !_movementLogic.IsDashing
+                && !_isCharging
+                && _staminaRecoveryDelayTimer <= 0f)
             {
                 vitals.currentStamina = Mathf.Min(
                     vitals.maxStamina,
                     vitals.currentStamina + vitals.staminaRecoveryRate * Time.fixedDeltaTime);
             }
 
-            // 攻撃処理
-            HandleAttack(input);
+            // ガード接続
+            if (_damageReceiver != null)
+            {
+                _damageReceiver.SetGuarding(input.guardHeld);
+            }
+
+            // 攻撃処理（ActionExecutorController経由）
+            _attackConsumed = false;
+            HandleAttack(input, ref vitals);
+
+            // フラッシュ更新（デバッグ補助）
+            UpdateAttackFlash();
 
             // 位置同期
             SyncPositionToData();
         }
 
-        private void HandleAttack(MovementInfo input)
-        {
-            _attackCooldownTimer -= Time.fixedDeltaTime;
-            _attackTimer -= Time.fixedDeltaTime;
+        // ============================================================
+        //  攻撃・コンボ（ActionExecutorController経由）
+        // ============================================================
 
-            if (_attackTimer <= 0f && _damageDealer != null)
+        private void HandleAttack(MovementInfo input, ref CharacterVitals vitals)
+        {
+            // 落下攻撃中は新しい攻撃を受け付けない
+            if (_isDivingAttack)
             {
-                _damageDealer.Deactivate();
+                return;
             }
 
-            if (input.attackInput.HasValue && _attackCooldownTimer <= 0f && _damageDealer != null)
+            float dt = Time.fixedDeltaTime;
+            _comboWindowTimer -= dt;
+
+            // コンボウィンドウ終了 → リセット
+            if (_comboWindowTimer <= 0f && _comboStep > 0 && !IsActionExecutorBusy())
             {
-                float chargeMultiplier = input.chargeMultiplier > 0f ? input.chargeMultiplier : 1f;
-                AttackMotionData motion = new AttackMotionData
+                _comboStep = 0;
+                _comboQueued = false;
+            }
+
+            bool wantsAttack = input.attackInput.HasValue && !_attackConsumed;
+            bool executorBusy = IsActionExecutorBusy();
+
+            // 空中コンボ使い切りチェック
+            bool isAerial = !IsGrounded;
+            if (isAerial && _aerialComboUsed && wantsAttack)
+            {
+                AttackInputType at = input.attackInput.Value;
+                // 空中弱攻撃系はロック（強攻撃=落下攻撃は許可）
+                if (at == AttackInputType.AerialLight || at == AttackInputType.LightAttack)
                 {
-                    motionValue = 1.0f * chargeMultiplier,
-                    attackElement = Element.Slash,
-                    feature = AttackFeature.Light,
-                    knockbackForce = new Vector2(_isFacingRight ? 3f : -3f, 1f),
-                    armorBreakValue = 10f,
-                    maxHitCount = 1
+                    return;
+                }
+            }
+
+            // コンボ先行入力（弱攻撃系のみコンボ対象）
+            if (wantsAttack && executorBusy && _comboStep < MaxCombo)
+            {
+                AttackInputType attackType = input.attackInput.Value;
+                if (attackType == AttackInputType.LightAttack || attackType == AttackInputType.AerialLight)
+                {
+                    _comboQueued = true;
+                }
+            }
+
+            // 弱攻撃コンボ判定
+            bool isLightAttack = wantsAttack && input.attackInput.HasValue
+                && (input.attackInput.Value == AttackInputType.LightAttack
+                    || input.attackInput.Value == AttackInputType.AerialLight
+                    || input.attackInput.Value == AttackInputType.ChargeLight);
+            bool canStartAttack = isLightAttack && !executorBusy && _comboStep == 0;
+            bool canCombo = _comboQueued && !executorBusy
+                && _comboWindowTimer > 0f && _comboStep < MaxCombo;
+
+            if ((canStartAttack || canCombo) && _actionExecutor != null && MaxCombo > 0)
+            {
+                int nextStep = canCombo ? _comboStep + 1 : 1;
+                int paramId = nextStep - 1;
+                AttackInfo info = _lightAttacks[paramId];
+
+                ActionSlot slot = new ActionSlot
+                {
+                    execType = ActionExecType.Attack,
+                    paramId = paramId,
+                    paramValue = input.chargeMultiplier > 0f ? input.chargeMultiplier : 1f,
+                    displayName = info.attackName
                 };
 
-                _damageDealer.Activate(motion, ObjectHash);
-                _attackTimer = k_AttackDuration;
-                _attackCooldownTimer = k_AttackCooldown;
+                bool executed = _actionExecutor.ExecuteAction(slot);
+                if (!executed)
+                {
+                    return;
+                }
+
+                _attackConsumed = true;
+                if (_inputHandler != null) { _inputHandler.ConsumeAttackInput(); }
+
+                // スタミナ消費があった場合、回復遅延リセット
+                ResetStaminaRecoveryDelay(ref vitals);
+
+                _comboStep = nextStep;
+                _comboQueued = false;
+
+                float comboWindow = info.inputWindow > 0f ? info.inputWindow : 0.6f;
+                _comboWindowTimer = comboWindow;
+
+                float dir = _isFacingRight ? 1f : -1f;
+
+                // 攻撃移動（AttackInfoのデータ駆動）
+                if (info.attackMoveDuration > 0f)
+                {
+                    _attackMoveTimer = info.attackMoveDuration;
+                    _attackMoveSpeed = info.attackMoveDistance / info.attackMoveDuration;
+                    _attackMoveDir = dir;
+                }
+
+                // デバッグフラッシュ
+                _flashTimer = k_AttackFlashDuration;
+                if (_spriteRenderer != null)
+                {
+                    int colorIdx = Mathf.Min(nextStep - 1, k_ComboColors.Length - 1);
+                    _spriteRenderer.color = k_ComboColors[colorIdx];
+                }
+
+                // 空中攻撃浮遊
+                if (isAerial && !_isAirAttacking)
+                {
+                    _isAirAttacking = true;
+                    _currentAirHangDuration = info.airHangDuration;
+                    _currentAirHangGravityScale = info.airHangGravityScale;
+                    _airHangTimer = _currentAirHangDuration;
+                    _rb.gravityScale = _currentAirHangGravityScale;
+
+                    _aerialMoveDir = info.aerialMoveDirection.sqrMagnitude > 0.01f
+                        ? info.aerialMoveDirection.normalized
+                        : new Vector2(0f, 0.3f);
+                    _aerialMoveSpeed = info.attackMoveDistance > 0f
+                        ? info.attackMoveDistance / Mathf.Max(info.attackMoveDuration, 0.1f)
+                        : info.aerialMoveSpeedDefault;
+
+                    Vector2 vel = _rb.linearVelocity;
+                    if (vel.y < 0f)
+                    {
+                        vel.y = 0f;
+                        _rb.linearVelocity = vel;
+                    }
+                }
+
+                // 空中コンボ最終段で使い切り判定
+                if (isAerial && nextStep >= MaxCombo)
+                {
+                    _aerialComboUsed = true;
+                }
+            }
+
+            // 強攻撃
+            bool isHeavyAttack = wantsAttack && input.attackInput.HasValue
+                && (input.attackInput.Value == AttackInputType.HeavyAttack
+                    || input.attackInput.Value == AttackInputType.AerialHeavy
+                    || input.attackInput.Value == AttackInputType.ChargeHeavy);
+            if (isHeavyAttack && !executorBusy && _actionExecutor != null && MaxCombo > 0)
+            {
+                // 空中強攻撃 → 落下攻撃
+                bool aerialHeavy = isAerial
+                    && (input.attackInput.Value == AttackInputType.AerialHeavy
+                        || input.attackInput.Value == AttackInputType.ChargeHeavy);
+
+                // フィニッシュ技（最後のAttackInfo）を強攻撃として使用
+                int heavyParamId = MaxCombo - 1;
+                AttackInfo heavyInfo = _lightAttacks[heavyParamId];
+
+                ActionSlot slot = new ActionSlot
+                {
+                    execType = ActionExecType.Attack,
+                    paramId = heavyParamId,
+                    paramValue = input.chargeMultiplier > 0f ? input.chargeMultiplier : 1f,
+                    displayName = heavyInfo.attackName
+                };
+
+                bool executed = _actionExecutor.ExecuteAction(slot);
+                if (executed)
+                {
+                    _attackConsumed = true;
+                    if (_inputHandler != null) { _inputHandler.ConsumeAttackInput(); }
+                    ResetStaminaRecoveryDelay(ref vitals);
+                    _comboStep = 0;
+                    _comboQueued = false;
+                    _comboWindowTimer = 0f;
+
+                    float dir = _isFacingRight ? 1f : -1f;
+
+                    if (aerialHeavy)
+                    {
+                        // 落下攻撃開始
+                        _isDivingAttack = true;
+                        _isAirAttacking = true;
+                        _divingAttackInfo = heavyInfo;
+                        _rb.gravityScale = GameConstants.k_GravityScale * heavyInfo.divingGravityMultiplier;
+                        _attackMoveTimer = 0f; // 水平移動なし
+
+                        // フラッシュ
+                        _flashTimer = k_AttackFlashDuration;
+                        if (_spriteRenderer != null)
+                        {
+                            _spriteRenderer.color = new Color(1f, 0f, 0.5f);
+                        }
+                    }
+                    else
+                    {
+                        // 地上強攻撃
+                        if (heavyInfo.attackMoveDuration > 0f)
+                        {
+                            _attackMoveTimer = heavyInfo.attackMoveDuration;
+                            _attackMoveSpeed = heavyInfo.attackMoveDistance / heavyInfo.attackMoveDuration;
+                            _attackMoveDir = dir;
+                        }
+
+                        _flashTimer = k_AttackFlashDuration;
+                        if (_spriteRenderer != null)
+                        {
+                            _spriteRenderer.color = new Color(1f, 0f, 1f);
+                        }
+                    }
+                }
+            }
+        }
+
+        private bool IsActionExecutorBusy()
+        {
+            return _actionExecutor != null && _actionExecutor.IsExecuting;
+        }
+
+        /// <summary>
+        /// スタミナ消費時に回復遅延タイマーをリセットする。
+        /// </summary>
+        private void ResetStaminaRecoveryDelay(ref CharacterVitals vitals)
+        {
+            float delay = vitals.staminaRecoveryDelay > 0f ? vitals.staminaRecoveryDelay : 1f;
+            _staminaRecoveryDelayTimer = delay;
+        }
+
+        // ============================================================
+        //  空中攻撃浮遊
+        // ============================================================
+
+        private void UpdateAirHang()
+        {
+            // 落下攻撃は接地で終了（FixedUpdateで処理）
+            if (_isDivingAttack)
+            {
+                return;
+            }
+
+            if (!_isAirAttacking)
+            {
+                return;
+            }
+
+            _airHangTimer -= Time.fixedDeltaTime;
+
+            if (_airHangTimer <= 0f || IsGrounded)
+            {
+                _isAirAttacking = false;
+                _rb.gravityScale = GameConstants.k_GravityScale;
+            }
+        }
+
+        // ============================================================
+        //  落下攻撃着地リカバリー
+        // ============================================================
+
+        /// <summary>
+        /// 落下攻撃が接地した瞬間に呼ばれる。
+        /// 着地SE再生 → リカバリータイマー開始 → 攻撃判定終了。
+        /// </summary>
+        private void BeginDivingLanding()
+        {
+            _isDivingAttack = false;
+            _isAirAttacking = false;
+            _isDivingLanding = true;
+            _rb.gravityScale = GameConstants.k_GravityScale;
+            _rb.linearVelocity = new Vector2(0f, _rb.linearVelocity.y);
+
+            float recoveryDuration = _divingAttackInfo != null
+                ? _divingAttackInfo.divingLandingRecoveryDuration
+                : 0.3f;
+            _divingLandingTimer = recoveryDuration;
+
+            // ActionExecutorの攻撃判定を終了（ヒットボックス停止）
+            if (_actionExecutor != null && _actionExecutor.IsExecuting)
+            {
+                _actionExecutor.CancelAction();
+            }
+
+            // 着地SE再生
+            if (_divingAttackInfo != null
+                && _divingAttackInfo.effectSoundInfo.landingSound != null
+                && _audioSource != null)
+            {
+                _audioSource.PlayOneShot(_divingAttackInfo.effectSoundInfo.landingSound);
+            }
+
+            // 着地フラッシュ
+            _flashTimer = k_AttackFlashDuration;
+            if (_spriteRenderer != null)
+            {
+                _spriteRenderer.color = new Color(1f, 0f, 1f);
+            }
+        }
+
+        /// <summary>
+        /// 落下攻撃着地リカバリーの更新。タイマー消化で通常状態に復帰。
+        /// </summary>
+        private void UpdateDivingLanding()
+        {
+            _divingLandingTimer -= Time.fixedDeltaTime;
+
+            // リカバリー中は水平速度を0に
+            Vector2 vel = _rb.linearVelocity;
+            vel.x = 0f;
+            _rb.linearVelocity = vel;
+
+            UpdateAttackFlash();
+
+            if (_divingLandingTimer <= 0f)
+            {
+                _isDivingLanding = false;
+                _divingAttackInfo = null;
+            }
+        }
+
+        // ============================================================
+        //  フラッシュ（デバッグ補助）
+        // ============================================================
+
+        private void UpdateAttackFlash()
+        {
+            if (_flashTimer <= 0f)
+            {
+                return;
+            }
+
+            _flashTimer -= Time.fixedDeltaTime;
+            if (_flashTimer <= 0f && _spriteRenderer != null)
+            {
+                _spriteRenderer.color = _originalColor;
             }
         }
 
         protected override void OnDestroy()
         {
+            if (_collisionController != null)
+            {
+                _collisionController.SetInvincible(false);
+            }
             CharacterRegistry.Unregister(ObjectHash);
             base.OnDestroy();
         }

--- a/Assets/MyAsset/Runtime/Combat/ActionExecutorController.cs
+++ b/Assets/MyAsset/Runtime/Combat/ActionExecutorController.cs
@@ -17,6 +17,7 @@ namespace Game.Runtime
         private HitBox _hitBox;
         private DamageDealer _damageDealer;
         private DamageReceiver _damageReceiver;
+        private CharacterCollisionController _collisionController;
 
         private ActionExecutor _executor;
         private ActionPhaseCoordinator _phaseCoordinator;
@@ -42,6 +43,7 @@ namespace Game.Runtime
             _hitBox = GetComponentInChildren<HitBox>();
             _damageDealer = GetComponentInChildren<DamageDealer>();
             _damageReceiver = GetComponent<DamageReceiver>();
+            _collisionController = GetComponent<CharacterCollisionController>();
 
             _executor = new ActionExecutor();
             _phaseCoordinator = new ActionPhaseCoordinator();
@@ -49,14 +51,29 @@ namespace Game.Runtime
             RegisterHandlers();
         }
 
+        private void Start()
+        {
+            // Bridge購読はStart()で行う。
+            // CharacterAnimationController.Awake()でBridgeが生成されるが、
+            // ActionExecutorController.Awake()→OnEnable()時点ではまだnullの場合がある
+            // （同一GameObjectのAwake実行順序は不定）。
+            SubscribeToBridge();
+        }
+
         private void OnEnable()
         {
-            if (_animController != null && _animController.Bridge != null)
+            // Start()前のOnEnableではBridge未生成の可能性があるため、
+            // Bridge購読はStart()で行い、ここではexecutorイベントのみ購読する。
+            // OnDisable→OnEnable再有効化時はBridge再購読が必要。
+            if (_cachedBridge != null)
             {
-                _cachedBridge = _animController.Bridge;
+                // 再有効化時: OnDisableで解除済みのBridgeを再購読
                 _cachedBridge.OnPhaseChanged += HandlePhaseChanged;
             }
-            _executor.OnActionCompleted += HandleActionCompleted;
+            if (_executor != null)
+            {
+                _executor.OnActionCompleted += HandleActionCompleted;
+            }
         }
 
         private void OnDisable()
@@ -64,13 +81,29 @@ namespace Game.Runtime
             if (_cachedBridge != null)
             {
                 _cachedBridge.OnPhaseChanged -= HandlePhaseChanged;
-                _cachedBridge = null;
             }
-            _executor.OnActionCompleted -= HandleActionCompleted;
+            if (_executor != null)
+            {
+                _executor.OnActionCompleted -= HandleActionCompleted;
+            }
+        }
+
+        private void SubscribeToBridge()
+        {
+            if (_animController != null && _animController.Bridge != null)
+            {
+                _cachedBridge = _animController.Bridge;
+                _cachedBridge.OnPhaseChanged += HandlePhaseChanged;
+            }
         }
 
         private void Update()
         {
+            if (_executor == null)
+            {
+                return;
+            }
+
             _executor.Tick(Time.deltaTime);
 
             if (_phaseCoordinator.ShouldCompleteAction)
@@ -116,6 +149,12 @@ namespace Game.Runtime
                 if (_animController != null)
                 {
                     _animController.StartActionPhase(info.motionInfo, (byte)slot.paramId);
+                }
+
+                // 攻撃のcontactTypeに応じて衝突モードを切替
+                if (_collisionController != null)
+                {
+                    _collisionController.SetCollisionMode(info.contactType);
                 }
 
                 _phaseCoordinator.BeginAction();
@@ -270,6 +309,12 @@ namespace Game.Runtime
             if (_damageReceiver != null)
             {
                 _damageReceiver.ClearActionEffects();
+            }
+
+            // 衝突モードをすり抜けに戻す
+            if (_collisionController != null)
+            {
+                _collisionController.ClearCollisionMode();
             }
         }
     }

--- a/Assets/MyAsset/Runtime/Combat/HitBox.cs
+++ b/Assets/MyAsset/Runtime/Combat/HitBox.cs
@@ -89,6 +89,23 @@ namespace Game.Runtime
                 return;
             }
 
+            // 死亡キャラにはダメージを与えない
+            if (!receiver.IsAlive)
+            {
+                return;
+            }
+
+            // 味方同士はダメージを与えない（陣営チェック）
+            if (GameManager.IsCharacterValid(_ownerHash) && GameManager.IsCharacterValid(receiver.ObjectHash))
+            {
+                CharacterBelong ownerBelong = GameManager.Data.GetFlags(_ownerHash).Belong;
+                CharacterBelong targetBelong = GameManager.Data.GetFlags(receiver.ObjectHash).Belong;
+                if (ownerBelong == targetBelong)
+                {
+                    return;
+                }
+            }
+
             // HitboxLogicでヒット登録（重複防止+上限管理）
             if (!_logic.TryRegisterHit(receiver.ObjectHash))
             {

--- a/Assets/MyAsset/Runtime/Combat/Projectile/ProjectileManager.cs
+++ b/Assets/MyAsset/Runtime/Combat/Projectile/ProjectileManager.cs
@@ -239,8 +239,14 @@ namespace Game.Runtime
                 ReturnControllerInternal(_activeControllers[i], i);
             }
 
-            _pendingReturns.Clear();
-            _corePool.Clear();
+            if (_pendingReturns != null)
+            {
+                _pendingReturns.Clear();
+            }
+            if (_corePool != null)
+            {
+                _corePool.Clear();
+            }
         }
 
         /// <summary>

--- a/Assets/MyAsset/Runtime/Debug.meta
+++ b/Assets/MyAsset/Runtime/Debug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e75b202677c28a046bfc1866c21077e1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Runtime/Debug/AutoInputTester.cs
+++ b/Assets/MyAsset/Runtime/Debug/AutoInputTester.cs
@@ -1,0 +1,689 @@
+using UnityEngine;
+using Game.Core;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Game.Runtime
+{
+    /// <summary>
+    /// Play Mode で自動入力シーケンスを送信してメカニクスを検証するデバッグコンポーネント。
+    /// PlayerInputHandler.SetOverrideInput() を使い、スクリプト化された入力を送る。
+    /// 各テストステップの結果をコンソールに出力する。
+    ///
+    /// TestSceneBuilder がGameManagerに追加する。enableOnStart = true で自動開始。
+    /// </summary>
+    public class AutoInputTester : MonoBehaviour
+    {
+        [SerializeField] private bool _enableOnStart = true;
+        [SerializeField] private int _loopCount = 3;
+
+        [Header("テスト選択（falseで無効化）")]
+        [SerializeField] private bool _testMove = true;
+        [SerializeField] private bool _testJump = true;
+        [SerializeField] private bool _testLightAttack = true;
+        [SerializeField] private bool _testHeavyAttack = true;
+        [SerializeField] private bool _testSkill = true;
+        [SerializeField] private bool _testDodge = true;
+        [SerializeField] private bool _testSprint = true;
+        [SerializeField] private bool _testGuard = true;
+        [SerializeField] private bool _testButtons = true;
+        [SerializeField] private bool _testStamina = true;
+        [SerializeField] private bool _testAerialAttack = true;
+        [SerializeField] private bool _testComposite = true;
+
+#if UNITY_EDITOR
+        public bool EnableOnStart { get => _enableOnStart; set => _enableOnStart = value; }
+        public int LoopCount { get => _loopCount; set => _loopCount = value; }
+        public bool TestMove { get => _testMove; set => _testMove = value; }
+        public bool TestJump { get => _testJump; set => _testJump = value; }
+        public bool TestLightAttack { get => _testLightAttack; set => _testLightAttack = value; }
+        public bool TestHeavyAttack { get => _testHeavyAttack; set => _testHeavyAttack = value; }
+        public bool TestSkill { get => _testSkill; set => _testSkill = value; }
+        public bool TestDodge { get => _testDodge; set => _testDodge = value; }
+        public bool TestSprint { get => _testSprint; set => _testSprint = value; }
+        public bool TestGuard { get => _testGuard; set => _testGuard = value; }
+        public bool TestButtons { get => _testButtons; set => _testButtons = value; }
+        public bool TestStamina { get => _testStamina; set => _testStamina = value; }
+        public bool TestAerialAttack { get => _testAerialAttack; set => _testAerialAttack = value; }
+        public bool TestComposite { get => _testComposite; set => _testComposite = value; }
+#endif
+
+        private static readonly string k_LogPath = Path.Combine(Application.dataPath, "../auto-input-test-log.txt");
+        private StreamWriter _logWriter;
+
+        private PlayerCharacter _player;
+        private PlayerInputHandler _inputHandler;
+        private BaseCharacter _baseCharacter;
+        private ActionExecutorController _actionExecutor;
+        private Rigidbody2D _rb;
+
+        private bool _isRunning;
+        private int _testIndex;
+        private float _stepTimer;
+        private float _stepDuration;
+        private string _currentTestName;
+        private System.Action _stepValidation;
+
+        // テストステップ定義
+        private List<TestStep> _steps;
+
+        // 検証用スナップショット
+        private float _snapshotStamina;
+        private Vector2 _snapshotPosition;
+        private bool _snapshotGrounded;
+        private int _passCount;
+        private int _failCount;
+
+        // 周回管理
+        private int _currentLoop;
+        private int _totalPassCount;
+        private int _totalFailCount;
+        private int _fixedUpdateCount;
+        private bool _suppressErrors;
+
+        private struct TestStep
+        {
+            public string name;
+            public float duration;
+            public MovementInfo input;
+            public System.Action onStart;
+            public System.Action onValidate;
+        }
+
+        private void OnDestroy()
+        {
+            _suppressErrors = false;
+#if UNITY_EDITOR
+            UnityEditor.EditorApplication.update -= EditorUnpause;
+#endif
+            _logWriter?.Close();
+            _logWriter = null;
+        }
+
+
+#if UNITY_EDITOR
+        private void EditorUnpause()
+        {
+            if (_suppressErrors && UnityEditor.EditorApplication.isPaused
+                && UnityEditor.EditorApplication.isPlaying)
+            {
+                UnityEditor.EditorApplication.isPaused = false;
+            }
+        }
+#endif
+
+        private void Awake()
+        {
+            // Error Pause 対策: MCP例外等でポーズされるのを即座に防ぐ
+            _suppressErrors = true;
+#if UNITY_EDITOR
+            UnityEditor.EditorApplication.update += EditorUnpause;
+#endif
+        }
+
+        private void Start()
+        {
+            if (!_enableOnStart)
+            {
+                return;
+            }
+
+            StartCoroutine(DelayedStart());
+        }
+
+        private IEnumerator DelayedStart()
+        {
+            // GameManager初期化とキャラクター登録を待つ
+            yield return new WaitForSeconds(0.5f);
+
+            _player = FindFirstObjectByType<PlayerCharacter>();
+            if (_player == null)
+            {
+                Debug.LogError("[AutoInputTester] PlayerCharacter が見つかりません");
+                yield break;
+            }
+
+            _inputHandler = _player.GetComponent<PlayerInputHandler>();
+            _baseCharacter = _player.GetComponent<BaseCharacter>();
+            _actionExecutor = _player.GetComponent<ActionExecutorController>();
+            _rb = _player.GetComponent<Rigidbody2D>();
+
+            if (_inputHandler == null)
+            {
+                Debug.LogError("[AutoInputTester] PlayerInputHandler が見つかりません");
+                yield break;
+            }
+
+            // Error Pause 対策は Awake() で登録済み
+
+            _logWriter = new StreamWriter(k_LogPath, false, System.Text.Encoding.UTF8);
+            _logWriter.AutoFlush = true;
+
+            WriteLog("========================================");
+            WriteLog($"[AutoInputTester] 自動入力テスト開始 ({_loopCount}周)");
+            WriteLog("========================================");
+
+            _currentLoop = 0;
+            _totalPassCount = 0;
+            _totalFailCount = 0;
+
+            StartLoop();
+        }
+
+        private void StartLoop()
+        {
+            _currentLoop++;
+            _passCount = 0;
+            _failCount = 0;
+
+            WriteLog($"[AutoInputTester] ====== 周回 {_currentLoop}/{_loopCount} 開始 ======");
+
+            BuildTestSteps();
+            _testIndex = 0;
+            _isRunning = true;
+            BeginStep();
+        }
+
+        private void FixedUpdate()
+        {
+            if (!_isRunning)
+            {
+                return;
+            }
+
+            _stepTimer -= Time.fixedDeltaTime;
+
+            if (_stepTimer <= 0f)
+            {
+                // 現在のステップ検証
+                ValidateStep();
+
+                // 次のステップへ
+                _testIndex++;
+                if (_testIndex >= _steps.Count)
+                {
+                    FinishLoop();
+                    return;
+                }
+
+                BeginStep();
+            }
+        }
+
+        private void BeginStep()
+        {
+            TestStep step = _steps[_testIndex];
+            _currentTestName = step.name;
+            _stepDuration = step.duration;
+            _stepTimer = step.duration;
+            _stepValidation = step.onValidate;
+
+            // スナップショット取得
+            TakeSnapshot();
+
+            // コールバック
+            if (step.onStart != null)
+            {
+                step.onStart();
+            }
+
+            // 入力オーバーライド設定
+            _inputHandler.SetOverrideInput(step.input);
+
+            WriteLog($"[AutoInputTester] --- テスト開始: {step.name} (duration={step.duration:F2}s) ---");
+        }
+
+        private void ValidateStep()
+        {
+            if (_stepValidation != null)
+            {
+                _stepValidation();
+            }
+            else
+            {
+                LogPass("(検証なし - 入力送信のみ)");
+            }
+
+            // 入力クリア
+            _inputHandler.SetOverrideInput(default);
+        }
+
+        private void FinishLoop()
+        {
+            _isRunning = false;
+            _inputHandler.ClearOverrideInput();
+            _totalPassCount += _passCount;
+            _totalFailCount += _failCount;
+
+            WriteLog($"[AutoInputTester] 周回 {_currentLoop}/{_loopCount} 完了: PASS={_passCount} FAIL={_failCount}");
+
+            if (_currentLoop < _loopCount)
+            {
+                // プレイヤーをスタート位置に戻す
+                ResetPlayerPosition();
+                // 次の周回を少し遅延して開始（位置リセットを反映させる）
+                StartCoroutine(DelayedNextLoop());
+            }
+            else
+            {
+                WriteLog("========================================");
+                WriteLog($"[AutoInputTester] 全{_loopCount}周完了: TOTAL PASS={_totalPassCount} TOTAL FAIL={_totalFailCount}");
+                WriteLog("========================================");
+                _logWriter?.Close();
+                _logWriter = null;
+            }
+        }
+
+        private IEnumerator DelayedNextLoop()
+        {
+            yield return new WaitForSeconds(0.3f);
+            StartLoop();
+        }
+
+        private void ResetPlayerPosition()
+        {
+            if (_player != null)
+            {
+                _player.transform.position = new Vector3(-6f, 2f, 0f);
+                _rb.linearVelocity = Vector2.zero;
+
+                // スタミナをフル回復
+                int hash = _baseCharacter.ObjectHash;
+                if (GameManager.IsCharacterValid(hash))
+                {
+                    ref CharacterVitals vitals = ref GameManager.Data.GetVitals(hash);
+                    vitals.currentStamina = vitals.maxStamina;
+                }
+            }
+        }
+
+        private void TakeSnapshot()
+        {
+            if (_player == null)
+            {
+                return;
+            }
+
+            int hash = _baseCharacter.ObjectHash;
+            if (GameManager.IsCharacterValid(hash))
+            {
+                ref CharacterVitals vitals = ref GameManager.Data.GetVitals(hash);
+                _snapshotStamina = vitals.currentStamina;
+            }
+
+            _snapshotPosition = _player.transform.position;
+            _snapshotGrounded = _baseCharacter.IsGrounded;
+        }
+
+        private float GetCurrentStamina()
+        {
+            int hash = _baseCharacter.ObjectHash;
+            if (GameManager.IsCharacterValid(hash))
+            {
+                ref CharacterVitals vitals = ref GameManager.Data.GetVitals(hash);
+                return vitals.currentStamina;
+            }
+            return -1f;
+        }
+
+        private void WriteLog(string msg)
+        {
+            Debug.Log(msg);
+            if (_logWriter != null)
+            {
+                _logWriter.WriteLine(msg);
+            }
+        }
+
+        private void LogPass(string detail)
+        {
+            _passCount++;
+            WriteLog($"[AutoInputTester] PASS: {_currentTestName} - {detail}");
+        }
+
+        private void LogFail(string detail)
+        {
+            _failCount++;
+            WriteLog($"[AutoInputTester] FAIL: {_currentTestName} - {detail}");
+        }
+
+        // ============================================================
+        //  テストステップ定義
+        // ============================================================
+
+        private void BuildTestSteps()
+        {
+            _steps = new List<TestStep>();
+
+            // 0. 初期待機（安定化）— 常に実行
+            AddStep("00_初期待機", 0.3f, default, null, () =>
+            {
+                LogPass($"初期位置: {_player.transform.position}, Grounded={_baseCharacter.IsGrounded}");
+            });
+
+            // ===== 移動系 =====
+            if (_testMove)
+            {
+                AddStep("01_右移動", 0.5f,
+                    new MovementInfo { moveDirection = new Vector2(1f, 0f) },
+                    null,
+                    () =>
+                    {
+                        float dx = _player.transform.position.x - _snapshotPosition.x;
+                        if (dx > 0.1f) { LogPass($"右に {dx:F2} 移動"); }
+                        else { LogFail($"右移動不足: dx={dx:F2}"); }
+                    });
+
+                AddStep("02_左移動", 0.5f,
+                    new MovementInfo { moveDirection = new Vector2(-1f, 0f) },
+                    null,
+                    () =>
+                    {
+                        float dx = _player.transform.position.x - _snapshotPosition.x;
+                        if (dx < -0.1f) { LogPass($"左に {Mathf.Abs(dx):F2} 移動"); }
+                        else { LogFail($"左移動不足: dx={dx:F2}"); }
+                    });
+            }
+
+            // ===== ジャンプ =====
+            if (_testJump)
+            {
+                AddStep("03_ジャンプ", 0.4f,
+                    new MovementInfo { jumpPressed = true, jumpHeld = true },
+                    null,
+                    () =>
+                    {
+                        float dy = _player.transform.position.y - _snapshotPosition.y;
+                        if (dy > 0.1f) { LogPass($"上に {dy:F2} 上昇"); }
+                        else { LogFail($"ジャンプ不足: dy={dy:F2}"); }
+                    });
+
+                AddStep("03b_着地待機", 0.8f, default, null, () =>
+                {
+                    if (_baseCharacter.IsGrounded) { LogPass("着地確認"); }
+                    else { LogFail("未着地"); }
+                });
+            }
+
+            // ===== 弱攻撃（コンボ） =====
+            if (_testLightAttack)
+            {
+                AddStep("04_弱攻撃1段", 0.1f,
+                    new MovementInfo { attackInput = AttackInputType.LightAttack, chargeMultiplier = 1f },
+                    null,
+                    () =>
+                    {
+                        bool busy = _actionExecutor != null && _actionExecutor.IsExecuting;
+                        float stDiff = _snapshotStamina - GetCurrentStamina();
+                        if (stDiff > 0f || busy) { LogPass($"攻撃発動 executing={busy} staminaCost={stDiff:F1}"); }
+                        else { LogFail($"攻撃未発動 executing={busy} stamina変化={stDiff:F1}"); }
+                    });
+
+                AddStep("04b_攻撃完了待機", 0.4f, default, null, () => { LogPass("攻撃完了待機"); });
+
+                AddStep("05_弱攻撃コンボ2段", 0.1f,
+                    new MovementInfo { attackInput = AttackInputType.LightAttack, chargeMultiplier = 1f },
+                    null,
+                    () =>
+                    {
+                        bool busy = _actionExecutor != null && _actionExecutor.IsExecuting;
+                        float stDiff = _snapshotStamina - GetCurrentStamina();
+                        if (busy || stDiff > 0f) { LogPass($"コンボ2段 executing={busy} staminaCost={stDiff:F1}"); }
+                        else { LogFail($"コンボ2段未発動 executing={busy} staminaCost={stDiff:F1}"); }
+                    });
+
+                AddStep("05b_コンボ完了待機", 0.4f, default, null, () => { LogPass("コンボ2段待機完了"); });
+
+                AddStep("06_弱攻撃コンボ3段", 0.1f,
+                    new MovementInfo { attackInput = AttackInputType.LightAttack, chargeMultiplier = 1f },
+                    null,
+                    () =>
+                    {
+                        bool busy = _actionExecutor != null && _actionExecutor.IsExecuting;
+                        float stDiff = _snapshotStamina - GetCurrentStamina();
+                        if (busy || stDiff > 0f) { LogPass($"コンボ3段 executing={busy} staminaCost={stDiff:F1}"); }
+                        else { LogFail($"コンボ3段未発動 executing={busy} staminaCost={stDiff:F1}"); }
+                    });
+
+                AddStep("06b_全コンボ完了待機", 1.0f, default, null, () => { LogPass("全コンボ完了待機終了"); });
+            }
+
+            // ===== 強攻撃 =====
+            if (_testHeavyAttack)
+            {
+                AddStep("07_強攻撃", 0.1f,
+                    new MovementInfo { attackInput = AttackInputType.HeavyAttack, chargeMultiplier = 1f },
+                    null,
+                    () =>
+                    {
+                        bool busy = _actionExecutor != null && _actionExecutor.IsExecuting;
+                        float stDiff = _snapshotStamina - GetCurrentStamina();
+                        if (stDiff > 0f || busy) { LogPass($"強攻撃発動 executing={busy} staminaCost={stDiff:F1}"); }
+                        else { LogFail($"強攻撃未発動 executing={busy} stamina変化={stDiff:F1}"); }
+                    });
+
+                AddStep("07b_強攻撃完了待機", 1.0f, default, null, () => { LogPass("強攻撃完了待機終了"); });
+            }
+
+            // ===== スキル =====
+            if (_testSkill)
+            {
+                AddStep("08_スキル攻撃", 0.1f,
+                    new MovementInfo { attackInput = AttackInputType.Skill, chargeMultiplier = 1f },
+                    null,
+                    () =>
+                    {
+                        bool busy = _actionExecutor != null && _actionExecutor.IsExecuting;
+                        LogPass($"スキル入力送信 executing={busy}");
+                    });
+
+                AddStep("08b_スキル完了待機", 0.5f, default, null, () => { LogPass("スキル完了待機"); });
+            }
+
+            // ===== 回避 =====
+            if (_testDodge)
+            {
+                AddStep("09_回避", 0.1f,
+                    new MovementInfo { dodgePressed = true, moveDirection = new Vector2(1f, 0f) },
+                    null,
+                    () =>
+                    {
+                        float dx = _player.transform.position.x - _snapshotPosition.x;
+                        float stDiff = _snapshotStamina - GetCurrentStamina();
+                        if (dx > 0.1f || stDiff > 0f) { LogPass($"回避発動 移動={dx:F2} staminaCost={stDiff:F1}"); }
+                        else { LogFail($"回避未発動 移動={dx:F2} stamina変化={stDiff:F1}"); }
+                    });
+
+                AddStep("09b_回避後待機", 0.5f, default, null, () => { LogPass("回避後待機完了"); });
+            }
+
+            // ===== スプリント =====
+            if (_testSprint)
+            {
+                AddStep("10_スプリント", 0.5f,
+                    new MovementInfo { moveDirection = new Vector2(1f, 0f), sprintHeld = true },
+                    null,
+                    () =>
+                    {
+                        float dx = _player.transform.position.x - _snapshotPosition.x;
+                        float stDiff = _snapshotStamina - GetCurrentStamina();
+                        if (dx > 0.5f) { LogPass($"スプリント移動={dx:F2} staminaCost={stDiff:F1}"); }
+                        else { LogFail($"スプリント不足 移動={dx:F2}"); }
+                    });
+
+                AddStep("10b_静止スプリント", 0.5f,
+                    new MovementInfo { sprintHeld = true },
+                    null,
+                    () =>
+                    {
+                        float stDiff = _snapshotStamina - GetCurrentStamina();
+                        if (stDiff <= 0.1f) { LogPass($"静止スプリントでスタミナ消費なし: diff={stDiff:F2}"); }
+                        else { LogFail($"静止スプリントでスタミナ消費あり: diff={stDiff:F2}"); }
+                    });
+            }
+
+            // ===== ガード =====
+            if (_testGuard)
+            {
+                AddStep("11_ガード", 0.3f,
+                    new MovementInfo { guardHeld = true },
+                    null,
+                    () => { LogPass("ガード入力送信完了（クラッシュなし）"); });
+            }
+
+            // ===== ボタン入力系 =====
+            if (_testButtons)
+            {
+                AddStep("12_インタラクト", 0.1f,
+                    new MovementInfo { interactPressed = true }, null,
+                    () => { LogPass("インタラクト入力送信（クラッシュなし）"); });
+
+                AddStep("13_連携", 0.1f,
+                    new MovementInfo { cooperationPressed = true }, null,
+                    () => { LogPass("連携入力送信（クラッシュなし）"); });
+
+                AddStep("14_武器切替", 0.1f,
+                    new MovementInfo { weaponSwitchPressed = true }, null,
+                    () => { LogPass("武器切替入力送信（クラッシュなし）"); });
+
+                AddStep("15_グリップ切替", 0.1f,
+                    new MovementInfo { gripSwitchPressed = true }, null,
+                    () => { LogPass("グリップ切替入力送信（クラッシュなし）"); });
+
+                AddStep("16_メニュー", 0.1f,
+                    new MovementInfo { menuPressed = true }, null,
+                    () => { LogPass("メニュー入力送信（クラッシュなし）"); });
+
+                AddStep("17_マップ", 0.1f,
+                    new MovementInfo { mapPressed = true }, null,
+                    () => { LogPass("マップ入力送信（クラッシュなし）"); });
+            }
+
+            // ===== スタミナ回復 =====
+            if (_testStamina)
+            {
+                AddStep("18_スタミナ回復待機", 2.0f, default, null, () =>
+                {
+                    float stNow = GetCurrentStamina();
+                    float recovery = stNow - _snapshotStamina;
+                    if (recovery > 0f) { LogPass($"スタミナ回復確認: +{recovery:F1} (現在={stNow:F1})"); }
+                    else { LogFail($"スタミナ未回復: 変化={recovery:F1} (現在={stNow:F1})"); }
+                });
+
+                AddStep("21_スタミナ枯渇開始", 0.15f, default,
+                    () =>
+                    {
+                        int hash = _baseCharacter.ObjectHash;
+                        if (GameManager.IsCharacterValid(hash))
+                        {
+                            ref CharacterVitals vitals = ref GameManager.Data.GetVitals(hash);
+                            vitals.currentStamina = 0f;
+                        }
+                    },
+                    () =>
+                    {
+                        float stNow = GetCurrentStamina();
+                        if (stNow < 5f) { LogPass($"枯渇直後: スタミナ={stNow:F1}（まだ回復していない）"); }
+                        else { LogFail($"枯渇直後なのに回復: スタミナ={stNow:F1}"); }
+                    });
+
+                AddStep("21b_枯渇ペナルティ確認", 1.0f, default, null, () =>
+                {
+                    float stNow = GetCurrentStamina();
+                    float recovery = stNow - _snapshotStamina;
+                    if (recovery < 5f) { LogPass($"枯渇ペナルティ: 1秒で回復={recovery:F1}（遅延あり）"); }
+                    else { LogFail($"枯渇ペナルティなし: 1秒で回復={recovery:F1}（即回復）"); }
+                });
+            }
+
+            // ===== 空中攻撃 =====
+            if (_testAerialAttack)
+            {
+                AddStep("19_ジャンプ開始", 0.15f,
+                    new MovementInfo { jumpPressed = true, jumpHeld = true }, null,
+                    () => { LogPass("ジャンプ入力送信"); });
+
+                AddStep("19b_空中弱攻撃", 0.1f,
+                    new MovementInfo { attackInput = AttackInputType.AerialLight, chargeMultiplier = 1f, jumpHeld = true },
+                    null,
+                    () =>
+                    {
+                        bool busy = _actionExecutor != null && _actionExecutor.IsExecuting;
+                        bool grounded = _baseCharacter.IsGrounded;
+                        if (busy && !grounded) { LogPass($"空中弱攻撃発動 grounded={grounded}"); }
+                        else { LogFail($"空中弱攻撃問題 executing={busy} grounded={grounded}"); }
+                    });
+
+                AddStep("19c_空中攻撃着地待機", 2.5f, default, null, () =>
+                {
+                    if (_baseCharacter.IsGrounded) { LogPass("空中攻撃後着地"); }
+                    else { LogFail("空中攻撃後未着地"); }
+                });
+
+                AddStep("20_ジャンプ開始(落下攻撃)", 0.2f,
+                    new MovementInfo { jumpPressed = true, jumpHeld = true }, null,
+                    () => { LogPass("ジャンプ入力送信（落下攻撃用）"); });
+
+                AddStep("20b_空中強攻撃(落下)", 0.1f,
+                    new MovementInfo { attackInput = AttackInputType.AerialHeavy, chargeMultiplier = 1f }, null,
+                    () =>
+                    {
+                        bool busy = _actionExecutor != null && _actionExecutor.IsExecuting;
+                        LogPass($"空中強攻撃送信 executing={busy}");
+                    });
+
+                AddStep("20c_落下攻撃着地", 1.5f, default, null, () =>
+                {
+                    if (_baseCharacter.IsGrounded) { LogPass("落下攻撃後着地"); }
+                    else { LogFail("落下攻撃後未着地（まだ空中）"); }
+                });
+            }
+
+            // ===== 複合入力テスト =====
+            if (_testComposite)
+            {
+                AddStep("22_移動+ジャンプ同時", 0.2f,
+                    new MovementInfo { moveDirection = new Vector2(1f, 0f), jumpPressed = true, jumpHeld = true },
+                    null,
+                    () =>
+                    {
+                        float dx = _player.transform.position.x - _snapshotPosition.x;
+                        float dy = _player.transform.position.y - _snapshotPosition.y;
+                        if (dx > 0.01f && dy > 0.01f) { LogPass($"移動+ジャンプ同時 dx={dx:F2} dy={dy:F2}"); }
+                        else { LogFail($"移動+ジャンプ同時失敗 dx={dx:F2} dy={dy:F2}"); }
+                    });
+
+                AddStep("22b_複合着地待機", 0.8f, default, null, () => { LogPass("複合入力着地待機完了"); });
+
+                AddStep("23_ガード+移動", 0.3f,
+                    new MovementInfo { guardHeld = true, moveDirection = new Vector2(-1f, 0f) }, null,
+                    () => { LogPass("ガード+移動 同時入力（クラッシュなし）"); });
+            }
+
+            // 最終状態ログ — 常に実行
+            AddStep("24_最終状態ログ", 0.1f, default, null, () =>
+            {
+                float stNow = GetCurrentStamina();
+                Vector2 pos = _player.transform.position;
+                bool grounded = _baseCharacter.IsGrounded;
+                bool executing = _actionExecutor != null && _actionExecutor.IsExecuting;
+                WriteLog($"[AutoInputTester] 最終状態: pos={pos} grounded={grounded} stamina={stNow:F1} executing={executing}");
+                LogPass("最終状態ログ出力完了");
+            });
+        }
+
+        private void AddStep(string name, float duration, MovementInfo input,
+            System.Action onStart, System.Action onValidate)
+        {
+            _steps.Add(new TestStep
+            {
+                name = name,
+                duration = duration,
+                input = input,
+                onStart = onStart,
+                onValidate = onValidate
+            });
+        }
+    }
+}

--- a/Assets/MyAsset/Runtime/Debug/AutoInputTester.cs.meta
+++ b/Assets/MyAsset/Runtime/Debug/AutoInputTester.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 66abae95ed551244ebb5aeef83a84589

--- a/Assets/MyAsset/Runtime/Debug/DebugStatusOverlay.cs
+++ b/Assets/MyAsset/Runtime/Debug/DebugStatusOverlay.cs
@@ -1,0 +1,136 @@
+using UnityEngine;
+using Game.Core;
+
+namespace Game.Runtime
+{
+    /// <summary>
+    /// デバッグ用ステータスオーバーレイ。
+    /// プレイヤーのHP・スタミナ・MP・アーマーをOnGUIで画面左上に表示する。
+    /// DEVELOPMENT_BUILD / UNITY_EDITOR でのみ有効。
+    /// </summary>
+    public class DebugStatusOverlay : MonoBehaviour
+    {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+        private BaseCharacter _player;
+        private GUIStyle _labelStyle;
+        private GUIStyle _barBackStyle;
+        private GUIStyle _hpBarStyle;
+        private GUIStyle _staminaBarStyle;
+        private GUIStyle _mpBarStyle;
+        private GUIStyle _armorBarStyle;
+        private bool _stylesInitialized;
+
+        private const float k_PanelX = 10f;
+        private const float k_PanelY = 10f;
+        private const float k_BarWidth = 200f;
+        private const float k_BarHeight = 18f;
+        private const float k_Spacing = 4f;
+
+        private void Start()
+        {
+            // プレイヤーキャラクターを検索
+            PlayerCharacter pc = FindFirstObjectByType<PlayerCharacter>();
+            if (pc != null)
+            {
+                _player = pc;
+            }
+        }
+
+        private void InitStyles()
+        {
+            if (_stylesInitialized)
+            {
+                return;
+            }
+
+            _labelStyle = new GUIStyle(GUI.skin.label);
+            _labelStyle.fontSize = 14;
+            _labelStyle.fontStyle = FontStyle.Bold;
+            _labelStyle.normal.textColor = Color.white;
+
+            _barBackStyle = new GUIStyle();
+            _barBackStyle.normal.background = MakeTex(1, 1, new Color(0.1f, 0.1f, 0.1f, 0.8f));
+
+            _hpBarStyle = new GUIStyle();
+            _hpBarStyle.normal.background = MakeTex(1, 1, new Color(0.2f, 0.8f, 0.2f, 0.9f));
+
+            _staminaBarStyle = new GUIStyle();
+            _staminaBarStyle.normal.background = MakeTex(1, 1, new Color(0.9f, 0.7f, 0.1f, 0.9f));
+
+            _mpBarStyle = new GUIStyle();
+            _mpBarStyle.normal.background = MakeTex(1, 1, new Color(0.2f, 0.4f, 0.9f, 0.9f));
+
+            _armorBarStyle = new GUIStyle();
+            _armorBarStyle.normal.background = MakeTex(1, 1, new Color(0.6f, 0.6f, 0.6f, 0.9f));
+
+            _stylesInitialized = true;
+        }
+
+        private void OnGUI()
+        {
+            if (_player == null || !GameManager.IsCharacterValid(_player.ObjectHash))
+            {
+                return;
+            }
+
+            InitStyles();
+
+            ref CharacterVitals vitals = ref GameManager.Data.GetVitals(_player.ObjectHash);
+
+            float y = k_PanelY;
+
+            // 背景パネル
+            GUI.Box(new Rect(k_PanelX - 4, k_PanelY - 4, k_BarWidth + 80, (k_BarHeight + k_Spacing) * 5 + 8),
+                "", _barBackStyle);
+
+            // HP
+            DrawBar(ref y, "HP", vitals.currentHp, vitals.maxHp, _hpBarStyle);
+
+            // スタミナ
+            DrawBar(ref y, "STA", vitals.currentStamina, vitals.maxStamina, _staminaBarStyle);
+
+            // MP
+            DrawBar(ref y, "MP", vitals.currentMp, vitals.maxMp, _mpBarStyle);
+
+            // アーマー
+            DrawBar(ref y, "ARM", vitals.currentArmor, vitals.maxArmor, _armorBarStyle);
+
+            // 接地状態
+            string groundText = _player.IsGrounded ? "GROUNDED" : "AIRBORNE";
+            GUI.Label(new Rect(k_PanelX, y, k_BarWidth + 70, k_BarHeight), groundText, _labelStyle);
+        }
+
+        private void DrawBar(ref float y, string label, float current, float max, GUIStyle barStyle)
+        {
+            float ratio = max > 0 ? Mathf.Clamp01(current / max) : 0f;
+
+            // ラベル
+            string text = $"{label}: {current:F0}/{max:F0}";
+            GUI.Label(new Rect(k_PanelX, y, k_BarWidth + 70, k_BarHeight), text, _labelStyle);
+
+            // バー背景
+            Rect barRect = new Rect(k_PanelX + 70, y + 2, k_BarWidth, k_BarHeight - 4);
+            GUI.Box(barRect, "", _barBackStyle);
+
+            // バー本体
+            Rect fillRect = new Rect(barRect.x, barRect.y, barRect.width * ratio, barRect.height);
+            GUI.Box(fillRect, "", barStyle);
+
+            y += k_BarHeight + k_Spacing;
+        }
+
+        private static Texture2D MakeTex(int width, int height, Color color)
+        {
+            Texture2D tex = new Texture2D(width, height);
+            Color[] pix = new Color[width * height];
+            for (int i = 0; i < pix.Length; i++)
+            {
+                pix[i] = color;
+            }
+            tex.SetPixels(pix);
+            tex.Apply();
+            return tex;
+        }
+#endif
+    }
+}

--- a/Assets/MyAsset/Runtime/Debug/DebugStatusOverlay.cs.meta
+++ b/Assets/MyAsset/Runtime/Debug/DebugStatusOverlay.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b22bb78b23027514c928cc32747b2e65

--- a/Assets/MyAsset/Runtime/Debug/SimpleEnemyBrain.cs
+++ b/Assets/MyAsset/Runtime/Debug/SimpleEnemyBrain.cs
@@ -1,0 +1,112 @@
+using UnityEngine;
+using Game.Core;
+
+namespace Game.Runtime
+{
+    /// <summary>
+    /// テストシーン用の簡易敵AI。
+    /// プレイヤーが一定距離内に入ると追従し、近接で攻撃する。
+    /// </summary>
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+    public class SimpleEnemyBrain : MonoBehaviour
+    {
+        [Header("Detection")]
+        [SerializeField] private float _detectionRange = 8f;
+        [SerializeField] private float _attackRange = 1.2f;
+
+        [Header("Movement")]
+        [SerializeField] private float _moveSpeed = 3f;
+
+        [Header("Attack")]
+        [SerializeField] private float _attackCooldown = 2f;
+        [SerializeField] private float _attackDuration = 0.3f;
+
+        private EnemyCharacter _enemy;
+        private Rigidbody2D _rb;
+        private DamageDealer _damageDealer;
+        private float _attackCooldownTimer;
+        private float _attackTimer;
+
+        private void Awake()
+        {
+            _enemy = GetComponent<EnemyCharacter>();
+            _rb = GetComponent<Rigidbody2D>();
+            _damageDealer = GetComponentInChildren<DamageDealer>();
+        }
+
+        private void FixedUpdate()
+        {
+            if (_enemy == null || !_enemy.IsAlive)
+            {
+                _rb.linearVelocity = new Vector2(0f, _rb.linearVelocity.y);
+                return;
+            }
+
+            int playerHash = CharacterRegistry.PlayerHash;
+            if (playerHash == 0 || !GameManager.IsCharacterValid(playerHash))
+            {
+                return;
+            }
+
+            ref CharacterVitals playerVitals = ref GameManager.Data.GetVitals(playerHash);
+            Vector2 playerPos = playerVitals.position;
+            Vector2 myPos = (Vector2)transform.position;
+            float distX = playerPos.x - myPos.x;
+            float absDist = Mathf.Abs(distX);
+
+            // 攻撃タイマー
+            _attackCooldownTimer -= Time.fixedDeltaTime;
+            _attackTimer -= Time.fixedDeltaTime;
+
+            if (_attackTimer <= 0f && _damageDealer != null)
+            {
+                _damageDealer.Deactivate();
+            }
+
+            // 検出範囲外
+            if (absDist > _detectionRange)
+            {
+                _rb.linearVelocity = new Vector2(0f, _rb.linearVelocity.y);
+                return;
+            }
+
+            // 向き設定
+            bool facingRight = distX > 0f;
+            Vector3 scale = transform.localScale;
+            scale.x = facingRight ? Mathf.Abs(scale.x) : -Mathf.Abs(scale.x);
+            transform.localScale = scale;
+
+            // 攻撃範囲内
+            if (absDist <= _attackRange)
+            {
+                _rb.linearVelocity = new Vector2(0f, _rb.linearVelocity.y);
+
+                if (_attackCooldownTimer <= 0f && _damageDealer != null)
+                {
+                    AttackMotionData motion = new AttackMotionData
+                    {
+                        motionValue = 0.8f,
+                        attackElement = Element.Strike,
+                        feature = AttackFeature.Light,
+                        knockbackForce = new Vector2(facingRight ? 2f : -2f, 0.5f),
+                        armorBreakValue = 5f,
+                        maxHitCount = 1
+                    };
+
+                    _damageDealer.Activate(motion, _enemy.ObjectHash);
+                    _attackTimer = _attackDuration;
+                    _attackCooldownTimer = _attackCooldown;
+                }
+                return;
+            }
+
+            // 追従
+            float dir = distX > 0f ? 1f : -1f;
+            _rb.linearVelocity = new Vector2(dir * _moveSpeed, _rb.linearVelocity.y);
+        }
+    }
+#else
+    // リリースビルドではコンパイルされない
+    public class SimpleEnemyBrain : MonoBehaviour { }
+#endif
+}

--- a/Assets/MyAsset/Runtime/Debug/SimpleEnemyBrain.cs.meta
+++ b/Assets/MyAsset/Runtime/Debug/SimpleEnemyBrain.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1ac3d1999d739da46b5a0f582426e045

--- a/Assets/MyAsset/Runtime/GameManager.cs
+++ b/Assets/MyAsset/Runtime/GameManager.cs
@@ -107,7 +107,10 @@ namespace Game.Runtime
                 dashSpeed = info.dashSpeed,
                 dashDuration = GameConstants.k_DefaultDashDuration,
                 gravityScale = GameConstants.k_GravityScale,
-                weightRatio = 0f
+                weightRatio = 0f,
+                jumpStaminaCost = info.jumpStaminaCost,
+                dodgeStaminaCost = info.dodgeStaminaCost,
+                sprintStaminaPerSecond = info.sprintStaminaPerSecond
             };
 
             return _core.RegisterCharacter(hash, vitals, combat, flags, move);

--- a/Assets/MyAsset/Runtime/Input/PlayerInputHandler.cs
+++ b/Assets/MyAsset/Runtime/Input/PlayerInputHandler.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 using Game.Core;
+using CharacterInfo = Game.Core.CharacterInfo;
 
 namespace Game.Runtime
 {
@@ -8,6 +9,11 @@ namespace Game.Runtime
     /// Unity InputSystem → MovementInfo変換。
     /// PlayerInputコンポーネントからコールバックを受け取り、
     /// 純ロジックが使うMovementInfo構造体に変換する。
+    ///
+    /// 攻撃入力はInputActionを直接ポーリングして
+    /// 押下/リリースを検出する（SendMessagesのcanceled未到達問題の回避）。
+    ///
+    /// スプリント: 長押しで継続スプリント、単押しで回避。
     /// </summary>
     [RequireComponent(typeof(PlayerInput))]
     public class PlayerInputHandler : MonoBehaviour
@@ -16,24 +22,85 @@ namespace Game.Runtime
         private BaseCharacter _character;
         private MovementInfo _currentInput;
 
+        // CharacterInfoから読み込む入力設定値（Awakeでキャッシュ）
+        private float _inputBufferDuration;
+        private float _chargeThreshold;
+        private float _sprintHoldThreshold;
+
         // チャージ攻撃
         private ChargeInputHandler _chargeHandler;
         private ChargeAttackLogic _chargeLogic;
 
-        // ボタン状態追跡
-        private bool _jumpPressed;
+        // 連続入力
         private bool _jumpHeld;
-        private bool _dashPressed;
         private bool _guardHeld;
-        private bool _interactPressed;
-        private bool _weaponSwitchPressed;
-        private bool _gripSwitchPressed;
-        private bool _cooperationPressed;
-        private bool _menuPressed;
-        private bool _mapPressed;
         private Vector2 _moveDirection;
 
-        public MovementInfo CurrentInput => _currentInput;
+        // 一発入力バッファ
+        private float _jumpBuffer;
+        private float _dodgeBuffer;
+        private float _interactBuffer;
+        private float _weaponSwitchBuffer;
+        private float _gripSwitchBuffer;
+        private float _cooperationBuffer;
+        private float _menuBuffer;
+        private float _mapBuffer;
+
+        // 攻撃バッファ
+        private float _attackBuffer;
+        private AttackButtonId _bufferedAttackButtonId;
+        private bool _bufferedIsCharging;
+
+        // 攻撃ボタン直接ポーリング用
+        private InputAction _attackAction;
+        private InputAction _heavyAttackAction;
+        private bool _attackHeldLastFrame;
+        private bool _heavyHeldLastFrame;
+        private float _attackHoldTime;
+        private float _heavyHoldTime;
+        private AttackButtonId _holdingButtonId;
+        private bool _isHoldingButton;
+
+        // スプリント/回避
+        private InputAction _sprintAction;
+        private bool _sprintHeld;
+        private float _sprintHoldTime;
+        private bool _sprintHeldLastFrame;
+
+        // --- 入力オーバーライド（自動テスト用）---
+        private bool _overrideActive;
+        private MovementInfo _overrideInput;
+
+        public MovementInfo CurrentInput => _overrideActive ? _overrideInput : _currentInput;
+
+        /// <summary>チャージ中かどうか（ボタンホールド中）。</summary>
+        public bool IsCharging => _overrideActive ? false : (_chargeHandler != null && _chargeHandler.IsHolding);
+
+        /// <summary>
+        /// 自動テスト用: 入力をオーバーライドする。実入力を無視してこの値を返す。
+        /// </summary>
+        public void SetOverrideInput(MovementInfo input)
+        {
+            _overrideActive = true;
+            _overrideInput = input;
+        }
+
+        /// <summary>
+        /// 自動テスト用: オーバーライドを解除して実入力に戻す。
+        /// </summary>
+        public void ClearOverrideInput()
+        {
+            _overrideActive = false;
+        }
+
+        /// <summary>
+        /// 攻撃入力を消費する。PlayerCharacterが攻撃実行後に呼ぶ。
+        /// バッファをクリアして同一入力で複数攻撃が出るのを防ぐ。
+        /// </summary>
+        public void ConsumeAttackInput()
+        {
+            _attackBuffer = 0f;
+        }
 
         private void Awake()
         {
@@ -41,6 +108,23 @@ namespace Game.Runtime
             _character = GetComponent<BaseCharacter>();
             _chargeLogic = new ChargeAttackLogic();
             _chargeHandler = new ChargeInputHandler(_chargeLogic);
+
+            // CharacterInfoから入力設定値をキャッシュ（フォールバック付き）
+            CharacterInfo info = _character != null ? _character.CharacterInfoRef : null;
+            _inputBufferDuration = info != null ? info.inputBufferDuration : 0.15f;
+            _chargeThreshold = info != null ? info.chargeThreshold : 0.3f;
+            _sprintHoldThreshold = info != null ? info.sprintHoldThreshold : 0.25f;
+        }
+
+        private void OnEnable()
+        {
+            // InputActionを直接取得してポーリング用に保持
+            if (_playerInput != null && _playerInput.actions != null)
+            {
+                _attackAction = _playerInput.actions["Attack"];
+                _heavyAttackAction = _playerInput.actions["HeavyAttack"];
+                _sprintAction = _playerInput.actions["Sprint"];
+            }
         }
 
         // --- InputSystem Callbacks (Message mode) ---
@@ -54,7 +138,7 @@ namespace Game.Runtime
         {
             if (value.isPressed)
             {
-                _jumpPressed = true;
+                _jumpBuffer = _inputBufferDuration;
                 _jumpHeld = true;
             }
             else
@@ -63,45 +147,17 @@ namespace Game.Runtime
             }
         }
 
-        public void OnSprint(InputValue value)
-        {
-            if (value.isPressed)
-            {
-                _dashPressed = true;
-            }
-        }
-
-        public void OnAttack(InputValue value)
-        {
-            if (value.isPressed)
-            {
-                _chargeHandler.BeginHold(0); // Light
-            }
-            else
-            {
-                _chargeHandler.EndHold(0);
-            }
-        }
-
-        public void OnHeavyAttack(InputValue value)
-        {
-            if (value.isPressed)
-            {
-                _chargeHandler.BeginHold(1); // Heavy
-            }
-            else
-            {
-                _chargeHandler.EndHold(1);
-            }
-        }
+        // OnSprint: 長押し判定はUpdateのポーリングで行うため、ここでは何もしない。
+        // SendMessagesではcanceledが来ないためポーリング必須。
 
         public void OnSkill(InputValue value)
         {
             if (value.isPressed)
             {
                 _chargeHandler.CancelCharge();
-                _chargeHandler.BeginHold(2); // Skill — チャージなし、即発動
-                _chargeHandler.EndHold(2);
+                _attackBuffer = _inputBufferDuration;
+                _bufferedAttackButtonId = AttackButtonId.Skill;
+                _bufferedIsCharging = false;
             }
         }
 
@@ -118,7 +174,7 @@ namespace Game.Runtime
         {
             if (value.isPressed)
             {
-                _interactPressed = true;
+                _interactBuffer = _inputBufferDuration;
             }
         }
 
@@ -126,7 +182,7 @@ namespace Game.Runtime
         {
             if (value.isPressed)
             {
-                _weaponSwitchPressed = true;
+                _weaponSwitchBuffer = _inputBufferDuration;
             }
         }
 
@@ -134,7 +190,7 @@ namespace Game.Runtime
         {
             if (value.isPressed)
             {
-                _gripSwitchPressed = true;
+                _gripSwitchBuffer = _inputBufferDuration;
             }
         }
 
@@ -142,7 +198,7 @@ namespace Game.Runtime
         {
             if (value.isPressed)
             {
-                _cooperationPressed = true;
+                _cooperationBuffer = _inputBufferDuration;
             }
         }
 
@@ -150,7 +206,7 @@ namespace Game.Runtime
         {
             if (value.isPressed)
             {
-                _menuPressed = true;
+                _menuBuffer = _inputBufferDuration;
             }
         }
 
@@ -158,55 +214,194 @@ namespace Game.Runtime
         {
             if (value.isPressed)
             {
-                _mapPressed = true;
+                _mapBuffer = _inputBufferDuration;
             }
         }
 
         private void Update()
         {
+            if (_chargeHandler == null)
+            {
+                return;
+            }
+
+            float dt = Time.deltaTime;
+
+            // --- 攻撃ボタン直接ポーリング（SendMessagesのcanceled未到達を回避）---
+            PollAttackButtons(dt);
+
+            // --- スプリント/回避ポーリング ---
+            PollSprintButton(dt);
+
             // チャージ更新
-            _chargeHandler.UpdateHold(Time.deltaTime);
+            _chargeHandler.UpdateHold(dt);
+
+            // バッファタイマー減算
+            _jumpBuffer -= dt;
+            _dodgeBuffer -= dt;
+            _interactBuffer -= dt;
+            _weaponSwitchBuffer -= dt;
+            _gripSwitchBuffer -= dt;
+            _cooperationBuffer -= dt;
+            _menuBuffer -= dt;
+            _mapBuffer -= dt;
+            _attackBuffer -= dt;
 
             // 攻撃入力変換
             AttackInputType? attackInput = null;
-            if (_chargeHandler.HasAttackInput)
+            if (_attackBuffer > 0f)
             {
                 bool isAirborne = _character != null && !_character.IsGrounded;
                 attackInput = InputConverter.ConvertAttackInput(
-                    _chargeHandler.AttackButtonId, isAirborne, _chargeHandler.IsCharging);
+                    _bufferedAttackButtonId, isAirborne, _bufferedIsCharging);
             }
 
             // MovementInfoを更新
             _currentInput = new MovementInfo
             {
                 moveDirection = _moveDirection,
-                jumpPressed = _jumpPressed,
+                jumpPressed = _jumpBuffer > 0f,
                 jumpHeld = _jumpHeld,
-                dashPressed = _dashPressed,
+                dodgePressed = _dodgeBuffer > 0f,
+                sprintHeld = _sprintHeld,
                 attackInput = attackInput,
                 guardHeld = _guardHeld,
-                interactPressed = _interactPressed,
-                cooperationPressed = _cooperationPressed,
-                weaponSwitchPressed = _weaponSwitchPressed,
-                gripSwitchPressed = _gripSwitchPressed,
-                menuPressed = _menuPressed,
-                mapPressed = _mapPressed,
+                interactPressed = _interactBuffer > 0f,
+                cooperationPressed = _cooperationBuffer > 0f,
+                weaponSwitchPressed = _weaponSwitchBuffer > 0f,
+                gripSwitchPressed = _gripSwitchBuffer > 0f,
+                menuPressed = _menuBuffer > 0f,
+                mapPressed = _mapBuffer > 0f,
                 chargeMultiplier = _chargeHandler.ChargeMultiplier
             };
         }
 
-        private void LateUpdate()
+        /// <summary>
+        /// 攻撃ボタンをポーリングして押下/リリースを検出する。
+        /// 短押し=即攻撃、長押し(>_chargeThreshold)=ため攻撃（リリースで発動）。
+        /// </summary>
+        private void PollAttackButtons(float dt)
         {
-            // per-frameフラグをクリア
-            _jumpPressed = false;
-            _dashPressed = false;
-            _interactPressed = false;
-            _weaponSwitchPressed = false;
-            _gripSwitchPressed = false;
-            _cooperationPressed = false;
-            _menuPressed = false;
-            _mapPressed = false;
-            _chargeHandler.ConsumeAttack();
+            // Light Attack
+            bool attackHeld = _attackAction != null && _attackAction.IsPressed();
+            if (attackHeld && !_attackHeldLastFrame)
+            {
+                // 押下開始
+                _holdingButtonId = AttackButtonId.Light;
+                _isHoldingButton = true;
+                _attackHoldTime = 0f;
+                _chargeHandler.BeginHold((int)AttackButtonId.Light);
+                // 即座に通常攻撃バッファをセット（短押し想定）
+                _attackBuffer = _inputBufferDuration;
+                _bufferedAttackButtonId = AttackButtonId.Light;
+                _bufferedIsCharging = false;
+            }
+            else if (!attackHeld && _attackHeldLastFrame)
+            {
+                // リリース
+                if (_isHoldingButton && _holdingButtonId == AttackButtonId.Light)
+                {
+                    if (_attackHoldTime >= _chargeThreshold)
+                    {
+                        // ため攻撃として上書き（押下時の通常攻撃バッファをチャージに差し替え）
+                        _chargeHandler.EndHold((int)AttackButtonId.Light);
+                        _attackBuffer = _inputBufferDuration;
+                        _bufferedAttackButtonId = AttackButtonId.Light;
+                        _bufferedIsCharging = true;
+                        _chargeHandler.ConsumeAttack();
+                    }
+                    else
+                    {
+                        // 短押し: 押下時にバッファ済みなのでここでは何もしない
+                        _chargeHandler.CancelCharge();
+                    }
+                    _isHoldingButton = false;
+                }
+            }
+            else if (attackHeld && _isHoldingButton && _holdingButtonId == AttackButtonId.Light)
+            {
+                _attackHoldTime += dt;
+            }
+            _attackHeldLastFrame = attackHeld;
+
+            // Heavy Attack — リリース時確定方式
+            // 押下: ホールド計測開始のみ。リリース: 秒数で通常/ため攻撃を確定
+            bool heavyHeld = _heavyAttackAction != null && _heavyAttackAction.IsPressed();
+            if (heavyHeld && !_heavyHeldLastFrame)
+            {
+                _holdingButtonId = AttackButtonId.Heavy;
+                _isHoldingButton = true;
+                _heavyHoldTime = 0f;
+                _chargeHandler.BeginHold((int)AttackButtonId.Heavy);
+            }
+            else if (!heavyHeld && _heavyHeldLastFrame)
+            {
+                if (_isHoldingButton && _holdingButtonId == AttackButtonId.Heavy)
+                {
+                    if (_heavyHoldTime >= _chargeThreshold)
+                    {
+                        _chargeHandler.EndHold((int)AttackButtonId.Heavy);
+                        _attackBuffer = _inputBufferDuration;
+                        _bufferedAttackButtonId = AttackButtonId.Heavy;
+                        _bufferedIsCharging = true;
+                        _chargeHandler.ConsumeAttack();
+                    }
+                    else
+                    {
+                        _chargeHandler.CancelCharge();
+                        _attackBuffer = _inputBufferDuration;
+                        _bufferedAttackButtonId = AttackButtonId.Heavy;
+                        _bufferedIsCharging = false;
+                    }
+                    _isHoldingButton = false;
+                }
+            }
+            else if (heavyHeld && _isHoldingButton && _holdingButtonId == AttackButtonId.Heavy)
+            {
+                _heavyHoldTime += dt;
+            }
+            _heavyHeldLastFrame = heavyHeld;
+        }
+
+        /// <summary>
+        /// スプリントボタンをポーリング。
+        /// 短押し(&lt;_sprintHoldThreshold)=回避、長押し=スプリント。
+        /// </summary>
+        private void PollSprintButton(float dt)
+        {
+            bool held = _sprintAction != null && _sprintAction.IsPressed();
+
+            if (held && !_sprintHeldLastFrame)
+            {
+                // 押下開始
+                _sprintHoldTime = 0f;
+            }
+            else if (held)
+            {
+                _sprintHoldTime += dt;
+            }
+
+            if (!held && _sprintHeldLastFrame)
+            {
+                // リリース
+                if (_sprintHoldTime < _sprintHoldThreshold)
+                {
+                    // 短押し → 回避
+                    _dodgeBuffer = _inputBufferDuration;
+                }
+                _sprintHeld = false;
+            }
+            else if (held && _sprintHoldTime >= _sprintHoldThreshold)
+            {
+                // 長押し → スプリント継続中
+                _sprintHeld = true;
+            }
+            else if (!held)
+            {
+                _sprintHeld = false;
+            }
+
+            _sprintHeldLastFrame = held;
         }
     }
 }

--- a/Assets/MyAsset/Runtime/Input/PlayerInputHandler.cs
+++ b/Assets/MyAsset/Runtime/Input/PlayerInputHandler.cs
@@ -18,6 +18,10 @@ namespace Game.Runtime
     [RequireComponent(typeof(PlayerInput))]
     public class PlayerInputHandler : MonoBehaviour
     {
+        private const string k_AttackActionName = "Attack";
+        private const string k_HeavyAttackActionName = "HeavyAttack";
+        private const string k_SprintActionName = "Sprint";
+
         private PlayerInput _playerInput;
         private BaseCharacter _character;
         private MovementInfo _currentInput;
@@ -121,9 +125,9 @@ namespace Game.Runtime
             // InputActionを直接取得してポーリング用に保持
             if (_playerInput != null && _playerInput.actions != null)
             {
-                _attackAction = _playerInput.actions["Attack"];
-                _heavyAttackAction = _playerInput.actions["HeavyAttack"];
-                _sprintAction = _playerInput.actions["Sprint"];
+                _attackAction = _playerInput.actions[k_AttackActionName];
+                _heavyAttackAction = _playerInput.actions[k_HeavyAttackActionName];
+                _sprintAction = _playerInput.actions[k_SprintActionName];
             }
         }
 

--- a/Assets/MyAsset/Runtime/UI/DamagePopupController.cs
+++ b/Assets/MyAsset/Runtime/UI/DamagePopupController.cs
@@ -239,6 +239,11 @@ namespace Game.Runtime
 
         private void CancelAllActive()
         {
+            if (_active == null)
+            {
+                return;
+            }
+
             for (int i = _active.Count - 1; i >= 0; i--)
             {
                 PoolEntry entry = _active[i];

--- a/Assets/Scenes/CoreTestScene.unity.meta
+++ b/Assets/Scenes/CoreTestScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c27abfe13392f29448887eea21be13be
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/AllInputMappingTests.cs
+++ b/Assets/Tests/EditMode/AllInputMappingTests.cs
@@ -1,0 +1,550 @@
+using NUnit.Framework;
+using UnityEngine;
+using Game.Core;
+
+namespace Game.Tests.EditMode
+{
+    /// <summary>
+    /// 全13入力操作のマッピングテスト。
+    /// InputConverter / MovementInfo / ChargeInputHandler の入力変換を網羅的に検証する。
+    ///
+    /// 対応表:
+    ///   移動(WASD)    → MovementInfo.moveDirection
+    ///   ジャンプ(Space) → jumpPressed / jumpHeld
+    ///   ダッシュ(Shift) → dodgePressed(短押し) / sprintHeld(長押し)
+    ///   通常攻撃(LMB)  → attackInput = LightAttack
+    ///   強攻撃(X)      → attackInput = HeavyAttack
+    ///   スキル(Q)      → attackInput = Skill
+    ///   ガード(RMB)    → guardHeld
+    ///   インタラクト(E) → interactPressed
+    ///   連携(V)        → cooperationPressed
+    ///   武器切替(Tab)   → weaponSwitchPressed
+    ///   グリップ切替(G) → gripSwitchPressed
+    ///   メニュー(Esc)   → menuPressed
+    ///   マップ(M)      → mapPressed
+    /// </summary>
+    [TestFixture]
+    public class AllInputMappingTests
+    {
+        // =============================================================
+        //  1. 移動 (WASD / 矢印キー) → moveDirection
+        // =============================================================
+
+        [Test]
+        public void Move_RightInput_NormalizesToPositiveX()
+        {
+            Vector2 raw = new Vector2(1f, 0f);
+            Vector2 result = InputConverter.NormalizeDirection(raw);
+            Assert.AreEqual(1f, result.x, 0.001f);
+            Assert.AreEqual(0f, result.y, 0.001f);
+        }
+
+        [Test]
+        public void Move_LeftInput_NormalizesToNegativeX()
+        {
+            Vector2 raw = new Vector2(-1f, 0f);
+            Vector2 result = InputConverter.NormalizeDirection(raw);
+            Assert.AreEqual(-1f, result.x, 0.001f);
+        }
+
+        [Test]
+        public void Move_DiagonalInput_PreservesMagnitudeUnderOne()
+        {
+            // スティック入力 (0.5, 0.5) → magnitude ~0.707 → そのまま返す
+            Vector2 raw = new Vector2(0.5f, 0.5f);
+            Vector2 result = InputConverter.NormalizeDirection(raw);
+            Assert.AreEqual(raw.x, result.x, 0.001f);
+            Assert.AreEqual(raw.y, result.y, 0.001f);
+        }
+
+        [Test]
+        public void Move_DiagonalOverOne_Normalizes()
+        {
+            Vector2 raw = new Vector2(1f, 1f); // magnitude ~1.414
+            Vector2 result = InputConverter.NormalizeDirection(raw);
+            Assert.AreEqual(1f, result.magnitude, 0.001f);
+        }
+
+        [Test]
+        public void Move_DeadZone_ReturnsZero()
+        {
+            Vector2 raw = new Vector2(0.05f, 0.05f); // magnitude ~0.07
+            Vector2 result = InputConverter.NormalizeDirection(raw);
+            Assert.AreEqual(Vector2.zero, result);
+        }
+
+        [Test]
+        public void Move_ExactDeadZoneBoundary_ReturnsZero()
+        {
+            // magnitude == k_DeadZone (0.15) → ゼロ (<=)
+            Vector2 raw = new Vector2(0.15f, 0f);
+            Vector2 result = InputConverter.NormalizeDirection(raw);
+            Assert.AreEqual(Vector2.zero, result);
+        }
+
+        [Test]
+        public void Move_JustAboveDeadZone_ReturnsInput()
+        {
+            Vector2 raw = new Vector2(0.16f, 0f);
+            Vector2 result = InputConverter.NormalizeDirection(raw);
+            Assert.AreEqual(0.16f, result.x, 0.001f);
+        }
+
+        // =============================================================
+        //  2. ジャンプ (Space) → jumpPressed / jumpHeld
+        // =============================================================
+
+        [Test]
+        public void Jump_MovementInfo_PressedAndHeldAreIndependent()
+        {
+            // jumpPressed = バッファ付き一発入力、jumpHeld = 継続入力
+            MovementInfo info = new MovementInfo
+            {
+                jumpPressed = true,
+                jumpHeld = true,
+            };
+            Assert.IsTrue(info.jumpPressed);
+            Assert.IsTrue(info.jumpHeld);
+        }
+
+        [Test]
+        public void Jump_ReleaseState_HeldFalsePressedFalse()
+        {
+            MovementInfo info = new MovementInfo
+            {
+                jumpPressed = false,
+                jumpHeld = false,
+            };
+            Assert.IsFalse(info.jumpPressed);
+            Assert.IsFalse(info.jumpHeld);
+        }
+
+        // =============================================================
+        //  3. ダッシュ (Left Shift) → dodgePressed(短押し) / sprintHeld(長押し)
+        // =============================================================
+
+        [Test]
+        public void Sprint_ShortPress_SetsDodgeNotSprint()
+        {
+            // 短押し → 回避入力
+            MovementInfo info = new MovementInfo
+            {
+                dodgePressed = true,
+                sprintHeld = false,
+            };
+            Assert.IsTrue(info.dodgePressed);
+            Assert.IsFalse(info.sprintHeld);
+        }
+
+        [Test]
+        public void Sprint_LongPress_SetsSprintNotDodge()
+        {
+            // 長押し → スプリント
+            MovementInfo info = new MovementInfo
+            {
+                dodgePressed = false,
+                sprintHeld = true,
+            };
+            Assert.IsFalse(info.dodgePressed);
+            Assert.IsTrue(info.sprintHeld);
+        }
+
+        // =============================================================
+        //  4. 通常攻撃 (マウス左 / Enter) → LightAttack
+        // =============================================================
+
+        [Test]
+        public void LightAttack_Ground_ReturnsLightAttack()
+        {
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                AttackButtonId.Light, isAirborne: false, isCharging: false);
+            Assert.AreEqual(AttackInputType.LightAttack, result);
+        }
+
+        [Test]
+        public void LightAttack_Airborne_ReturnsAerialLight()
+        {
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                AttackButtonId.Light, isAirborne: true, isCharging: false);
+            Assert.AreEqual(AttackInputType.AerialLight, result);
+        }
+
+        [Test]
+        public void LightAttack_Charging_ReturnsChargeLight()
+        {
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                AttackButtonId.Light, isAirborne: false, isCharging: true);
+            Assert.AreEqual(AttackInputType.ChargeLight, result);
+        }
+
+        [Test]
+        public void LightAttack_AirborneAndCharging_AirbornePriority()
+        {
+            // 空中判定が優先される
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                AttackButtonId.Light, isAirborne: true, isCharging: true);
+            Assert.AreEqual(AttackInputType.AerialLight, result);
+        }
+
+        // =============================================================
+        //  5. 強攻撃 (X) → HeavyAttack
+        // =============================================================
+
+        [Test]
+        public void HeavyAttack_Ground_ReturnsHeavyAttack()
+        {
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                AttackButtonId.Heavy, isAirborne: false, isCharging: false);
+            Assert.AreEqual(AttackInputType.HeavyAttack, result);
+        }
+
+        [Test]
+        public void HeavyAttack_Airborne_ReturnsAerialHeavy()
+        {
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                AttackButtonId.Heavy, isAirborne: true, isCharging: false);
+            Assert.AreEqual(AttackInputType.AerialHeavy, result);
+        }
+
+        [Test]
+        public void HeavyAttack_Charging_ReturnsChargeHeavy()
+        {
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                AttackButtonId.Heavy, isAirborne: false, isCharging: true);
+            Assert.AreEqual(AttackInputType.ChargeHeavy, result);
+        }
+
+        [Test]
+        public void HeavyAttack_AirborneAndCharging_AirbornePriority()
+        {
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                AttackButtonId.Heavy, isAirborne: true, isCharging: true);
+            Assert.AreEqual(AttackInputType.AerialHeavy, result);
+        }
+
+        // =============================================================
+        //  6. スキル (Q) → Skill
+        // =============================================================
+
+        [Test]
+        public void Skill_Ground_ReturnsSkill()
+        {
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                AttackButtonId.Skill, isAirborne: false, isCharging: false);
+            Assert.AreEqual(AttackInputType.Skill, result);
+        }
+
+        [Test]
+        public void Skill_Airborne_StillReturnsSkill()
+        {
+            // Skill は空中/地上関係なく Skill
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                AttackButtonId.Skill, isAirborne: true, isCharging: false);
+            Assert.AreEqual(AttackInputType.Skill, result);
+        }
+
+        [Test]
+        public void Skill_Charging_StillReturnsSkill()
+        {
+            // Skill はチャージ状態に関係なく Skill
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                AttackButtonId.Skill, isAirborne: false, isCharging: true);
+            Assert.AreEqual(AttackInputType.Skill, result);
+        }
+
+        // =============================================================
+        //  7. ガード (マウス右ボタン) → guardHeld
+        // =============================================================
+
+        [Test]
+        public void Guard_HeldTrue_SetsGuardHeld()
+        {
+            MovementInfo info = new MovementInfo { guardHeld = true };
+            Assert.IsTrue(info.guardHeld);
+        }
+
+        [Test]
+        public void Guard_Released_ClearsGuardHeld()
+        {
+            MovementInfo info = new MovementInfo { guardHeld = false };
+            Assert.IsFalse(info.guardHeld);
+        }
+
+        // =============================================================
+        //  8. インタラクト (E) → interactPressed
+        // =============================================================
+
+        [Test]
+        public void Interact_Pressed_SetsInteractPressed()
+        {
+            MovementInfo info = new MovementInfo { interactPressed = true };
+            Assert.IsTrue(info.interactPressed);
+        }
+
+        // =============================================================
+        //  9. 連携 (V) → cooperationPressed
+        // =============================================================
+
+        [Test]
+        public void Cooperation_Pressed_SetsCooperationPressed()
+        {
+            MovementInfo info = new MovementInfo { cooperationPressed = true };
+            Assert.IsTrue(info.cooperationPressed);
+        }
+
+        // =============================================================
+        // 10. 武器切替 (Tab) → weaponSwitchPressed
+        // =============================================================
+
+        [Test]
+        public void WeaponSwitch_Pressed_SetsWeaponSwitchPressed()
+        {
+            MovementInfo info = new MovementInfo { weaponSwitchPressed = true };
+            Assert.IsTrue(info.weaponSwitchPressed);
+        }
+
+        // =============================================================
+        // 11. グリップ切替 (G) → gripSwitchPressed
+        // =============================================================
+
+        [Test]
+        public void GripSwitch_Pressed_SetsGripSwitchPressed()
+        {
+            MovementInfo info = new MovementInfo { gripSwitchPressed = true };
+            Assert.IsTrue(info.gripSwitchPressed);
+        }
+
+        // =============================================================
+        // 12. メニュー (Escape) → menuPressed
+        // =============================================================
+
+        [Test]
+        public void Menu_Pressed_SetsMenuPressed()
+        {
+            MovementInfo info = new MovementInfo { menuPressed = true };
+            Assert.IsTrue(info.menuPressed);
+        }
+
+        // =============================================================
+        // 13. マップ (M) → mapPressed
+        // =============================================================
+
+        [Test]
+        public void Map_Pressed_SetsMapPressed()
+        {
+            MovementInfo info = new MovementInfo { mapPressed = true };
+            Assert.IsTrue(info.mapPressed);
+        }
+
+        // =============================================================
+        //  MovementInfo 全フィールド同時設定テスト
+        // =============================================================
+
+        [Test]
+        public void MovementInfo_AllFieldsSet_NoConflict()
+        {
+            // 全フィールドを同時にtrueに設定しても干渉しないことを確認
+            MovementInfo info = new MovementInfo
+            {
+                moveDirection = new Vector2(0.5f, 0f),
+                jumpPressed = true,
+                jumpHeld = true,
+                dodgePressed = true,
+                sprintHeld = true,
+                attackInput = AttackInputType.LightAttack,
+                guardHeld = true,
+                interactPressed = true,
+                cooperationPressed = true,
+                weaponSwitchPressed = true,
+                gripSwitchPressed = true,
+                menuPressed = true,
+                mapPressed = true,
+                chargeMultiplier = 1.5f,
+            };
+
+            Assert.AreEqual(0.5f, info.moveDirection.x, 0.001f);
+            Assert.IsTrue(info.jumpPressed);
+            Assert.IsTrue(info.jumpHeld);
+            Assert.IsTrue(info.dodgePressed);
+            Assert.IsTrue(info.sprintHeld);
+            Assert.AreEqual(AttackInputType.LightAttack, info.attackInput);
+            Assert.IsTrue(info.guardHeld);
+            Assert.IsTrue(info.interactPressed);
+            Assert.IsTrue(info.cooperationPressed);
+            Assert.IsTrue(info.weaponSwitchPressed);
+            Assert.IsTrue(info.gripSwitchPressed);
+            Assert.IsTrue(info.menuPressed);
+            Assert.IsTrue(info.mapPressed);
+            Assert.AreEqual(1.5f, info.chargeMultiplier, 0.001f);
+        }
+
+        [Test]
+        public void MovementInfo_Default_AllFieldsFalseOrZero()
+        {
+            // デフォルト状態は全入力なし
+            MovementInfo info = default;
+
+            Assert.AreEqual(Vector2.zero, info.moveDirection);
+            Assert.IsFalse(info.jumpPressed);
+            Assert.IsFalse(info.jumpHeld);
+            Assert.IsFalse(info.dodgePressed);
+            Assert.IsFalse(info.sprintHeld);
+            Assert.IsNull(info.attackInput);
+            Assert.IsFalse(info.guardHeld);
+            Assert.IsFalse(info.interactPressed);
+            Assert.IsFalse(info.cooperationPressed);
+            Assert.IsFalse(info.weaponSwitchPressed);
+            Assert.IsFalse(info.gripSwitchPressed);
+            Assert.IsFalse(info.menuPressed);
+            Assert.IsFalse(info.mapPressed);
+            Assert.AreEqual(0f, info.chargeMultiplier);
+        }
+
+        // =============================================================
+        //  ChargeInputHandler × InputConverter 結合（全ボタン）
+        // =============================================================
+
+        [Test]
+        public void ChargeHandler_LightShortPress_ProducesLightAttack()
+        {
+            ChargeAttackLogic logic = new ChargeAttackLogic();
+            ChargeInputHandler handler = new ChargeInputHandler(logic);
+
+            handler.BeginHold((int)AttackButtonId.Light);
+            handler.UpdateHold(0.1f);
+            handler.EndHold((int)AttackButtonId.Light);
+
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                (AttackButtonId)handler.AttackButtonId, false, handler.IsCharging);
+            Assert.AreEqual(AttackInputType.LightAttack, result);
+        }
+
+        [Test]
+        public void ChargeHandler_HeavyShortPress_ProducesHeavyAttack()
+        {
+            ChargeAttackLogic logic = new ChargeAttackLogic();
+            ChargeInputHandler handler = new ChargeInputHandler(logic);
+
+            handler.BeginHold((int)AttackButtonId.Heavy);
+            handler.UpdateHold(0.1f);
+            handler.EndHold((int)AttackButtonId.Heavy);
+
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                (AttackButtonId)handler.AttackButtonId, false, handler.IsCharging);
+            Assert.AreEqual(AttackInputType.HeavyAttack, result);
+        }
+
+        [Test]
+        public void ChargeHandler_LightLongPress_ProducesChargeLight()
+        {
+            ChargeAttackLogic logic = new ChargeAttackLogic();
+            ChargeInputHandler handler = new ChargeInputHandler(logic);
+
+            handler.BeginHold((int)AttackButtonId.Light);
+            handler.UpdateHold(0.6f); // > chargeLevel1 threshold
+            handler.EndHold((int)AttackButtonId.Light);
+
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                (AttackButtonId)handler.AttackButtonId, false, handler.IsCharging);
+            Assert.AreEqual(AttackInputType.ChargeLight, result);
+            Assert.Greater(handler.ChargeMultiplier, 1f);
+        }
+
+        [Test]
+        public void ChargeHandler_HeavyLongPress_ProducesChargeHeavy()
+        {
+            ChargeAttackLogic logic = new ChargeAttackLogic();
+            ChargeInputHandler handler = new ChargeInputHandler(logic);
+
+            handler.BeginHold((int)AttackButtonId.Heavy);
+            handler.UpdateHold(1.6f); // > chargeLevel2 threshold
+            handler.EndHold((int)AttackButtonId.Heavy);
+
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                (AttackButtonId)handler.AttackButtonId, false, handler.IsCharging);
+            Assert.AreEqual(AttackInputType.ChargeHeavy, result);
+            Assert.Greater(handler.ChargeMultiplier, 1f);
+        }
+
+        [Test]
+        public void ChargeHandler_SkillButton_ProducesSkill()
+        {
+            ChargeAttackLogic logic = new ChargeAttackLogic();
+            ChargeInputHandler handler = new ChargeInputHandler(logic);
+
+            handler.BeginHold((int)AttackButtonId.Skill);
+            handler.EndHold((int)AttackButtonId.Skill);
+
+            AttackInputType? result = InputConverter.ConvertAttackInput(
+                (AttackButtonId)handler.AttackButtonId, false, handler.IsCharging);
+            Assert.AreEqual(AttackInputType.Skill, result);
+        }
+
+        [Test]
+        public void ChargeHandler_CancelCharge_NoAttackOutput()
+        {
+            ChargeAttackLogic logic = new ChargeAttackLogic();
+            ChargeInputHandler handler = new ChargeInputHandler(logic);
+
+            handler.BeginHold((int)AttackButtonId.Light);
+            handler.UpdateHold(0.8f);
+            handler.CancelCharge();
+
+            Assert.IsFalse(handler.HasAttackInput);
+            Assert.IsFalse(handler.IsHolding);
+            Assert.AreEqual(1f, handler.ChargeMultiplier);
+        }
+
+        // =============================================================
+        //  AttackButtonId enum 値の一貫性
+        // =============================================================
+
+        [Test]
+        public void AttackButtonId_Values_MatchExpectedIntegers()
+        {
+            // PlayerInputHandler のポーリングは int キャストに依存
+            Assert.AreEqual(0, (int)AttackButtonId.Light);
+            Assert.AreEqual(1, (int)AttackButtonId.Heavy);
+            Assert.AreEqual(2, (int)AttackButtonId.Skill);
+        }
+
+        // =============================================================
+        //  InputConverter 全パターン網羅（境界）
+        // =============================================================
+
+        [Test]
+        public void InputConverter_AllButtonIds_GroundNoCharge_ReturnsCorrectType()
+        {
+            Assert.AreEqual(AttackInputType.LightAttack,
+                InputConverter.ConvertAttackInput(AttackButtonId.Light, false, false));
+            Assert.AreEqual(AttackInputType.HeavyAttack,
+                InputConverter.ConvertAttackInput(AttackButtonId.Heavy, false, false));
+            Assert.AreEqual(AttackInputType.Skill,
+                InputConverter.ConvertAttackInput(AttackButtonId.Skill, false, false));
+        }
+
+        [Test]
+        public void InputConverter_AllButtonIds_Airborne_ReturnsCorrectType()
+        {
+            Assert.AreEqual(AttackInputType.AerialLight,
+                InputConverter.ConvertAttackInput(AttackButtonId.Light, true, false));
+            Assert.AreEqual(AttackInputType.AerialHeavy,
+                InputConverter.ConvertAttackInput(AttackButtonId.Heavy, true, false));
+            // Skill は空中でも Skill
+            Assert.AreEqual(AttackInputType.Skill,
+                InputConverter.ConvertAttackInput(AttackButtonId.Skill, true, false));
+        }
+
+        [Test]
+        public void InputConverter_AllButtonIds_Charging_ReturnsCorrectType()
+        {
+            Assert.AreEqual(AttackInputType.ChargeLight,
+                InputConverter.ConvertAttackInput(AttackButtonId.Light, false, true));
+            Assert.AreEqual(AttackInputType.ChargeHeavy,
+                InputConverter.ConvertAttackInput(AttackButtonId.Heavy, false, true));
+            // Skill はチャージ関係なし
+            Assert.AreEqual(AttackInputType.Skill,
+                InputConverter.ConvertAttackInput(AttackButtonId.Skill, false, true));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/AllInputMappingTests.cs.meta
+++ b/Assets/Tests/EditMode/AllInputMappingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aea4f7f6dcbe12245817c57cedccbac0

--- a/Assets/Tests/EditMode/InputSystemCoreTests.cs
+++ b/Assets/Tests/EditMode/InputSystemCoreTests.cs
@@ -41,10 +41,10 @@ namespace Game.Tests.EditMode
         [Test]
         public void InputConverter_ConvertAttackInput_WhenAirborne_ReturnsAerialType()
         {
-            // Act: 空中でLightAttack (buttonId=0)
-            AttackInputType? aerialLight = InputConverter.ConvertAttackInput(0, isAirborne: true, isCharging: false);
-            // Act: 空中でHeavyAttack (buttonId=1)
-            AttackInputType? aerialHeavy = InputConverter.ConvertAttackInput(1, isAirborne: true, isCharging: false);
+            // Act: 空中でLightAttack
+            AttackInputType? aerialLight = InputConverter.ConvertAttackInput(AttackButtonId.Light, isAirborne: true, isCharging: false);
+            // Act: 空中でHeavyAttack
+            AttackInputType? aerialHeavy = InputConverter.ConvertAttackInput(AttackButtonId.Heavy, isAirborne: true, isCharging: false);
 
             // Assert
             Assert.AreEqual(AttackInputType.AerialLight, aerialLight);

--- a/Assets/Tests/EditMode/PlayerInputIntegrationTests.cs
+++ b/Assets/Tests/EditMode/PlayerInputIntegrationTests.cs
@@ -29,7 +29,7 @@ namespace Game.Tests.EditMode
 
             // Act — InputConverterで変換
             AttackInputType? result = InputConverter.ConvertAttackInput(
-                _chargeHandler.AttackButtonId, false, _chargeHandler.IsCharging);
+                (AttackButtonId)_chargeHandler.AttackButtonId, false, _chargeHandler.IsCharging);
 
             // Assert
             Assert.AreEqual(AttackInputType.LightAttack, result);
@@ -46,7 +46,7 @@ namespace Game.Tests.EditMode
 
             // Act
             AttackInputType? result = InputConverter.ConvertAttackInput(
-                _chargeHandler.AttackButtonId, false, _chargeHandler.IsCharging);
+                (AttackButtonId)_chargeHandler.AttackButtonId, false, _chargeHandler.IsCharging);
 
             // Assert
             Assert.AreEqual(AttackInputType.ChargeLight, result);
@@ -63,7 +63,7 @@ namespace Game.Tests.EditMode
 
             // Act
             AttackInputType? result = InputConverter.ConvertAttackInput(
-                _chargeHandler.AttackButtonId, false, _chargeHandler.IsCharging);
+                (AttackButtonId)_chargeHandler.AttackButtonId, false, _chargeHandler.IsCharging);
 
             // Assert
             Assert.AreEqual(AttackInputType.ChargeHeavy, result);
@@ -80,7 +80,7 @@ namespace Game.Tests.EditMode
 
             // Act — isAirborne=true
             AttackInputType? result = InputConverter.ConvertAttackInput(
-                _chargeHandler.AttackButtonId, true, _chargeHandler.IsCharging);
+                (AttackButtonId)_chargeHandler.AttackButtonId, true, _chargeHandler.IsCharging);
 
             // Assert — 空中攻撃が優先
             Assert.AreEqual(AttackInputType.AerialLight, result);
@@ -95,7 +95,7 @@ namespace Game.Tests.EditMode
 
             // Act
             AttackInputType? result = InputConverter.ConvertAttackInput(
-                _chargeHandler.AttackButtonId, false, _chargeHandler.IsCharging);
+                (AttackButtonId)_chargeHandler.AttackButtonId, false, _chargeHandler.IsCharging);
 
             // Assert — Skillはチャージ無関係
             Assert.AreEqual(AttackInputType.Skill, result);

--- a/Assets/Tests/EditMode/PlayerMovementGroundTests.cs
+++ b/Assets/Tests/EditMode/PlayerMovementGroundTests.cs
@@ -126,7 +126,7 @@ namespace Game.Tests.EditMode
 
             Assert.IsTrue(started);
             Assert.IsTrue(_logic.IsDashing);
-            Assert.AreEqual(100f - GroundMovementLogic.k_DashStaminaCost, stamina, 0.001f);
+            Assert.AreEqual(100f - GroundMovementLogic.k_DodgeStaminaCost, stamina, 0.001f);
         }
 
         [Test]

--- a/Assets/Tests/PlayMode/BaseCharacterLifecycleTests.cs.meta
+++ b/Assets/Tests/PlayMode/BaseCharacterLifecycleTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f05724d16f578dc428211d238c6b580b

--- a/Assets/Tests/PlayMode/CharacterRegistryIntegrationTests.cs.meta
+++ b/Assets/Tests/PlayMode/CharacterRegistryIntegrationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 63d9b467730238f43b8f403c485ccd89

--- a/Assets/Tests/PlayMode/MultiCharacterCoexistenceTests.cs.meta
+++ b/Assets/Tests/PlayMode/MultiCharacterCoexistenceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1fd35cb543ce8ae4babd5d04ef62635e

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -3,12 +3,12 @@
 --- !u!19 &1
 Physics2DSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 5
+  serializedVersion: 11
   m_Gravity: {x: 0, y: -9.81}
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 8
   m_PositionIterations: 3
-  m_VelocityThreshold: 1
+  m_BounceThreshold: 1
   m_MaxLinearCorrection: 0.2
   m_MaxAngularCorrection: 8
   m_MaxTranslationSpeed: 100
@@ -19,6 +19,7 @@ Physics2DSettings:
   m_LinearSleepTolerance: 0.01
   m_AngularSleepTolerance: 2
   m_DefaultContactOffset: 0.01
+  m_ContactThreshold: 0
   m_JobOptions:
     serializedVersion: 2
     useMultithreading: 0
@@ -39,18 +40,18 @@ Physics2DSettings:
     m_IslandSolverBodiesPerJob: 50
     m_IslandSolverContactsPerJob: 50
   m_SimulationMode: 0
+  m_SimulationLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_MaxSubStepCount: 4
+  m_MinSubStepFPS: 30
+  m_UseSubStepping: 0
+  m_UseSubStepContacts: 0
   m_QueriesHitTriggers: 1
   m_QueriesStartInColliders: 1
   m_CallbacksOnDisable: 1
   m_ReuseCollisionCallbacks: 1
   m_AutoSyncTransforms: 0
-  m_AlwaysShowColliders: 0
-  m_ShowColliderSleep: 1
-  m_ShowColliderContacts: 0
-  m_ShowColliderAABB: 0
-  m_ContactArrowScale: 0.2
-  m_ColliderAwakeColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.7529412}
-  m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
-  m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
-  m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_GizmoOptions: 10
+  m_LayerCollisionMatrix: fffffffffffffffffffffffffffffffffffffffffffffffffff3ffffffabffffffa5ffffffaaffff3fb5ffffbfbaffff7facffffffbfffff7f80ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_PhysicsLowLevelSettings: {fileID: 0}

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -12,15 +12,15 @@ TagManager:
   - Water
   - UI
   - Ground
-  -
-  -
-  -
+  - Player
+  - Enemy
+  - Companion
   - PlayerHitbox
   - EnemyHitbox
   - CharaPassThrough
   - CharaCollide
   - CharaInvincible
-  -
+  - 
   - 
   - 
   - 


### PR DESCRIPTION
## Summary
- **物理レイヤー統一**: 全キャラをレイヤー12(CharaPassThrough)に統一し、CollisionMatrixSetup準拠に修正。旧レイヤー7/8/9の不整合を解消
- **攻撃ヒット修正**: HitBoxに陣営チェック(CharacterBelong)と死亡チェック(IsAlive)を追加。フレンドリーファイア防止+死体攻撃遮断防止
- **強攻撃二重発火修正**: 押下時即発動→リリース時確定方式に変更。短押し=通常強攻撃、長押し=ため攻撃
- **攻撃中移動ブロック**: IsActionExecutorBusy時に通常移動・スプリントを無効化。攻撃移動(AttackInfo駆動)のみ許可
- **敵AI攻撃修正**: 検出範囲拡大(8→15)、モード遷移sourceModeIndex追加、Wait無限ループ解消、BridgeAction ForceComplete追加
- **ActionExecutor衝突モード**: 攻撃開始時SetCollisionMode、終了時ClearCollisionModeを追加
- **TestSceneBuilder**: テストシーン自動構築エディタツール+PLACEHOLDERアセット一式
- **AutoInputTester**: 12カテゴリのテスト選択機能をInspectorに追加
- **DamagePopupController**: R3 Observable購読でダメージポップアップ表示

## Test plan
- [ ] Tools > Build Test Scene でテストシーン再構築
- [ ] Play Modeで敵がプレイヤーに接近→攻撃を実行するか確認
- [ ] プレイヤーの攻撃が敵にダメージを与え、ダメージポップアップが表示されるか確認
- [ ] 強攻撃が短押しリリース時に1回だけ発動するか確認
- [ ] 攻撃中にプレイヤーが移動入力で動かないか確認
- [ ] 敵撃破後にさらに攻撃しても当たらないか確認
- [ ] EditModeテストが全Passするか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)