### PR TITLE
feat(ui): 仲間AI設定UIにターゲット選定/切替ルール編集を追加

### DIFF
--- a/Assets/MyAsset/Core/UI/CompanionAISettingsLogic.cs
+++ b/Assets/MyAsset/Core/UI/CompanionAISettingsLogic.cs
@@ -538,5 +538,34 @@ namespace Game.Core
 
             return clone;
         }
+
+        /// <summary>
+        /// targetSelect を1件削除した時の targetRules 配列を返す純粋関数。
+        /// 参照していた rule は破棄し、より大きい actionIndex を decrement する。
+        /// UI の RebuildTargetSelectList 削除ボタンから呼ばれ、同時にテストから直接検証される。
+        /// </summary>
+        public static AIRule[] AdjustTargetRulesForRemovedSelect(AIRule[] rules, int removedIdx)
+        {
+            if (rules == null || rules.Length == 0)
+            {
+                return rules ?? new AIRule[0];
+            }
+
+            List<AIRule> adjusted = new List<AIRule>(rules.Length);
+            for (int k = 0; k < rules.Length; k++)
+            {
+                AIRule r = rules[k];
+                if (r.actionIndex == removedIdx)
+                {
+                    continue;
+                }
+                if (r.actionIndex > removedIdx)
+                {
+                    r.actionIndex--;
+                }
+                adjusted.Add(r);
+            }
+            return adjusted.ToArray();
+        }
     }
 }

--- a/Assets/MyAsset/Runtime/UI/CompanionAISettingsController.Dialogs.cs
+++ b/Assets/MyAsset/Runtime/UI/CompanionAISettingsController.Dialogs.cs
@@ -993,11 +993,7 @@ namespace Game.Runtime
                   .Append(f.distanceRange.y.ToString("0.#"))
                   .Append("m");
             }
-            if (f.includeSelf)
-            {
-                if (sb.Length > 0) sb.Append(", ");
-                sb.Append("自分も含む");
-            }
+            // includeSelf は UI 編集廃止（Companion 特徴で代替）したため、サマリでも表示しない。
             if (sb.Length == 0)
             {
                 return "条件なし（全員が対象）";
@@ -2238,25 +2234,11 @@ namespace Game.Runtime
                     }
                     setSelects(newArr);
 
-                    // targetRules のインデックス整合: 参照ルール破棄 + より大きい index を decrement
+                    // targetRules のインデックス整合: Logic 層の純粋関数を経由（テストで直接検証される）
                     AIRule[] rules = getTargetRules();
                     if (rules != null && rules.Length > 0)
                     {
-                        List<AIRule> adjusted = new List<AIRule>(rules.Length);
-                        for (int k = 0; k < rules.Length; k++)
-                        {
-                            AIRule r = rules[k];
-                            if (r.actionIndex == idx)
-                            {
-                                continue;
-                            }
-                            if (r.actionIndex > idx)
-                            {
-                                r.actionIndex--;
-                            }
-                            adjusted.Add(r);
-                        }
-                        setTargetRules(adjusted.ToArray());
+                        setTargetRules(CompanionAISettingsLogic.AdjustTargetRulesForRemovedSelect(rules, idx));
                     }
 
                     rebuild();
@@ -2296,6 +2278,15 @@ namespace Game.Runtime
             }
 
             AIMode parentMode = getParentMode();
+
+            // ルールはあるが targetSelects が空の場合、このモードの第1層判定は機能しない状態。警告を出す。
+            if (parentMode.targetSelects == null || parentMode.targetSelects.Length == 0)
+            {
+                Label warn = new Label("⚠ ターゲット選定が空のため、これらのルールは参照先が無く機能しません");
+                warn.AddToClassList("mode-detail-empty");
+                container.Add(warn);
+            }
+
             for (int i = 0; i < count; i++)
             {
                 int idx = i;
@@ -2313,12 +2304,17 @@ namespace Game.Runtime
 
                 Button editButton = new Button(() =>
                 {
-                    ShowTargetRuleEditDialog(rule, getParentMode(), edited =>
+                    AIRule[] arr = getRules();
+                    if (arr == null || idx >= arr.Length)
                     {
-                        AIRule[] arr = getRules();
-                        if (arr != null && idx < arr.Length)
+                        return;
+                    }
+                    ShowTargetRuleEditDialog(arr[idx], getParentMode(), edited =>
+                    {
+                        AIRule[] current = getRules();
+                        if (current != null && idx < current.Length)
                         {
-                            arr[idx] = edited;
+                            current[idx] = edited;
                         }
                         rebuild();
                     });

--- a/Assets/MyAsset/Runtime/UI/CompanionAISettingsController.Dialogs.cs
+++ b/Assets/MyAsset/Runtime/UI/CompanionAISettingsController.Dialogs.cs
@@ -87,6 +87,97 @@ namespace Game.Runtime
             });
             basicSection.Add(defaultIndexField);
 
+            // === ターゲット選定 (targetSelects) — JudgmentLoop 第1層 ===
+            VisualElement targetSelectsSection = BuildDetailSection("ターゲット選定 (誰を狙うか)");
+            scroll.Add(targetSelectsSection);
+
+            VisualElement targetSelectsList = new VisualElement();
+            targetSelectsList.AddToClassList("mode-detail-list");
+            targetSelectsSection.Add(targetSelectsList);
+
+            Action rebuildTargetSelects = null;
+            rebuildTargetSelects = () => RebuildTargetSelectList(
+                targetSelectsList,
+                () => working.targetSelects,
+                arr => working.targetSelects = arr,
+                rebuildTargetSelects,
+                () => working.targetRules,
+                arr => working.targetRules = arr);
+            rebuildTargetSelects();
+
+            Button addTargetSelectButton = new Button(() =>
+            {
+                AITargetSelect newTs = new AITargetSelect
+                {
+                    sortKey = TargetSortKey.Distance,
+                    isDescending = false,
+                    filter = new TargetFilter
+                    {
+                        belong = CharacterBelong.Enemy,
+                        includeSelf = false,
+                    },
+                };
+                int newCount = (working.targetSelects != null ? working.targetSelects.Length : 0) + 1;
+                AITargetSelect[] newArr = new AITargetSelect[newCount];
+                if (working.targetSelects != null)
+                {
+                    for (int i = 0; i < working.targetSelects.Length; i++)
+                    {
+                        newArr[i] = working.targetSelects[i];
+                    }
+                }
+                newArr[newCount - 1] = newTs;
+                working.targetSelects = newArr;
+                rebuildTargetSelects();
+            });
+            addTargetSelectButton.text = "＋ ターゲット選定を追加";
+            addTargetSelectButton.tooltip = "新しいターゲット選定パターンを追加";
+            addTargetSelectButton.AddToClassList("mode-detail-add-button");
+            targetSelectsSection.Add(addTargetSelectButton);
+
+            // === ターゲット切替ルール (targetRules) — JudgmentLoop 第1層ルール ===
+            VisualElement targetRulesSection = BuildDetailSection("ターゲット切替ルール (優先度順)");
+            scroll.Add(targetRulesSection);
+
+            VisualElement targetRulesList = new VisualElement();
+            targetRulesList.AddToClassList("mode-detail-list");
+            targetRulesSection.Add(targetRulesList);
+
+            Action rebuildTargetRules = null;
+            rebuildTargetRules = () => RebuildTargetRuleList(
+                targetRulesList,
+                () => working.targetRules,
+                arr => working.targetRules = arr,
+                () => working,
+                rebuildTargetRules);
+            rebuildTargetRules();
+
+            Button addTargetRuleButton = new Button(() =>
+            {
+                AIRule newRule = new AIRule
+                {
+                    conditions = new AICondition[0],
+                    actionIndex = 0,
+                    probability = 100,
+                };
+                int newCount = (working.targetRules != null ? working.targetRules.Length : 0) + 1;
+                AIRule[] newArr = new AIRule[newCount];
+                if (working.targetRules != null)
+                {
+                    for (int i = 0; i < working.targetRules.Length; i++)
+                    {
+                        newArr[i] = working.targetRules[i];
+                    }
+                }
+                newArr[newCount - 1] = newRule;
+                working.targetRules = newArr;
+                rebuildTargetRules();
+            });
+            addTargetRuleButton.text = "＋ ターゲット切替ルールを追加";
+            addTargetRuleButton.tooltip = "新しいターゲット切替ルールを追加";
+            addTargetRuleButton.AddToClassList("mode-detail-add-button");
+            targetRulesSection.Add(addTargetRuleButton);
+
             // === 行動スロット ===
             VisualElement actionsSection = BuildDetailSection("行動スロット");
             scroll.Add(actionsSection);
@@ -474,7 +565,7 @@ namespace Game.Runtime
                     compareOp = CompareOp.LessEqual,
                     operandA = 50,
                     operandB = 0,
-                    filter = new TargetFilter { filterFlags = FilterBitFlag.IsSelf, includeSelf = true },
+                    filter = new TargetFilter(),
                 };
                 working.conditions = newArr;
                 rebuildConditions();
@@ -634,7 +725,8 @@ namespace Game.Runtime
 
         /// <summary>
         /// TargetFilter の編集 UI を Foldout で構築する。
-        /// 対象の選び方（自分/プレイヤー/周囲から陣営+特徴で絞る）と距離範囲を編集可能。
+        /// 陣営/特徴/弱点属性/距離範囲を編集可能。
+        /// 「自分を参照」は仲間AI設定では特徴=Companion（コンパニオンは1体のみ）で代替できるため、includeSelf UI は提供しない。
         /// </summary>
         private VisualElement BuildTargetFilterSection(TargetFilter initial, Action<TargetFilter> onChanged)
         {
@@ -661,16 +753,9 @@ namespace Game.Runtime
                 onChanged?.Invoke(current);
             }
 
-            Toggle includeSelfToggle = new Toggle("自分も対象に含める");
-            includeSelfToggle.tooltip = "自分自身を対象に含めるかどうか";
-            includeSelfToggle.value = current.includeSelf;
-            includeSelfToggle.RegisterValueChangedCallback(evt =>
-            {
-                current.includeSelf = evt.newValue;
-                onChanged?.Invoke(current);
-                updateSummary();
-            });
-            foldout.Add(includeSelfToggle);
+            // includeSelf は UI で提供しない。
+            // 自分を参照したい場合は下の「特徴」で Companion にチェックを入れる（コンパニオンは1体のみ）。
+            // 既存データの includeSelf 値はそのまま保持される。
 
             // 陣営フィルター
             VisualElement belongSection = new VisualElement();
@@ -1367,7 +1452,7 @@ namespace Game.Runtime
                     compareOp = CompareOp.LessEqual,
                     operandA = 30,
                     operandB = 0,
-                    filter = new TargetFilter { filterFlags = FilterBitFlag.IsSelf, includeSelf = true },
+                    filter = new TargetFilter(),
                 };
                 working.conditions = newArr;
                 rebuildConditions();
@@ -2000,6 +2085,481 @@ namespace Game.Runtime
             };
             clone.conditions = source.conditions != null ? (AICondition[])source.conditions.Clone() : new AICondition[0];
             return clone;
+        }
+
+        // =========================================================================
+        // Target Select / Target Rule 編集UI (JudgmentLoop 第1層: ターゲット選択)
+        // =========================================================================
+
+        private static AITargetSelect CloneTargetSelect(AITargetSelect source)
+        {
+            return new AITargetSelect
+            {
+                sortKey = source.sortKey,
+                elementFilter = source.elementFilter,
+                isDescending = source.isDescending,
+                filter = source.filter,
+            };
+        }
+
+        private static string GetSortKeyLabel(TargetSortKey k)
+        {
+            switch (k)
+            {
+                case TargetSortKey.Distance:        return "距離";
+                case TargetSortKey.HpRatio:         return "HP割合";
+                case TargetSortKey.HpValue:         return "HP値";
+                case TargetSortKey.AttackPower:     return "攻撃力";
+                case TargetSortKey.DefensePower:    return "防御力";
+                case TargetSortKey.TargetingCount:  return "狙われ数";
+                case TargetSortKey.LastAttacker:    return "最終攻撃者";
+                case TargetSortKey.DamageScore:     return "ダメージスコア";
+                case TargetSortKey.Self:            return "自分";
+                case TargetSortKey.Player:          return "プレイヤー";
+                case TargetSortKey.Sister:          return "妹";
+                default:                            return k.ToString();
+            }
+        }
+
+        /// <summary>
+        /// AITargetSelect の概要を1行で返す。リスト表示・ドロップダウンラベル用。
+        /// </summary>
+        private static string FormatTargetSelectSummary(AITargetSelect ts)
+        {
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            sb.Append(GetSortKeyLabel(ts.sortKey));
+            sb.Append(ts.isDescending ? "↓" : "↑");
+            if (ts.elementFilter != 0)
+            {
+                sb.Append(" 弱点=").Append(ts.elementFilter.ToString());
+            }
+            string filterSummary = FormatFilterSummary(ts.filter);
+            if (filterSummary != "条件なし（全員が対象）")
+            {
+                sb.Append(" / ").Append(filterSummary);
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// ターゲット切替ルールの概要を1行で返す。参照先 targetSelects の内容もプレビューする。
+        /// </summary>
+        private static string FormatTargetRuleSummary(AIRule rule, AIMode mode)
+        {
+            int condCount = rule.conditions != null ? rule.conditions.Length : 0;
+            string condText = condCount == 0 ? "常時" : condCount + "個の条件(AND)";
+            string tsName = "#" + rule.actionIndex;
+            if (mode.targetSelects != null && rule.actionIndex >= 0 && rule.actionIndex < mode.targetSelects.Length)
+            {
+                tsName = "#" + rule.actionIndex + " " + FormatTargetSelectSummary(mode.targetSelects[rule.actionIndex]);
+            }
+            string prob = rule.probability == 100 ? "" : " (" + rule.probability + "%)";
+            return condText + " → " + tsName + prob;
+        }
+
+        /// <summary>
+        /// ターゲット選定リスト (AITargetSelect[]) を描画する。
+        /// 削除時に targetRules の actionIndex を自動補正する（参照ルール破棄 + より大きい index の decrement）。
+        /// </summary>
+        private void RebuildTargetSelectList(
+            VisualElement container,
+            Func<AITargetSelect[]> getSelects,
+            Action<AITargetSelect[]> setSelects,
+            Action rebuild,
+            Func<AIRule[]> getTargetRules,
+            Action<AIRule[]> setTargetRules)
+        {
+            container.Clear();
+
+            AITargetSelect[] selects = getSelects();
+            int count = selects != null ? selects.Length : 0;
+            if (count == 0)
+            {
+                Label empty = new Label("(ターゲット選定が空です - 第1層判定が機能しません)");
+                empty.AddToClassList("mode-detail-empty");
+                container.Add(empty);
+                return;
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                int idx = i;
+                AITargetSelect ts = selects[idx];
+                VisualElement row = new VisualElement();
+                row.AddToClassList("mode-detail-row");
+
+                Label indexLabel = new Label("[" + idx + "]");
+                indexLabel.AddToClassList("mode-detail-row__index");
+                row.Add(indexLabel);
+
+                Label label = new Label(FormatTargetSelectSummary(ts));
+                label.AddToClassList("mode-detail-row__label");
+                row.Add(label);
+
+                Button editButton = new Button(() =>
+                {
+                    AITargetSelect[] arr = getSelects();
+                    if (arr == null || idx >= arr.Length)
+                    {
+                        return;
+                    }
+                    ShowTargetSelectEditDialog(arr[idx], edited =>
+                    {
+                        AITargetSelect[] current = getSelects();
+                        if (current != null && idx < current.Length)
+                        {
+                            current[idx] = edited;
+                        }
+                        rebuild();
+                    });
+                });
+                editButton.text = "編集";
+                editButton.tooltip = "このターゲット選定を編集";
+                editButton.AddToClassList("mode-detail-row__button");
+                editButton.AddToClassList("secondary-button");
+                row.Add(editButton);
+
+                Button removeButton = new Button(() =>
+                {
+                    AITargetSelect[] arr = getSelects();
+                    if (arr == null || arr.Length == 0)
+                    {
+                        return;
+                    }
+                    AITargetSelect[] newArr = new AITargetSelect[arr.Length - 1];
+                    int dst = 0;
+                    for (int k = 0; k < arr.Length; k++)
+                    {
+                        if (k == idx)
+                        {
+                            continue;
+                        }
+                        newArr[dst++] = arr[k];
+                    }
+                    setSelects(newArr);
+
+                    // targetRules のインデックス整合: 参照ルール破棄 + より大きい index を decrement
+                    AIRule[] rules = getTargetRules();
+                    if (rules != null && rules.Length > 0)
+                    {
+                        List<AIRule> adjusted = new List<AIRule>(rules.Length);
+                        for (int k = 0; k < rules.Length; k++)
+                        {
+                            AIRule r = rules[k];
+                            if (r.actionIndex == idx)
+                            {
+                                continue;
+                            }
+                            if (r.actionIndex > idx)
+                            {
+                                r.actionIndex--;
+                            }
+                            adjusted.Add(r);
+                        }
+                        setTargetRules(adjusted.ToArray());
+                    }
+
+                    rebuild();
+                });
+                removeButton.text = "×";
+                removeButton.tooltip = "このターゲット選定を削除（参照するルールも自動調整）";
+                removeButton.AddToClassList("mode-detail-row__button");
+                removeButton.AddToClassList("danger-button");
+                row.Add(removeButton);
+
+                container.Add(row);
+            }
+
+            AttachTooltipHandlers(container);
+        }
+
+        /// <summary>
+        /// ターゲット切替ルールリスト (AIRule[]) を描画する。actionRules と同型の getter/setter closure パターン。
+        /// </summary>
+        private void RebuildTargetRuleList(
+            VisualElement container,
+            Func<AIRule[]> getRules,
+            Action<AIRule[]> setRules,
+            Func<AIMode> getParentMode,
+            Action rebuild)
+        {
+            container.Clear();
+
+            AIRule[] rules = getRules();
+            int count = rules != null ? rules.Length : 0;
+            if (count == 0)
+            {
+                Label empty = new Label("(ルールなし - 第1層判定は何もしません)");
+                empty.AddToClassList("mode-detail-empty");
+                container.Add(empty);
+                return;
+            }
+
+            AIMode parentMode = getParentMode();
+            for (int i = 0; i < count; i++)
+            {
+                int idx = i;
+                AIRule rule = rules[idx];
+                VisualElement row = new VisualElement();
+                row.AddToClassList("mode-detail-row");
+
+                Label priority = new Label("#" + (idx + 1));
+                priority.AddToClassList("mode-detail-row__index");
+                row.Add(priority);
+
+                Label summary = new Label(FormatTargetRuleSummary(rule, parentMode));
+                summary.AddToClassList("mode-detail-row__label");
+                row.Add(summary);
+
+                Button editButton = new Button(() =>
+                {
+                    ShowTargetRuleEditDialog(rule, getParentMode(), edited =>
+                    {
+                        AIRule[] arr = getRules();
+                        if (arr != null && idx < arr.Length)
+                        {
+                            arr[idx] = edited;
+                        }
+                        rebuild();
+                    });
+                });
+                editButton.text = "編集";
+                editButton.tooltip = "このターゲットルールを編集";
+                editButton.AddToClassList("mode-detail-row__button");
+                editButton.AddToClassList("secondary-button");
+                row.Add(editButton);
+
+                Button removeButton = new Button(() =>
+                {
+                    AIRule[] arr = getRules();
+                    if (arr == null || arr.Length == 0)
+                    {
+                        return;
+                    }
+                    AIRule[] newArr = new AIRule[arr.Length - 1];
+                    int dst = 0;
+                    for (int k = 0; k < arr.Length; k++)
+                    {
+                        if (k == idx)
+                        {
+                            continue;
+                        }
+                        newArr[dst++] = arr[k];
+                    }
+                    setRules(newArr);
+                    rebuild();
+                });
+                removeButton.text = "×";
+                removeButton.tooltip = "このルールを削除";
+                removeButton.AddToClassList("mode-detail-row__button");
+                removeButton.AddToClassList("danger-button");
+                row.Add(removeButton);
+
+                container.Add(row);
+            }
+
+            AttachTooltipHandlers(container);
+        }
+
+        /// <summary>
+        /// AITargetSelect 1件の編集ダイアログ。sortKey / isDescending / elementFilter / TargetFilter を編集。
+        /// </summary>
+        private void ShowTargetSelectEditDialog(AITargetSelect initial, Action<AITargetSelect> onConfirm)
+        {
+            AITargetSelect working = CloneTargetSelect(initial);
+
+            VisualElement dialog = BuildModalDialog("ターゲット選定編集", "並び順 + 属性/陣営フィルタで候補を絞り込みます。");
+            dialog.AddToClassList("target-select-edit-dialog");
+
+            ScrollView scroll = new ScrollView(ScrollViewMode.Vertical);
+            scroll.AddToClassList("mode-detail-scroll");
+            dialog.Add(scroll);
+
+            // === 並び順 ===
+            VisualElement sortSection = BuildDetailSection("並び順");
+            scroll.Add(sortSection);
+
+            TargetSortKey[] allSortKeys = (TargetSortKey[])Enum.GetValues(typeof(TargetSortKey));
+            List<string> sortChoices = new List<string>();
+            for (int i = 0; i < allSortKeys.Length; i++)
+            {
+                sortChoices.Add(GetSortKeyLabel(allSortKeys[i]));
+            }
+            int initialSortIndex = Array.IndexOf(allSortKeys, working.sortKey);
+            if (initialSortIndex < 0) initialSortIndex = 0;
+
+            DropdownField sortDropdown = new DropdownField("並び順キー", sortChoices, initialSortIndex);
+            sortDropdown.tooltip = "候補の中から最優先を1体選ぶための判断基準";
+            sortDropdown.RegisterValueChangedCallback(evt =>
+            {
+                int newIdx = sortDropdown.index;
+                if (newIdx >= 0 && newIdx < allSortKeys.Length)
+                {
+                    working.sortKey = allSortKeys[newIdx];
+                }
+            });
+            sortSection.Add(sortDropdown);
+
+            Toggle descToggle = new Toggle("降順 (大きい順)");
+            descToggle.tooltip = "OFF: 小さい順（例: 距離の昇順 = 近い順） / ON: 大きい順";
+            descToggle.value = working.isDescending;
+            descToggle.RegisterValueChangedCallback(evt => working.isDescending = evt.newValue);
+            sortSection.Add(descToggle);
+
+            // === 弱点属性フィルタ ===
+            VisualElement elemSection = BuildDetailSection("弱点属性フィルタ (候補絞り込み)");
+            scroll.Add(elemSection);
+
+            VisualElement elemFlags = new VisualElement();
+            elemFlags.AddToClassList("condition-row__flags");
+            foreach (object v in Enum.GetValues(typeof(Element)))
+            {
+                Element elem = (Element)v;
+                if ((int)elem == 0)
+                {
+                    continue;
+                }
+                Element captured = elem;
+                Toggle t = new Toggle(GetElementLabel(elem));
+                t.tooltip = "指定属性に弱い候補のみ対象。未指定=属性フィルタなし。";
+                t.value = (working.elementFilter & captured) != 0;
+                t.AddToClassList("condition-row__flag-toggle");
+                t.RegisterValueChangedCallback(evt =>
+                {
+                    if (evt.newValue)
+                    {
+                        working.elementFilter |= captured;
+                    }
+                    else
+                    {
+                        working.elementFilter &= ~captured;
+                    }
+                });
+                elemFlags.Add(t);
+            }
+            elemSection.Add(elemFlags);
+
+            // === 対象キャラクターフィルタ (既存 BuildTargetFilterSection 再利用) ===
+            VisualElement filterSection = BuildDetailSection("対象キャラクターフィルタ");
+            scroll.Add(filterSection);
+
+            VisualElement filterUi = BuildTargetFilterSection(working.filter, updated =>
+            {
+                working.filter = updated;
+            });
+            filterSection.Add(filterUi);
+
+            // === ボタン列 ===
+            VisualElement buttons = BuildButtonRow();
+            buttons.Add(BuildDialogButton("保存", "primary-button", () => onConfirm?.Invoke(working)));
+            buttons.Add(BuildDialogButton("キャンセル", "secondary-button", null));
+            dialog.Add(buttons);
+
+            ShowDialog(dialog);
+            AttachTooltipHandlers(dialog);
+        }
+
+        /// <summary>
+        /// AIRule (ターゲット切替ルール) 1件の編集ダイアログ。
+        /// actionIndex の選択肢は parentMode.targetSelects を参照する。
+        /// </summary>
+        private void ShowTargetRuleEditDialog(AIRule initialRule, AIMode parentMode, Action<AIRule> onConfirm)
+        {
+            AIRule working = CloneRule(initialRule);
+
+            VisualElement dialog = BuildModalDialog("ターゲット切替ルール編集", "条件はすべて AND 結合されます。ルール配列の順序が優先度（先勝ち）です。");
+            dialog.AddToClassList("target-rule-edit-dialog");
+
+            ScrollView scroll = new ScrollView(ScrollViewMode.Vertical);
+            scroll.AddToClassList("mode-detail-scroll");
+            dialog.Add(scroll);
+
+            // === 使用するターゲット選定 (actionIndex) ===
+            VisualElement targetSection = BuildDetailSection("使用するターゲット選定");
+            scroll.Add(targetSection);
+
+            List<string> tsChoices = new List<string>();
+            int tsCount = parentMode.targetSelects != null ? parentMode.targetSelects.Length : 0;
+            for (int i = 0; i < tsCount; i++)
+            {
+                tsChoices.Add("#" + i + " " + FormatTargetSelectSummary(parentMode.targetSelects[i]));
+            }
+            if (tsChoices.Count == 0)
+            {
+                tsChoices.Add("(ターゲット選定が空です)");
+            }
+
+            DropdownField tsDropdown = new DropdownField("ターゲット選定", tsChoices, Mathf.Clamp(working.actionIndex, 0, tsChoices.Count - 1));
+            tsDropdown.tooltip = "このルールが満たされた時に使うターゲット選定パターン";
+            tsDropdown.RegisterValueChangedCallback(evt =>
+            {
+                int newIndex = tsDropdown.index;
+                if (newIndex >= 0)
+                {
+                    working.actionIndex = newIndex;
+                }
+            });
+            targetSection.Add(tsDropdown);
+
+            Slider probSlider = new Slider("発動確率(%)", 0, 100);
+            probSlider.value = working.probability;
+            probSlider.tooltip = "ルール条件成立時にこのターゲット選定を使う確率(0-100)";
+            probSlider.showInputField = true;
+            probSlider.RegisterValueChangedCallback(evt =>
+            {
+                working.probability = (byte)Mathf.Clamp(Mathf.RoundToInt(evt.newValue), 0, 100);
+            });
+            targetSection.Add(probSlider);
+
+            // === 条件 (既存 RebuildConditionList を再利用) ===
+            VisualElement conditionsSection = BuildDetailSection("条件 (AND結合)");
+            scroll.Add(conditionsSection);
+
+            VisualElement conditionsList = new VisualElement();
+            conditionsList.AddToClassList("mode-detail-list");
+            conditionsSection.Add(conditionsList);
+
+            Action rebuildConditions = null;
+            rebuildConditions = () => RebuildConditionList(
+                conditionsList,
+                () => working.conditions,
+                arr => working.conditions = arr,
+                rebuildConditions);
+            rebuildConditions();
+
+            Button addCondButton = new Button(() =>
+            {
+                int newCount = (working.conditions != null ? working.conditions.Length : 0) + 1;
+                AICondition[] newArr = new AICondition[newCount];
+                if (working.conditions != null)
+                {
+                    for (int i = 0; i < working.conditions.Length; i++)
+                    {
+                        newArr[i] = working.conditions[i];
+                    }
+                }
+                newArr[newCount - 1] = new AICondition
+                {
+                    conditionType = AIConditionType.HpRatio,
+                    compareOp = CompareOp.LessEqual,
+                    operandA = 50,
+                    operandB = 0,
+                    filter = new TargetFilter(),
+                };
+                working.conditions = newArr;
+                rebuildConditions();
+            });
+            addCondButton.text = "＋ 条件を追加";
+            addCondButton.AddToClassList("mode-detail-add-button");
+            conditionsSection.Add(addCondButton);
+
+            VisualElement buttons = BuildButtonRow();
+            buttons.Add(BuildDialogButton("保存", "primary-button", () => onConfirm?.Invoke(working)));
+            buttons.Add(BuildDialogButton("キャンセル", "secondary-button", null));
+            dialog.Add(buttons);
+
+            ShowDialog(dialog);
+            AttachTooltipHandlers(dialog);
         }
     }
 }

--- a/Assets/MyAsset/Runtime/UI/CompanionAISettingsController.cs
+++ b/Assets/MyAsset/Runtime/UI/CompanionAISettingsController.cs
@@ -642,8 +642,39 @@ namespace Game.Runtime
             AIMode[] available = _modeRegistry.GetAll();
             if (available.Length == 0)
             {
-                // 空のモードを追加
-                bool ok = _logic.AddModeToBuffer(new AIMode { modeName = "新規モード", modeId = "" });
+                // UI単独で即動作する最小構成: Enemy を近距離順に狙う targetSelect 1件 + 無条件ルール 1件
+                AIMode emptyMode = new AIMode
+                {
+                    modeName = "新規モード",
+                    modeId = "",
+                    actions = new ActionSlot[0],
+                    actionRules = new AIRule[0],
+                    targetSelects = new AITargetSelect[]
+                    {
+                        new AITargetSelect
+                        {
+                            sortKey = TargetSortKey.Distance,
+                            isDescending = false,
+                            filter = new TargetFilter
+                            {
+                                belong = CharacterBelong.Enemy,
+                                includeSelf = false,
+                            },
+                        },
+                    },
+                    targetRules = new AIRule[]
+                    {
+                        new AIRule
+                        {
+                            conditions = new AICondition[0],
+                            actionIndex = 0,
+                            probability = 100,
+                        },
+                    },
+                    defaultActionIndex = 0,
+                    judgeInterval = new UnityEngine.Vector2(0.4f, 0.6f),
+                };
+                bool ok = _logic.AddModeToBuffer(emptyMode);
                 if (!ok)
                 {
                     ShowInfoDialog("モードは最大4個までです。");

--- a/Assets/MyAsset/Runtime/UI/CompanionAISettingsController.cs
+++ b/Assets/MyAsset/Runtime/UI/CompanionAISettingsController.cs
@@ -74,6 +74,10 @@ namespace Game.Runtime
 
         private const int k_ShortcutSlotCount = 4;
 
+        // 新規モード追加時のデフォルト判定間隔（min/max 秒）。ゆらぎ範囲。
+        private const float k_DefaultJudgeIntervalMin = 0.4f;
+        private const float k_DefaultJudgeIntervalMax = 0.6f;
+
         // =========================================================================
         // Lifecycle
         // =========================================================================
@@ -672,7 +676,7 @@ namespace Game.Runtime
                         },
                     },
                     defaultActionIndex = 0,
-                    judgeInterval = new UnityEngine.Vector2(0.4f, 0.6f),
+                    judgeInterval = new Vector2(k_DefaultJudgeIntervalMin, k_DefaultJudgeIntervalMax),
                 };
                 bool ok = _logic.AddModeToBuffer(emptyMode);
                 if (!ok)

--- a/Assets/Tests/EditMode/Integration_CompanionAISettingsFlowTests.cs
+++ b/Assets/Tests/EditMode/Integration_CompanionAISettingsFlowTests.cs
@@ -675,67 +675,66 @@ namespace Game.Tests.EditMode
         }
 
         /// <summary>
-        /// UI の RebuildTargetSelectList 削除ボタン挙動を Logic API 経由で再現し、
-        /// targetSelect 削除時に targetRules の actionIndex が整合補正される
-        /// （参照ルール破棄 + より大きい index の decrement）ことを確認する。
+        /// CompanionAISettingsLogic.AdjustTargetRulesForRemovedSelect を直接検証する。
+        /// UI の RebuildTargetSelectList 削除ボタンは実装本体としてこのヘルパーを呼んでおり、
+        /// ロジックを自前再現するのではなく純粋関数として直接テストする。
         /// </summary>
         [Test]
-        public void CompanionAISettings_UILike_RemoveTargetSelect_AdjustsReferencingRules()
+        public void AdjustTargetRulesForRemovedSelect_DiscardsReferencingRules_AndDecrementsHigherIndexes()
         {
-            _logic.AddModeToBuffer(new AIMode
+            AIRule[] rules = new AIRule[]
             {
-                modeName = "整合テスト",
-                actions = new ActionSlot[0],
-                actionRules = new AIRule[0],
-                targetSelects = new AITargetSelect[]
-                {
-                    new AITargetSelect { sortKey = TargetSortKey.Distance,     filter = new TargetFilter { belong = CharacterBelong.Enemy } },
-                    new AITargetSelect { sortKey = TargetSortKey.HpRatio,      filter = new TargetFilter { belong = CharacterBelong.Enemy } },
-                    new AITargetSelect { sortKey = TargetSortKey.DamageScore,  filter = new TargetFilter { belong = CharacterBelong.Enemy } },
-                },
-                targetRules = new AIRule[]
-                {
-                    new AIRule { actionIndex = 0, probability = 100, conditions = new AICondition[0] },
-                    new AIRule { actionIndex = 1, probability = 100, conditions = new AICondition[0] },
-                    new AIRule { actionIndex = 2, probability = 100, conditions = new AICondition[0] },
-                },
-            });
+                new AIRule { actionIndex = 0, probability = 100, conditions = new AICondition[0] },
+                new AIRule { actionIndex = 1, probability = 50,  conditions = new AICondition[0] },
+                new AIRule { actionIndex = 2, probability = 80,  conditions = new AICondition[0] },
+                new AIRule { actionIndex = 3, probability = 70,  conditions = new AICondition[0] },
+            };
 
-            // RebuildTargetSelectList 削除ボタン内ロジックを再現して idx=1 を削除
-            AIMode working = _logic.EditingBuffer.modes[0];
-            int removeIdx = 1;
+            AIRule[] adjusted = CompanionAISettingsLogic.AdjustTargetRulesForRemovedSelect(rules, 1);
 
-            AITargetSelect[] tsOld = working.targetSelects;
-            AITargetSelect[] tsNew = new AITargetSelect[tsOld.Length - 1];
-            int dst = 0;
-            for (int k = 0; k < tsOld.Length; k++)
+            Assert.AreEqual(3, adjusted.Length, "actionIndex=1 を参照していたルールは破棄");
+            Assert.AreEqual(0, adjusted[0].actionIndex, "元 actionIndex=0 は据え置き");
+            Assert.AreEqual(1, adjusted[1].actionIndex, "元 actionIndex=2 は decrement されて 1");
+            Assert.AreEqual(2, adjusted[2].actionIndex, "元 actionIndex=3 は decrement されて 2");
+
+            // probability など他フィールドが保持されていること
+            Assert.AreEqual((byte)100, adjusted[0].probability);
+            Assert.AreEqual((byte)80, adjusted[1].probability);
+            Assert.AreEqual((byte)70, adjusted[2].probability);
+        }
+
+        /// <summary>
+        /// null / 空配列 / 参照ルール全滅 の境界ケース。
+        /// </summary>
+        [Test]
+        public void AdjustTargetRulesForRemovedSelect_HandlesEdgeCases()
+        {
+            // null 入力 → 空配列
+            AIRule[] fromNull = CompanionAISettingsLogic.AdjustTargetRulesForRemovedSelect(null, 0);
+            Assert.IsNotNull(fromNull);
+            Assert.AreEqual(0, fromNull.Length);
+
+            // 空配列 → 空配列
+            AIRule[] fromEmpty = CompanionAISettingsLogic.AdjustTargetRulesForRemovedSelect(new AIRule[0], 0);
+            Assert.AreEqual(0, fromEmpty.Length);
+
+            // 全ルールが削除 idx を参照 → 全部破棄で空配列
+            AIRule[] allReferencing = new AIRule[]
             {
-                if (k == removeIdx) continue;
-                tsNew[dst++] = tsOld[k];
-            }
-            working.targetSelects = tsNew;
+                new AIRule { actionIndex = 2, probability = 100, conditions = new AICondition[0] },
+                new AIRule { actionIndex = 2, probability = 50,  conditions = new AICondition[0] },
+            };
+            AIRule[] afterAllRemoved = CompanionAISettingsLogic.AdjustTargetRulesForRemovedSelect(allReferencing, 2);
+            Assert.AreEqual(0, afterAllRemoved.Length);
 
-            System.Collections.Generic.List<AIRule> adjusted = new System.Collections.Generic.List<AIRule>(working.targetRules.Length);
-            for (int k = 0; k < working.targetRules.Length; k++)
+            // 削除 idx より小さい index のルールのみ → 変更なし
+            AIRule[] smallerOnly = new AIRule[]
             {
-                AIRule r = working.targetRules[k];
-                if (r.actionIndex == removeIdx) continue;
-                if (r.actionIndex > removeIdx) r.actionIndex--;
-                adjusted.Add(r);
-            }
-            working.targetRules = adjusted.ToArray();
-
-            Assert.IsTrue(_logic.UpdateModeInBuffer(0, working));
-            _logic.ApplyBufferToCurrentTactic();
-
-            AIMode result = _logic.CurrentTactic.modes[0];
-            Assert.AreEqual(2, result.targetSelects.Length);
-            Assert.AreEqual(TargetSortKey.Distance, result.targetSelects[0].sortKey);
-            Assert.AreEqual(TargetSortKey.DamageScore, result.targetSelects[1].sortKey, "idx=1 が削除され DamageScore が前詰め");
-
-            Assert.AreEqual(2, result.targetRules.Length, "actionIndex=1 を参照していたルールは破棄");
-            Assert.AreEqual(0, result.targetRules[0].actionIndex, "元 actionIndex=0 は据え置き");
-            Assert.AreEqual(1, result.targetRules[1].actionIndex, "元 actionIndex=2 は decrement されて 1");
+                new AIRule { actionIndex = 0, probability = 100, conditions = new AICondition[0] },
+            };
+            AIRule[] afterSmallerOnly = CompanionAISettingsLogic.AdjustTargetRulesForRemovedSelect(smallerOnly, 5);
+            Assert.AreEqual(1, afterSmallerOnly.Length);
+            Assert.AreEqual(0, afterSmallerOnly[0].actionIndex);
         }
     }
 }

--- a/Assets/Tests/EditMode/Integration_CompanionAISettingsFlowTests.cs
+++ b/Assets/Tests/EditMode/Integration_CompanionAISettingsFlowTests.cs
@@ -547,5 +547,195 @@ namespace Game.Tests.EditMode
             Assert.AreEqual(5, reloaded.operandA, "下限");
             Assert.AreEqual(15, reloaded.operandB, "上限");
         }
+
+        /// <summary>
+        /// targetRules / targetSelects が UI で編集後、保存 → 別プリセット切替 → 戻す
+        /// の流れでも全フィールドが永続化されることを確認する。
+        /// </summary>
+        [Test]
+        public void CompanionAISettings_EditMode_TargetRulesAndSelects_Roundtrip()
+        {
+            _logic.AddModeToBuffer(new AIMode
+            {
+                modeName = "ターゲット戦術",
+                judgeInterval = new Vector2(0.3f, 0.7f),
+                actions = new ActionSlot[0],
+                actionRules = new AIRule[0],
+                targetRules = new AIRule[0],
+                targetSelects = new AITargetSelect[0],
+            });
+
+            AIMode edited = new AIMode
+            {
+                modeName = "ターゲット戦術(編集済み)",
+                judgeInterval = new Vector2(0.3f, 0.7f),
+                defaultActionIndex = 0,
+                actions = new ActionSlot[0],
+                actionRules = new AIRule[0],
+                targetSelects = new AITargetSelect[]
+                {
+                    new AITargetSelect
+                    {
+                        sortKey = TargetSortKey.Distance,
+                        isDescending = false,
+                        filter = new TargetFilter
+                        {
+                            belong = CharacterBelong.Enemy,
+                            includeSelf = false,
+                        },
+                    },
+                    new AITargetSelect
+                    {
+                        sortKey = TargetSortKey.HpRatio,
+                        elementFilter = Element.Fire | Element.Thunder,
+                        isDescending = false,
+                        filter = new TargetFilter
+                        {
+                            belong = CharacterBelong.Enemy,
+                            feature = CharacterFeature.Boss,
+                            weakPoint = Element.Fire,
+                            distanceRange = new Vector2(0f, 20f),
+                            filterFlags = FilterBitFlag.FeatureAnd,
+                            includeSelf = false,
+                        },
+                    },
+                },
+                targetRules = new AIRule[]
+                {
+                    new AIRule
+                    {
+                        actionIndex = 1,
+                        probability = 80,
+                        conditions = new AICondition[]
+                        {
+                            new AICondition
+                            {
+                                conditionType = AIConditionType.HpRatio,
+                                compareOp = CompareOp.LessEqual,
+                                operandA = 30,
+                                operandB = 0,
+                                filter = new TargetFilter { includeSelf = true },
+                            },
+                        },
+                    },
+                    new AIRule
+                    {
+                        actionIndex = 0,
+                        probability = 100,
+                        conditions = new AICondition[0],
+                    },
+                },
+            };
+            Assert.IsTrue(_logic.UpdateModeInBuffer(0, edited));
+            _logic.ApplyBufferToCurrentTactic();
+
+            // 別プリセットへ切替 → 戻すで再読み込みを再現
+            string otherId = _tacticalRegistry.Save("別戦術", new CompanionAIConfig
+            {
+                configName = "別戦術",
+                modes = new AIMode[0],
+                modeTransitionRules = new ModeTransitionRule[0],
+                shortcutModeBindings = new int[4],
+            });
+            _logic.SwitchEditingTarget(otherId, force: false);
+            _logic.SwitchEditingTarget(null, force: false);
+
+            AIMode reloaded = _logic.EditingBuffer.modes[0];
+
+            // targetSelects 全フィールド
+            Assert.AreEqual(2, reloaded.targetSelects.Length);
+
+            Assert.AreEqual(TargetSortKey.Distance, reloaded.targetSelects[0].sortKey);
+            Assert.IsFalse(reloaded.targetSelects[0].isDescending);
+            Assert.AreEqual(CharacterBelong.Enemy, reloaded.targetSelects[0].filter.belong);
+            Assert.IsFalse(reloaded.targetSelects[0].filter.includeSelf);
+
+            Assert.AreEqual(TargetSortKey.HpRatio, reloaded.targetSelects[1].sortKey);
+            Assert.AreEqual(Element.Fire | Element.Thunder, reloaded.targetSelects[1].elementFilter);
+            Assert.AreEqual(CharacterFeature.Boss, reloaded.targetSelects[1].filter.feature);
+            Assert.AreEqual(Element.Fire, reloaded.targetSelects[1].filter.weakPoint);
+            Assert.AreEqual(new Vector2(0f, 20f), reloaded.targetSelects[1].filter.distanceRange);
+            Assert.IsTrue((reloaded.targetSelects[1].filter.filterFlags & FilterBitFlag.FeatureAnd) != 0);
+
+            // targetRules 全フィールド
+            Assert.AreEqual(2, reloaded.targetRules.Length);
+
+            AIRule tRule0 = reloaded.targetRules[0];
+            Assert.AreEqual(1, tRule0.actionIndex);
+            Assert.AreEqual((byte)80, tRule0.probability);
+            Assert.AreEqual(1, tRule0.conditions.Length);
+            Assert.AreEqual(AIConditionType.HpRatio, tRule0.conditions[0].conditionType);
+            Assert.AreEqual(CompareOp.LessEqual, tRule0.conditions[0].compareOp);
+            Assert.AreEqual(30, tRule0.conditions[0].operandA);
+
+            AIRule tRule1 = reloaded.targetRules[1];
+            Assert.AreEqual(0, tRule1.actionIndex);
+            Assert.AreEqual((byte)100, tRule1.probability);
+            Assert.AreEqual(0, tRule1.conditions.Length);
+        }
+
+        /// <summary>
+        /// UI の RebuildTargetSelectList 削除ボタン挙動を Logic API 経由で再現し、
+        /// targetSelect 削除時に targetRules の actionIndex が整合補正される
+        /// （参照ルール破棄 + より大きい index の decrement）ことを確認する。
+        /// </summary>
+        [Test]
+        public void CompanionAISettings_UILike_RemoveTargetSelect_AdjustsReferencingRules()
+        {
+            _logic.AddModeToBuffer(new AIMode
+            {
+                modeName = "整合テスト",
+                actions = new ActionSlot[0],
+                actionRules = new AIRule[0],
+                targetSelects = new AITargetSelect[]
+                {
+                    new AITargetSelect { sortKey = TargetSortKey.Distance,     filter = new TargetFilter { belong = CharacterBelong.Enemy } },
+                    new AITargetSelect { sortKey = TargetSortKey.HpRatio,      filter = new TargetFilter { belong = CharacterBelong.Enemy } },
+                    new AITargetSelect { sortKey = TargetSortKey.DamageScore,  filter = new TargetFilter { belong = CharacterBelong.Enemy } },
+                },
+                targetRules = new AIRule[]
+                {
+                    new AIRule { actionIndex = 0, probability = 100, conditions = new AICondition[0] },
+                    new AIRule { actionIndex = 1, probability = 100, conditions = new AICondition[0] },
+                    new AIRule { actionIndex = 2, probability = 100, conditions = new AICondition[0] },
+                },
+            });
+
+            // RebuildTargetSelectList 削除ボタン内ロジックを再現して idx=1 を削除
+            AIMode working = _logic.EditingBuffer.modes[0];
+            int removeIdx = 1;
+
+            AITargetSelect[] tsOld = working.targetSelects;
+            AITargetSelect[] tsNew = new AITargetSelect[tsOld.Length - 1];
+            int dst = 0;
+            for (int k = 0; k < tsOld.Length; k++)
+            {
+                if (k == removeIdx) continue;
+                tsNew[dst++] = tsOld[k];
+            }
+            working.targetSelects = tsNew;
+
+            System.Collections.Generic.List<AIRule> adjusted = new System.Collections.Generic.List<AIRule>(working.targetRules.Length);
+            for (int k = 0; k < working.targetRules.Length; k++)
+            {
+                AIRule r = working.targetRules[k];
+                if (r.actionIndex == removeIdx) continue;
+                if (r.actionIndex > removeIdx) r.actionIndex--;
+                adjusted.Add(r);
+            }
+            working.targetRules = adjusted.ToArray();
+
+            Assert.IsTrue(_logic.UpdateModeInBuffer(0, working));
+            _logic.ApplyBufferToCurrentTactic();
+
+            AIMode result = _logic.CurrentTactic.modes[0];
+            Assert.AreEqual(2, result.targetSelects.Length);
+            Assert.AreEqual(TargetSortKey.Distance, result.targetSelects[0].sortKey);
+            Assert.AreEqual(TargetSortKey.DamageScore, result.targetSelects[1].sortKey, "idx=1 が削除され DamageScore が前詰め");
+
+            Assert.AreEqual(2, result.targetRules.Length, "actionIndex=1 を参照していたルールは破棄");
+            Assert.AreEqual(0, result.targetRules[0].actionIndex, "元 actionIndex=0 は据え置き");
+            Assert.AreEqual(1, result.targetRules[1].actionIndex, "元 actionIndex=2 は decrement されて 1");
+        }
     }
 }

--- a/designs/ui/target-rules-editor-mockup.html
+++ b/designs/ui/target-rules-editor-mockup.html
@@ -1,0 +1,873 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>仲間AI設定 — ターゲット選定 / ターゲット切替ルール モックアップ</title>
+<style>
+    :root {
+        --bg-app: rgba(0, 0, 0, 0.75);
+        --bg-panel: rgba(20, 20, 30, 0.95);
+        --bg-panel-2: rgba(15, 15, 25, 0.9);
+        --bg-row: rgba(35, 35, 45, 0.85);
+        --bg-row-hover: rgba(55, 55, 75, 0.9);
+        --bg-section: rgba(0, 0, 0, 0.25);
+        --bg-inset: rgba(0, 0, 0, 0.35);
+
+        --border-soft: rgba(80, 80, 100, 0.4);
+        --border-mid: rgba(100, 100, 130, 0.6);
+
+        --text-primary: rgb(240, 240, 245);
+        --text-secondary: rgb(160, 160, 175);
+        --text-dim: rgb(100, 100, 115);
+
+        --accent: rgb(79, 195, 247);
+        --accent-soft: rgba(79, 195, 247, 0.15);
+        --warning: rgb(255, 193, 7);
+        --danger: rgb(244, 67, 54);
+        --success: rgb(76, 175, 80);
+        --target-color: rgb(186, 104, 200);
+        --target-soft: rgba(186, 104, 200, 0.15);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+        margin: 0;
+        padding: 24px;
+        background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f1626 100%);
+        background-attachment: fixed;
+        color: var(--text-primary);
+        font-family: "Segoe UI", "Yu Gothic UI", "Meiryo", sans-serif;
+        font-size: 14px;
+    }
+
+    h1 { font-size: 20px; margin: 0 0 4px 0; font-weight: bold; }
+    .page-intro { color: var(--text-secondary); font-size: 13px; margin-bottom: 24px; }
+
+    .mockup-wrap {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 32px;
+        align-items: flex-start;
+    }
+
+    /* === モーダルダイアログ共通 === */
+    .mock-dialog {
+        background-color: rgba(20, 20, 30, 0.98);
+        border: 1px solid var(--border-mid);
+        border-radius: 8px;
+        width: 560px;
+        max-width: 100%;
+        display: flex;
+        flex-direction: column;
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
+        overflow: hidden;
+    }
+
+    .mock-dialog__header {
+        display: flex;
+        align-items: center;
+        padding: 16px 20px;
+        background-color: var(--bg-panel-2);
+        border-bottom: 1px solid var(--border-soft);
+    }
+
+    .mock-dialog__title {
+        font-size: 18px;
+        font-weight: bold;
+        flex-grow: 1;
+    }
+
+    .mock-dialog__close {
+        width: 32px;
+        height: 32px;
+        border: 0;
+        background: transparent;
+        color: var(--text-secondary);
+        font-size: 20px;
+        cursor: pointer;
+        border-radius: 4px;
+    }
+
+    .mock-dialog__close:hover { color: var(--text-primary); background-color: rgba(80, 80, 110, 0.5); }
+
+    .mock-dialog__body {
+        padding: 16px 20px;
+        max-height: 640px;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .mock-dialog__body::-webkit-scrollbar { width: 10px; }
+    .mock-dialog__body::-webkit-scrollbar-track { background: rgba(0,0,0,0.3); }
+    .mock-dialog__body::-webkit-scrollbar-thumb { background: rgba(100,100,130,0.5); border-radius: 4px; }
+
+    .mock-dialog__footer {
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
+        padding: 12px 20px;
+        background-color: var(--bg-panel-2);
+        border-top: 1px solid var(--border-soft);
+        gap: 8px;
+    }
+
+    /* === セクション === */
+    .section {
+        background-color: var(--bg-section);
+        border-radius: 6px;
+        padding: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .section-label {
+        font-size: 13px;
+        color: var(--text-secondary);
+        font-weight: bold;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .section-label--target { color: var(--target-color); }
+
+    .section-label__count {
+        font-size: 11px;
+        color: var(--text-dim);
+        font-weight: normal;
+    }
+
+    .section-hint {
+        font-size: 11px;
+        color: var(--text-dim);
+        font-style: italic;
+    }
+
+    /* === フォーム要素 === */
+    .form-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .form-row__label {
+        font-size: 12px;
+        color: var(--text-secondary);
+        min-width: 110px;
+    }
+
+    .form-row--grid {
+        display: grid;
+        grid-template-columns: 110px 1fr;
+        gap: 10px 14px;
+        align-items: center;
+    }
+
+    .form-input {
+        background-color: rgba(0, 0, 0, 0.45);
+        border: 1px solid var(--border-soft);
+        border-radius: 3px;
+        padding: 6px 10px;
+        color: var(--text-primary);
+        font-size: 13px;
+        font-family: inherit;
+        flex-grow: 1;
+        min-width: 0;
+    }
+
+    .form-input:focus { outline: none; border-color: var(--accent); }
+    .form-input--small { max-width: 80px; flex-grow: 0; }
+
+    .form-select {
+        background-color: rgba(0, 0, 0, 0.45);
+        color: var(--text-primary);
+        border: 1px solid var(--border-soft);
+        border-radius: 3px;
+        padding: 6px 24px 6px 10px;
+        font-size: 13px;
+        font-family: inherit;
+        appearance: none;
+        background-image: linear-gradient(45deg, transparent 50%, var(--text-secondary) 50%),
+                          linear-gradient(135deg, var(--text-secondary) 50%, transparent 50%);
+        background-position: right 10px center, right 5px center;
+        background-size: 5px 5px, 5px 5px;
+        background-repeat: no-repeat;
+        flex-grow: 1;
+        min-width: 0;
+    }
+
+    .form-select:focus { outline: none; border-color: var(--accent); }
+
+    .toggle-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+        color: var(--text-secondary);
+    }
+
+    .toggle-row input[type="checkbox"] { accent-color: var(--accent); }
+
+    /* === ボタン === */
+    .btn {
+        padding: 6px 14px;
+        border-radius: 3px;
+        font-size: 13px;
+        cursor: pointer;
+        font-family: inherit;
+        font-weight: bold;
+        transition: all 0.15s;
+    }
+
+    .btn--primary { background-color: var(--accent); color: rgb(10, 10, 20); border: 0; }
+    .btn--primary:hover { background-color: rgb(120, 215, 255); }
+    .btn--secondary { background-color: rgba(60, 60, 80, 0.8); color: var(--text-primary); border: 1px solid var(--border-mid); }
+    .btn--secondary:hover { background-color: rgba(80, 80, 110, 0.9); border-color: var(--accent); }
+
+    .btn--ghost {
+        background-color: transparent;
+        color: var(--text-secondary);
+        border: 1px dashed var(--border-mid);
+        padding: 8px;
+        font-weight: normal;
+        font-size: 12px;
+    }
+
+    .btn--ghost:hover { border-color: var(--accent); color: var(--accent); border-style: solid; }
+
+    .btn--icon {
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        background-color: transparent;
+        color: var(--text-secondary);
+        border: 0;
+        font-size: 16px;
+        border-radius: 3px;
+        cursor: pointer;
+    }
+
+    .btn--icon:hover { color: var(--danger); background-color: rgba(244, 67, 54, 0.1); }
+
+    /* === ターゲット選定カード (AITargetSelect) === */
+    .tselect-card {
+        background-color: var(--bg-row);
+        border: 1px solid var(--border-soft);
+        border-left: 3px solid var(--target-color);
+        border-radius: 4px;
+        padding: 10px 12px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .tselect-card__index {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        background-color: var(--target-soft);
+        color: var(--target-color);
+        font-size: 12px;
+        font-weight: bold;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+    }
+
+    .tselect-card__summary {
+        flex-grow: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        min-width: 0;
+    }
+
+    .tselect-card__sort {
+        font-size: 13px;
+        color: var(--text-primary);
+        font-weight: bold;
+    }
+
+    .tselect-card__sort .dir {
+        color: var(--target-color);
+        margin-left: 4px;
+        font-size: 11px;
+    }
+
+    .tselect-card__filter-chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+    }
+
+    .chip {
+        font-size: 10px;
+        padding: 2px 6px;
+        background-color: rgba(0, 0, 0, 0.35);
+        border: 1px solid var(--border-soft);
+        border-radius: 10px;
+        color: var(--text-secondary);
+        white-space: nowrap;
+    }
+
+    .chip--target { border-color: var(--target-color); color: var(--target-color); background-color: var(--target-soft); }
+    .chip--element { border-color: var(--warning); color: var(--warning); background-color: rgba(255, 193, 7, 0.1); }
+
+    /* === ターゲット切替ルールカード === */
+    .trule-card {
+        background-color: var(--bg-row);
+        border: 1px solid var(--border-soft);
+        border-left: 3px solid var(--target-color);
+        border-radius: 4px;
+        padding: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .trule-card__head {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .trule-card__badge {
+        font-size: 11px;
+        color: var(--target-color);
+        font-weight: bold;
+        padding: 2px 6px;
+        background-color: var(--target-soft);
+        border-radius: 2px;
+    }
+
+    .trule-card__conditions {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        padding-left: 12px;
+        border-left: 2px dashed rgba(100, 100, 130, 0.3);
+        margin-left: 4px;
+    }
+
+    .condition-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 0;
+    }
+
+    .condition-row__prefix {
+        font-size: 11px;
+        color: var(--text-dim);
+        min-width: 28px;
+        font-style: italic;
+    }
+
+    .condition-row .form-select,
+    .condition-row .form-input {
+        padding: 4px 22px 4px 8px;
+        font-size: 12px;
+    }
+
+    .condition-row .form-select--type { flex: 2; }
+    .condition-row .form-select--op { flex: 1; max-width: 68px; padding: 4px 22px 4px 8px; }
+    .condition-row .form-input--operand { flex: 1; max-width: 80px; }
+
+    .trule-card__then {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        background-color: rgba(0, 0, 0, 0.3);
+        border-radius: 3px;
+        margin-left: 4px;
+    }
+
+    .trule-card__then-label {
+        font-size: 12px;
+        color: var(--target-color);
+        font-weight: bold;
+        min-width: 56px;
+    }
+
+    .trule-card__then .form-select {
+        flex-grow: 1;
+        padding: 4px 22px 4px 8px;
+        font-size: 12px;
+    }
+
+    .trule-card__probability {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        color: var(--text-secondary);
+        font-size: 11px;
+        flex-shrink: 0;
+    }
+
+    .trule-card__probability .form-input {
+        max-width: 50px;
+        padding: 4px 6px;
+        font-size: 12px;
+    }
+
+    /* === フィルタ Foldout === */
+    .foldout {
+        background-color: var(--bg-inset);
+        border: 1px solid var(--border-soft);
+        border-radius: 4px;
+        padding: 10px 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .foldout__title {
+        font-size: 12px;
+        color: var(--text-primary);
+        font-weight: bold;
+    }
+
+    .flag-grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 4px 12px;
+        font-size: 11px;
+        color: var(--text-secondary);
+    }
+
+    .flag-grid--wide { grid-template-columns: repeat(2, 1fr); }
+
+    .flag-grid label { display: flex; align-items: center; gap: 4px; }
+    .flag-grid input[type="checkbox"] { accent-color: var(--accent); }
+
+    .and-or-toggle {
+        display: flex;
+        gap: 4px;
+    }
+
+    .and-or-toggle button {
+        font-size: 10px;
+        padding: 2px 8px;
+        background-color: rgba(0, 0, 0, 0.35);
+        border: 1px solid var(--border-soft);
+        color: var(--text-dim);
+        border-radius: 2px;
+        cursor: pointer;
+    }
+
+    .and-or-toggle button.active { color: var(--accent); border-color: var(--accent); background-color: var(--accent-soft); }
+
+    .row-controls { display: flex; align-items: center; gap: 4px; margin-left: auto; }
+
+    .notice {
+        padding: 10px 12px;
+        background-color: rgba(79, 195, 247, 0.08);
+        border: 1px solid rgba(79, 195, 247, 0.3);
+        border-radius: 4px;
+        color: var(--accent);
+        font-size: 11px;
+    }
+</style>
+</head>
+<body>
+
+<h1>仲間AI設定 — ターゲット選定 / ターゲット切替ルール モックアップ</h1>
+<p class="page-intro">
+    既存 mode-editor-mockup.html の「Stage 2 予定」だった targetRules / targetSelects 編集UI。<br>
+    モード詳細ダイアログに2セクション追加 + 個別編集ダイアログ2枚。
+</p>
+
+<div class="mockup-wrap">
+
+    <!-- =====================================================
+         Window A: モード詳細 (新セクションの位置に抜粋)
+         ===================================================== -->
+    <div class="mock-dialog" style="width: 700px;">
+        <div class="mock-dialog__header">
+            <div class="mock-dialog__title">モード詳細 — 通常攻撃</div>
+            <button class="mock-dialog__close" title="閉じる">×</button>
+        </div>
+
+        <div class="mock-dialog__body">
+
+            <div class="section">
+                <div class="section-label">① 基本設定</div>
+                <div class="section-hint" style="color: var(--text-dim); font-size: 10px;">(モード名/判定間隔/デフォルト行動 — 省略)</div>
+            </div>
+
+            <!-- 新規セクション② ターゲット選定 -->
+            <div class="section" style="border: 1px solid var(--target-color);">
+                <div class="section-label section-label--target">
+                    ② ターゲット選定 (targetSelects)
+                    <span class="section-label__count">(2件 / 上限 8件)</span>
+                </div>
+                <div class="section-hint">
+                    「どのキャラを狙うか」のパターンを登録。下の「ターゲット切替ルール」から index で参照されます。<br>
+                    並び順キー + 昇降順 + 弱点属性 + 対象フィルタ(陣営/特徴/距離)の組み合わせ。
+                </div>
+
+                <!-- TargetSelect #0 : 最近距離敵 -->
+                <div class="tselect-card">
+                    <div class="tselect-card__index">0</div>
+                    <div class="tselect-card__summary">
+                        <div class="tselect-card__sort">距離 <span class="dir">↑ 昇順 (近い順)</span></div>
+                        <div class="tselect-card__filter-chips">
+                            <span class="chip chip--target">陣営=Enemy</span>
+                            <span class="chip">自分を含めない</span>
+                        </div>
+                    </div>
+                    <div class="row-controls">
+                        <button class="btn btn--secondary" style="padding:4px 10px; font-size:11px;">編集</button>
+                        <button class="btn--icon" title="削除">🗑</button>
+                    </div>
+                </div>
+
+                <!-- TargetSelect #1 : HP低いボス優先 -->
+                <div class="tselect-card">
+                    <div class="tselect-card__index">1</div>
+                    <div class="tselect-card__summary">
+                        <div class="tselect-card__sort">HP割合 <span class="dir">↑ 昇順 (瀕死優先)</span></div>
+                        <div class="tselect-card__filter-chips">
+                            <span class="chip chip--target">陣営=Enemy</span>
+                            <span class="chip chip--target">特徴=Boss</span>
+                            <span class="chip chip--element">弱点=炎 OR 雷</span>
+                            <span class="chip">距離 0〜20</span>
+                        </div>
+                    </div>
+                    <div class="row-controls">
+                        <button class="btn btn--secondary" style="padding:4px 10px; font-size:11px;">編集</button>
+                        <button class="btn--icon" title="削除">🗑</button>
+                    </div>
+                </div>
+
+                <button class="btn btn--ghost" style="padding:10px;">＋ ターゲット選定を追加</button>
+            </div>
+
+            <!-- 新規セクション③ ターゲット切替ルール -->
+            <div class="section" style="border: 1px solid var(--target-color);">
+                <div class="section-label section-label--target">
+                    ③ ターゲット切替ルール (targetRules)
+                    <span class="section-label__count">(2件 / 上限 16件)</span>
+                </div>
+                <div class="section-hint">
+                    条件を満たした時、「どの targetSelect を使うか」を決めるルール。<br>
+                    並び順が優先度 (先勝ち)。
+                </div>
+
+                <!-- Rule 1: HP瀕死敵を優先 -->
+                <div class="trule-card">
+                    <div class="trule-card__head">
+                        <span class="trule-card__badge">RULE 1</span>
+                        <span style="color:var(--text-secondary); font-size:11px;">優先度1位</span>
+                        <div class="row-controls">
+                            <button class="btn--icon" title="上へ">▲</button>
+                            <button class="btn--icon" title="下へ">▼</button>
+                            <button class="btn btn--secondary" style="padding:4px 10px; font-size:11px;">編集</button>
+                            <button class="btn--icon" title="ルール削除">🗑</button>
+                        </div>
+                    </div>
+
+                    <div class="trule-card__conditions">
+                        <div class="condition-row">
+                            <span class="condition-row__prefix">IF</span>
+                            <select class="form-select form-select--type">
+                                <option selected>EnemyHpRatioMin</option>
+                                <option>SelfHpRatio</option>
+                                <option>MpRatio</option>
+                            </select>
+                            <select class="form-select form-select--op">
+                                <option selected>&lt;=</option>
+                            </select>
+                            <input class="form-input form-input--operand" value="30">
+                            <input class="form-input form-input--operand" value="" placeholder="(上限)">
+                        </div>
+                    </div>
+
+                    <div class="trule-card__then">
+                        <span class="trule-card__then-label">TARGET</span>
+                        <select class="form-select">
+                            <option>#0 距離↑ / Enemy</option>
+                            <option selected>#1 HP割合↑ / Boss 弱点=炎,雷</option>
+                        </select>
+                        <div class="trule-card__probability">
+                            確率 <input class="form-input" value="100"> %
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Rule 2: デフォルト = 最近距離敵 -->
+                <div class="trule-card">
+                    <div class="trule-card__head">
+                        <span class="trule-card__badge">RULE 2</span>
+                        <span style="color:var(--text-secondary); font-size:11px;">優先度2位 (無条件フォールバック)</span>
+                        <div class="row-controls">
+                            <button class="btn--icon" title="上へ">▲</button>
+                            <button class="btn--icon" title="下へ">▼</button>
+                            <button class="btn btn--secondary" style="padding:4px 10px; font-size:11px;">編集</button>
+                            <button class="btn--icon" title="ルール削除">🗑</button>
+                        </div>
+                    </div>
+
+                    <div class="trule-card__conditions">
+                        <div style="padding: 4px 0; font-size:11px; color: var(--text-dim); font-style:italic;">(条件なし = 常に合致)</div>
+                    </div>
+
+                    <div class="trule-card__then">
+                        <span class="trule-card__then-label">TARGET</span>
+                        <select class="form-select">
+                            <option selected>#0 距離↑ / Enemy</option>
+                            <option>#1 HP割合↑ / Boss 弱点=炎,雷</option>
+                        </select>
+                        <div class="trule-card__probability">
+                            確率 <input class="form-input" value="100"> %
+                        </div>
+                    </div>
+                </div>
+
+                <button class="btn btn--ghost" style="padding:10px;">＋ ターゲット切替ルールを追加</button>
+            </div>
+
+            <div class="section">
+                <div class="section-label">④ 行動定義 (ActionSlot)</div>
+                <div class="section-hint" style="color: var(--text-dim); font-size: 10px;">(既存 — 省略)</div>
+            </div>
+
+            <div class="section">
+                <div class="section-label">⑤ 行動切替ルール (actionRules)</div>
+                <div class="section-hint" style="color: var(--text-dim); font-size: 10px;">(既存 — 省略)</div>
+            </div>
+
+            <div class="notice">
+                <strong>評価順:</strong> JudgmentLoop は「② ターゲット選定 → ③ ターゲット切替ルール」で誰を狙うか決め、その後に「④ 行動定義 → ⑤ 行動切替ルール」で何をするか決める。<br>
+                UI のセクション順序もこの評価順に揃える。
+            </div>
+
+        </div>
+
+        <div class="mock-dialog__footer">
+            <button class="btn btn--secondary">キャンセル</button>
+            <button class="btn btn--primary">保存</button>
+        </div>
+    </div>
+
+
+    <!-- =====================================================
+         Window B: ターゲット選定編集ダイアログ (ShowTargetSelectEditDialog)
+         ===================================================== -->
+    <div class="mock-dialog">
+        <div class="mock-dialog__header">
+            <div class="mock-dialog__title">ターゲット選定編集 — #1</div>
+            <button class="mock-dialog__close" title="閉じる">×</button>
+        </div>
+
+        <div class="mock-dialog__body">
+
+            <!-- 並び順 -->
+            <div class="section">
+                <div class="section-label">並び順</div>
+                <div class="section-hint">候補の中から最優先を1体選ぶ判断基準。</div>
+
+                <div class="form-row--grid">
+                    <label class="form-row__label">並び順キー</label>
+                    <select class="form-select">
+                        <option>距離 (Distance)</option>
+                        <option selected>HP割合 (HpRatio)</option>
+                        <option>HP値 (HpValue)</option>
+                        <option>攻撃力 (AttackPower)</option>
+                        <option>防御力 (DefensePower)</option>
+                        <option>狙われ数 (TargetingCount)</option>
+                        <option>最終攻撃者 (LastAttacker)</option>
+                        <option>ダメージスコア (DamageScore)</option>
+                        <option>自分 (Self)</option>
+                        <option>プレイヤー (Player)</option>
+                        <option>妹 (Sister)</option>
+                    </select>
+
+                    <label class="form-row__label">並び順</label>
+                    <div class="toggle-row">
+                        <label><input type="checkbox"> 降順 (大きい順)</label>
+                        <span style="color:var(--text-dim);">※ HP割合の昇順 = 瀕死優先</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 弱点属性フィルタ -->
+            <div class="section">
+                <div class="section-label">弱点属性フィルタ (elementFilter)</div>
+                <div class="section-hint">指定属性に弱い候補のみを対象に絞る。未指定=属性フィルタなし。</div>
+                <div class="foldout">
+                    <div class="flag-grid">
+                        <label><input type="checkbox"> 斬撃</label>
+                        <label><input type="checkbox"> 打撃</label>
+                        <label><input type="checkbox"> 刺突</label>
+                        <label><input type="checkbox" checked> 炎</label>
+                        <label><input type="checkbox" checked> 雷</label>
+                        <label><input type="checkbox"> 聖</label>
+                        <label><input type="checkbox"> 闇</label>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 対象キャラクターフィルタ (TargetFilter 再利用) -->
+            <div class="section">
+                <div class="section-label">対象フィルタ (TargetFilter)</div>
+                <div class="section-hint">BuildTargetFilterSection を再利用。陣営/特徴/弱点/距離を複合指定。</div>
+
+                <div class="toggle-row" style="margin-bottom: 4px;">
+                    <label><input type="checkbox"> 自分を含める (includeSelf)</label>
+                </div>
+
+                <!-- 陣営 -->
+                <div class="foldout">
+                    <div style="display:flex; justify-content:space-between; align-items:center;">
+                        <div class="foldout__title">陣営 (belong)</div>
+                        <div class="and-or-toggle">
+                            <button>AND</button>
+                            <button class="active">OR</button>
+                        </div>
+                    </div>
+                    <div class="flag-grid">
+                        <label><input type="checkbox"> Ally</label>
+                        <label><input type="checkbox" checked> Enemy</label>
+                        <label><input type="checkbox"> Neutral</label>
+                    </div>
+                </div>
+
+                <!-- 特徴 -->
+                <div class="foldout">
+                    <div style="display:flex; justify-content:space-between; align-items:center;">
+                        <div class="foldout__title">特徴 (feature)</div>
+                        <div class="and-or-toggle">
+                            <button class="active">AND</button>
+                            <button>OR</button>
+                        </div>
+                    </div>
+                    <div class="flag-grid">
+                        <label><input type="checkbox"> Humanoid</label>
+                        <label><input type="checkbox" checked> Boss</label>
+                        <label><input type="checkbox"> Summon</label>
+                        <label><input type="checkbox"> Flying</label>
+                        <label><input type="checkbox"> Undead</label>
+                        <label><input type="checkbox"> Elite</label>
+                    </div>
+                </div>
+
+                <!-- 距離範囲 -->
+                <div class="foldout">
+                    <div class="foldout__title">距離範囲 (distanceRange)</div>
+                    <div class="form-row">
+                        <label class="form-row__label">最小 〜 最大</label>
+                        <input class="form-input form-input--small" value="0"> 〜
+                        <input class="form-input form-input--small" value="20">
+                        <span style="color:var(--text-dim); font-size:11px;">※ 0〜0=無制限</span>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+        <div class="mock-dialog__footer">
+            <button class="btn btn--secondary">キャンセル</button>
+            <button class="btn btn--primary">保存</button>
+        </div>
+    </div>
+
+
+    <!-- =====================================================
+         Window C: ターゲット切替ルール編集ダイアログ (ShowTargetRuleEditDialog)
+         ===================================================== -->
+    <div class="mock-dialog">
+        <div class="mock-dialog__header">
+            <div class="mock-dialog__title">ターゲット切替ルール編集 — RULE 1</div>
+            <button class="mock-dialog__close" title="閉じる">×</button>
+        </div>
+
+        <div class="mock-dialog__body">
+
+            <!-- 条件 (既存 RebuildConditionList / BuildConditionRow 再利用) -->
+            <div class="section">
+                <div class="section-label">
+                    条件 (AND結合)
+                    <span class="section-label__count">(1件)</span>
+                </div>
+                <div class="section-hint">全ての条件を満たした時に、このルールの TARGET が選ばれます。</div>
+
+                <div class="condition-row">
+                    <span class="condition-row__prefix">IF</span>
+                    <select class="form-select form-select--type">
+                        <option selected>EnemyHpRatioMin</option>
+                        <option>SelfHpRatio</option>
+                        <option>MpRatio</option>
+                        <option>ObjectNearby</option>
+                        <option>EventFired</option>
+                    </select>
+                    <select class="form-select form-select--op">
+                        <option selected>&lt;=</option>
+                        <option>&gt;=</option>
+                        <option>==</option>
+                        <option>!=</option>
+                    </select>
+                    <input class="form-input form-input--operand" value="30">
+                    <input class="form-input form-input--operand" value="" placeholder="(上限)">
+                    <button class="btn--icon" title="削除">×</button>
+                </div>
+
+                <button class="btn btn--ghost">＋ 条件を追加 (AND)</button>
+            </div>
+
+            <!-- TARGET (actionIndex) -->
+            <div class="section">
+                <div class="section-label section-label--target">TARGET (targetSelects から選択)</div>
+
+                <div class="form-row--grid">
+                    <label class="form-row__label">選ぶパターン</label>
+                    <select class="form-select">
+                        <option>#0 距離↑ / Enemy</option>
+                        <option selected>#1 HP割合↑ / Boss 弱点=炎,雷</option>
+                    </select>
+
+                    <label class="form-row__label">確率</label>
+                    <div style="display:flex; align-items:center; gap:6px;">
+                        <input class="form-input form-input--small" value="100">
+                        <span style="color:var(--text-dim); font-size:11px;">% (0〜100)</span>
+                    </div>
+                </div>
+                <div class="section-hint">
+                    確率 &lt; 100 の時は抽選でこのルールを使うか判定。外れたら次のルールへ。
+                </div>
+            </div>
+
+        </div>
+
+        <div class="mock-dialog__footer">
+            <button class="btn btn--secondary">キャンセル</button>
+            <button class="btn btn--primary">保存</button>
+        </div>
+    </div>
+
+</div>
+
+<div style="margin-top: 32px; padding: 16px; background: rgba(20,20,30,0.8); border: 1px solid var(--border-mid); border-radius: 6px;">
+    <h2 style="font-size: 16px; color: var(--target-color); margin: 0 0 8px 0;">実装仕様まとめ</h2>
+    <ul style="color: var(--text-secondary); font-size: 13px; line-height: 1.8; margin: 0; padding-left: 20px;">
+        <li><strong style="color:var(--text-primary);">Window A (モード詳細改訂):</strong>
+            既存4セクションの間に2セクション挿入。評価順に合わせて「基本設定 → ② ターゲット選定 → ③ ターゲット切替ルール → ④ 行動定義 → ⑤ 行動切替ルール」</li>
+        <li><strong style="color:var(--text-primary);">Window B (ShowTargetSelectEditDialog):</strong>
+            AITargetSelect 1件の編集。sortKey / isDescending / elementFilter / TargetFilter(既存 BuildTargetFilterSection 再利用)</li>
+        <li><strong style="color:var(--text-primary);">Window C (ShowTargetRuleEditDialog):</strong>
+            AIRule 1件の編集。conditions (既存 RebuildConditionList 再利用) + TARGET 選択(targetSelects からドロップダウン) + probability</li>
+        <li><strong style="color:var(--text-primary);">targetSelect 削除時:</strong>
+            自動補正。参照していたルールは削除、より大きい index を参照していたルールは decrement</li>
+        <li><strong style="color:var(--text-primary);">新規モード作成時:</strong>
+            デフォルトで「距離↑ / Enemy」1件と「無条件 → #0 / 100%」1件を投入。UI単独で即座に動作する状態</li>
+    </ul>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- 仲間AI設定UI（CompanionAISettings）に `AIMode.targetRules` / `targetSelects` 編集セクションを追加
- UI単独で新規作成したモードでも JudgmentLoop 第1層（ターゲット選択）が機能するように
- `BuildTargetFilterSection` から `includeSelf` UI を廃止し、Companion 特徴で代替（コンパニオンは1体のため一意）

## Changes
### 新規UI
- `ShowTargetSelectEditDialog` — `AITargetSelect` 編集（sortKey / isDescending / elementFilter / TargetFilter）
- `ShowTargetRuleEditDialog` — `AIRule` 編集（参照先 targetSelects を actionIndex で選択）
- `RebuildTargetSelectList` / `RebuildTargetRuleList` — リスト描画
- `ShowModeDetailDialog` に上記2セクションを挿入（評価順: ターゲット→行動）

### データ整合性
- targetSelect 削除時、参照していた targetRule は破棄、より大きい index を参照していた targetRule は自動 decrement
- `OnAddModeClicked` の新規モード初期値に `sortKey=Distance, belong=Enemy` targetSelect と無条件ルールを投入

### UI簡素化
- `BuildTargetFilterSection` の includeSelf トグルを廃止
- AICondition 新規作成時の filter 初期値を空の `TargetFilter()` に変更

### テスト
- `Integration_CompanionAISettingsFlowTests` に2本追加:
  - `CompanionAISettings_EditMode_TargetRulesAndSelects_Roundtrip` — 全フィールド永続化検証
  - `CompanionAISettings_UILike_RemoveTargetSelect_AdjustsReferencingRules` — インデックス整合検証

### ドキュメント
- `designs/ui/target-rules-editor-mockup.html` — 実装前視覚確認用モックアップ

## Test plan
- [x] EditMode Integration tests: 9/9 passed（既存7 + 新規2、回帰なし）
- [ ] Unity Editor 手動確認: モード詳細ダイアログを開き、targetSelects/targetRules の追加・編集・削除・保存・再ロードを一通り確認
- [ ] 新規モード追加時にデフォルト「Distance↑ / Enemy」targetSelect + 無条件ルールが入っていること
- [ ] targetSelect 削除時に参照ルールが自動補正されること
- [ ] Companion 特徴チェックで自分を対象にできること

`docs/FUTURE_TASKS.md` の🔴優先タスク「CompanionAISettings UI で AIMode.targetRules / targetSelects が編集不可」を解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)