### PR TITLE
fix: EditMode/PlayMode テストのコンパイル blocker を解消

### DIFF
--- a/Assets/MyAsset/Core/Save/SaveDataStore.cs
+++ b/Assets/MyAsset/Core/Save/SaveDataStore.cs
@@ -111,7 +111,13 @@ namespace Game.Core
             {
                 try
                 {
-                    File.Move(filePath, backupPath, true);
+                    // .NET Standard 2.0 互換: File.Move(src, dest, overwrite: true) が無いため
+                    // 既存 .bak を明示削除してから Move する (前世代 .bak を上書きする意図を維持)
+                    if (File.Exists(backupPath))
+                    {
+                        File.Delete(backupPath);
+                    }
+                    File.Move(filePath, backupPath);
                 }
                 catch (Exception ex)
                 {
@@ -125,7 +131,12 @@ namespace Game.Core
             // Step 3: 一時ファイルを filePath へ昇格
             try
             {
-                File.Move(tempPath, filePath, true);
+                // Step 2 後の filePath は不在のはずだが、念のため明示削除で冪等性を確保 (NS2.0 互換)
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+                File.Move(tempPath, filePath);
             }
             catch (Exception ex)
             {

--- a/Assets/Tests/PlayMode/Integration_WallKickTests.cs
+++ b/Assets/Tests/PlayMode/Integration_WallKickTests.cs
@@ -109,8 +109,7 @@ namespace Game.Tests.PlayMode
             rb.linearVelocity = Vector2.zero;
 
             // WallKick Ability を付与
-            ref CharacterFlags flags = ref GameManager.Data.GetFlags(pc.ObjectHash);
-            flags.AbilityFlags = AbilityFlag.WallKick;
+            SetAbilityFlags(pc.ObjectHash, AbilityFlag.WallKick);
 
             // プレイヤーの向きは右 (デフォルト _isFacingRight = true) → IsTouchingWall(+1) が右壁を検出
             // TryWallKick は facingRight=true で +k_WallKickForceX を返す (facingDir と同符号)
@@ -151,8 +150,7 @@ namespace Game.Tests.PlayMode
             // プレイヤーを左向きに変更 → IsTouchingWall(-1) が左壁を検出できる
             SetFacingLeft(pc);
 
-            ref CharacterFlags flags = ref GameManager.Data.GetFlags(pc.ObjectHash);
-            flags.AbilityFlags = AbilityFlag.WallKick;
+            SetAbilityFlags(pc.ObjectHash, AbilityFlag.WallKick);
 
             SetJumpBufferTimer(pc, 0.1f);
 
@@ -185,8 +183,7 @@ namespace Game.Tests.PlayMode
             rb.linearVelocity = Vector2.zero;
 
             // WallKick Ability を**付与しない** (AbilityFlag.None のまま)
-            ref CharacterFlags flags = ref GameManager.Data.GetFlags(pc.ObjectHash);
-            flags.AbilityFlags = AbilityFlag.None;
+            SetAbilityFlags(pc.ObjectHash, AbilityFlag.None);
 
             SetJumpBufferTimer(pc, 0.1f);
 
@@ -216,8 +213,7 @@ namespace Game.Tests.PlayMode
             rb.gravityScale = 0f;
             rb.linearVelocity = Vector2.zero;
 
-            ref CharacterFlags flags = ref GameManager.Data.GetFlags(pc.ObjectHash);
-            flags.AbilityFlags = AbilityFlag.WallKick;
+            SetAbilityFlags(pc.ObjectHash, AbilityFlag.WallKick);
 
             SetJumpBufferTimer(pc, 0.1f);
 
@@ -263,6 +259,20 @@ namespace Game.Tests.PlayMode
                 BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.IsNotNull(field, "PlayerCharacter._jumpBufferTimer が存在する");
             field.SetValue(pc, value);
+        }
+
+        /// <summary>
+        /// SoA の CharacterFlags.AbilityFlags をテストから設定するヘルパー。
+        /// <para>
+        /// UnityTest (IEnumerator) 内で <c>ref CharacterFlags = ref GameManager.Data.GetFlags(...)</c>
+        /// を直接使うと CS8176 (Iterators cannot have by-reference locals) になるため、
+        /// ref ローカル宣言を非イテレータメソッドに閉じ込める。
+        /// </para>
+        /// </summary>
+        private static void SetAbilityFlags(int hash, AbilityFlag abilityFlags)
+        {
+            ref CharacterFlags flags = ref GameManager.Data.GetFlags(hash);
+            flags.AbilityFlags = abilityFlags;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
既存 main に 2 件のコンパイル blocker が混入しており、EditMode/PlayMode テストがすべて実行不能になっていた。両方を hotfix として修正する。

### 1. SaveDataStore の .NET Standard 2.0 非互換 (PR #37 由来)
- `File.Move(src, dest, overwrite: true)` の 3 引数 overload は .NET Core 3.0+ 専用
- 本プロジェクトは `apiCompatibilityLevel: 6` (.NET Standard 2.0) のため CS1501 が発生
- `File.Delete(dest)` → `File.Move(src, dest)` に書き換えて互換性回復

### 2. UnityTest 内 ref local の CS8176 違反 (PR #40 由来)
- `Integration_WallKickTests.cs` の 4 テストメソッドが `IEnumerator` を返すイテレータ
- 内部で `ref CharacterFlags = ref GameManager.Data.GetFlags(...)` を宣言しており CS8176
- `SetAbilityFlags(int hash, AbilityFlag)` helper を追加し、ref ローカル宣言を非イテレータ methodに封じ込めて回避

## 変更点
- `Assets/MyAsset/Core/Save/SaveDataStore.cs` (Step 2 / Step 3 の書き込みパス)
- `Assets/Tests/PlayMode/Integration_WallKickTests.cs` (4 テストメソッド + 新規 helper)

## Test plan
- [ ] EditMode テスト全通過
- [ ] PlayMode テスト全通過
- [ ] `SaveDataStoreAtomicWriteTests` 6 ケース、`Integration_WallKickTests` 4 ケースが挙動変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)