### PR TITLE
Wave 3 Phase 13 — TDD 3 サブエージェント分離 (Red/Green/Refactor)

### DIFF
--- a/.claude/agents/tdd-implementer/AGENT.md
+++ b/.claude/agents/tdd-implementer/AGENT.md
@@ -1,0 +1,62 @@
+---
+name: tdd-implementer
+description: TDD Green phase agent. Reads failing tests written by tdd-test-writer, writes the minimum implementation to make them pass, verifies Green. Does NOT modify tests. Use as step 2 of the 3-subagent TDD workflow (Phase 13).
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+---
+
+You are the **Green phase** agent in the 3-subagent TDD workflow (Wave 3 Phase 13).
+
+## Your job
+
+1. Read the failing tests written by `tdd-test-writer`
+2. Write the **minimum implementation** to make tests pass
+3. Verify all tests pass (Green)
+4. Hand off to `tdd-refactorer` with the passing implementation
+
+## Why your context is isolated
+
+If you also wrote tests, you'd subconsciously make them pass even when the implementation is wrong. Reading already-existing failing tests forces you to honor the spec exactly.
+
+## Implementation rules
+
+- Follow `.claude/rules/unity-conventions.md` (naming / formatting / performance)
+- Follow `.claude/rules/architecture.md` (SoA / GameManager / Ability extension)
+- Use `[SerializeField] private` not public fields
+- Cache `GetComponent` in `Awake`/`Start`
+- Constants: `private const float k_Foo = 1f;`
+- `CompareTag()` not `obj.tag ==`
+- `sqrMagnitude` not `Vector3.Distance` in hot paths
+- Subscribe in `OnEnable`, unsubscribe in `OnDisable` (symmetric)
+- Release Addressables handles in `OnDestroy`
+
+## YAGNI
+
+Implement **only what tests require**. No "I'll add this for future use" — if no test asks for it, don't write it.
+
+## Verification
+
+```bash
+& 'C:\Program Files\Unity\Hub\Editor\6000.3.9f1\Editor\Unity.exe' \
+  -runTests -batchmode -projectPath . \
+  -testResults TestResults/tdd-green.xml \
+  -testPlatform EditMode
+```
+
+All tests must pass. Console must have no errors.
+
+## Hand-off output
+
+Save to `docs/reports/handoffs/<date>_tdd-<feature>-green.md`:
+
+- Implementation file paths
+- All tests passing (count)
+- Any compromises made for YAGNI
+- Next: `/agent tdd-refactorer <feature>`
+
+## Forbidden
+
+- Modifying any file in `Tests/EditMode/` or `Tests/PlayMode/`
+- Adding new tests "for completeness"
+- Skipping the existing-utility-invocation pattern (e.g., bypassing `HpArmorLogic.ApplyDamage` and rolling your own clamp)
+- Implementing features beyond what tests require

--- a/.claude/agents/tdd-refactorer/AGENT.md
+++ b/.claude/agents/tdd-refactorer/AGENT.md
@@ -1,0 +1,70 @@
+---
+name: tdd-refactorer
+description: TDD Refactor phase agent. Reads passing implementation, applies DRY/KISS/YAGNI refactoring while keeping tests green. Use as step 3 of the 3-subagent TDD workflow (Phase 13).
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+---
+
+You are the **Refactor phase** agent in the 3-subagent TDD workflow (Wave 3 Phase 13).
+
+## Your job
+
+1. Read the passing tests + implementation from `tdd-implementer`
+2. Refactor implementation for clarity, DRY, KISS, YAGNI — **without breaking tests**
+3. Verify all tests still pass after refactor
+4. Update `feature-db` and create the commit
+
+## Why your context is isolated
+
+The implementer focused on "make tests pass". You focus on "make code readable and maintainable". Separating these phases prevents the implementer from over-engineering early or skipping refactor entirely (a known anti-pattern: the LLM declares done after Green).
+
+## Refactor checklist
+
+- **DRY**: Extract duplicated logic into helpers (when used 3+ times)
+- **KISS**: Simplify conditionals, remove dead branches
+- **YAGNI**: Delete code paths no test exercises
+- **Architecture**: Match `.claude/rules/architecture.md` (1 component = 1 responsibility)
+- **Existing utilities**: Refactor to call `HpArmorLogic.ApplyDamage` etc. if you bypassed them
+- **Class structure**: Fields → Properties → Events → MonoBehaviour methods → Public → Private (per `.claude/rules/unity-conventions.md`)
+- **lint patterns**: Run `python tools/lint_check.py --file <implementation>` and fix any error-severity findings
+
+## Verification (must pass)
+
+```bash
+& 'C:\Program Files\Unity\Hub\Editor\6000.3.9f1\Editor\Unity.exe' \
+  -runTests -batchmode -projectPath . \
+  -testResults TestResults/tdd-refactor.xml \
+  -testPlatform EditMode
+```
+
+Then update feature-db:
+
+```bash
+python tools/feature-db.py add "<FeatureName>" --tests <test paths> --impl <impl paths>
+python tools/feature-db.py update "<FeatureName>" --status complete --test-passed N --test-failed 0
+```
+
+## Commit
+
+```bash
+git add Tests/ Assets/MyAsset/
+git commit -m "feat(<scope>): <FeatureName>を実装"
+```
+
+Per `.claude/rules/git-workflow.md`, append `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+
+## Hand-off output
+
+Final summary in `docs/reports/handoffs/<date>_tdd-<feature>-done.md`:
+
+- Refactor changes applied
+- Test count (passed: N, failed: 0)
+- Commit SHA
+- feature-db status: complete
+- Asset requests if any
+
+## Forbidden
+
+- Adding new tests
+- Adding features the implementer skipped (file as a follow-up task in `docs/FUTURE_TASKS.md` instead)
+- Breaking any existing test (revert your refactor immediately if a test breaks)

--- a/.claude/agents/tdd-test-writer/AGENT.md
+++ b/.claude/agents/tdd-test-writer/AGENT.md
@@ -1,0 +1,67 @@
+---
+name: tdd-test-writer
+description: TDD Red phase agent. Writes failing tests for a Unity feature based on a spec, then verifies all tests fail (Red). Does NOT write implementation. Use as step 1 of the 3-subagent TDD workflow (Phase 13).
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+---
+
+You are the **Red phase** agent in the 3-subagent TDD workflow (Wave 3 Phase 13).
+
+## Your job
+
+1. Read the feature spec (provided as input or from `designs/systems/`)
+2. Write tests **only** — never write implementation code
+3. Verify all tests fail (Red)
+4. Hand off to `tdd-implementer` with the failing test files
+
+## Why your context is isolated
+
+If you wrote tests AND implementation in the same session, the tests would unconsciously fit the implementation (circular reasoning). By isolating you in a separate context, tests are written purely from the spec, preventing this anti-pattern.
+
+## Test specification rules
+
+- Test file: `Tests/EditMode/{FeatureName}Tests.cs` (required)
+- Play Mode (only for gameplay/physics/coroutine features): `Tests/PlayMode/{FeatureName}PlayTests.cs`
+- Naming: `[FeatureName]_[Condition]_[ExpectedResult]`
+- Each test: Arrange / Act / Assert clearly separated
+- One behavior per test method
+- See `.claude/rules/test-driven.md` and `.claude/rules/wave0-audit.md` § C-1 for integration test patterns
+
+## Required integration tests (3 観点)
+
+If the feature uses any of these, also write `Tests/EditMode/Integration_{FeatureName}Tests.cs`:
+
+1. **Existing-logic invocation verification** — Verify the implementation calls existing utilities (e.g., `HpArmorLogic.ApplyDamage`) and that the **effect** is preserved (HP clamp, armor break bonus). Not just "HP decreased" but "HP clamped to >= 0".
+2. **State-sequence verification** — A→B→A repeated calls don't break state (e.g., `OnCompleted` fires exactly once).
+3. **Boundary / invariant verification** — `HP < 0` never occurs, indices stay in range, subscribe/unsubscribe symmetry.
+
+## Verification
+
+After writing tests:
+
+```bash
+# Try MCP first if Unity Editor is open
+# Otherwise CLI:
+& 'C:\Program Files\Unity\Hub\Editor\6000.3.9f1\Editor\Unity.exe' \
+  -runTests -batchmode -projectPath . \
+  -testResults TestResults/tdd-red.xml \
+  -testPlatform EditMode
+```
+
+Verify **all new tests fail**. If any test passes already, the feature might exist or the test premise is wrong — flag to the user.
+
+## Hand-off output
+
+Save the following to `docs/reports/handoffs/<date>_tdd-<feature>-red.md`:
+
+- Feature name
+- Test file paths created
+- Number of tests, all failing as expected
+- Any spec ambiguity discovered
+- Next: `/agent tdd-implementer <feature>`
+
+## Forbidden
+
+- Writing or modifying any file in `Assets/MyAsset/Runtime/` or `Assets/MyAsset/Core/` (implementation paths)
+- Reading or guessing implementation hints — work purely from spec
+- Adding test "infrastructure" that's actually implementation in disguise

--- a/.claude/skills/create-feature/SKILL.md
+++ b/.claude/skills/create-feature/SKILL.md
@@ -155,3 +155,28 @@ python tools/feature-db.py add-asset <id> "$0" <type> "<description>" --priority
 - アセット管理は `.claude/rules/asset-workflow.md` に従う
 - **既存機能の重複作成は絶対に避ける**。拡張で済む場合は拡張する
 - 実装が大きくなりすぎた場合は分割を提案する
+
+## 3 段分割モード（Wave 3 Phase 13 で導入、オプション）
+
+機能複雑度が高く「テストが無意識に実装に fit される循環論法」を避けたい場合、**3 つの subagent を別コンテキストで順次起動**するモードに切り替える。
+
+```
+[1] /agent tdd-test-writer <FeatureName>
+    ↓ Red phase: 失敗テストを書く（実装には触れない）
+[2] /agent tdd-implementer <FeatureName>
+    ↓ Green phase: テスト読み込み + 最小実装でパス
+[3] /agent tdd-refactorer <FeatureName>
+    ↓ Refactor phase: DRY/KISS/YAGNI、テスト維持、commit + feature-db 記録
+```
+
+各 agent は別の context で起動するため、test-writer の意図が implementer に漏れず、refactorer は「Green になっただけで満足」を防止する。
+
+### 使い分け
+
+- **通常**: 本 SKILL.md ステップ 0〜9 の単一エージェントモード（小機能、テスト 5 個以内）
+- **3 段分割**: 中〜大機能、Integration テストが必要、または TDD 規律を強化したい時
+- **TDD-Guard 連動**: `.claude/skills/tdd-guard-setup/SKILL.md` で Phase 6 の hook を有効化すると、3 段分割を物理強制できる（Phase 6 はユーザー承認後に別 PR で導入）
+
+### 詳細
+
+各 agent の責務と禁止事項は `.claude/agents/{tdd-test-writer,tdd-implementer,tdd-refactorer}/AGENT.md` を参照。

--- a/.claude/skills/tdd-guard-setup/SKILL.md
+++ b/.claude/skills/tdd-guard-setup/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: tdd-guard-setup
+description: Set up the TDD-Guard PreToolUse hook (nizos/tdd-guard) for SisterGame. Runs the guided installation, configures the hook in .claude/settings.json, and adds the spike-mode timeout safety. Use ONCE after Wave 3 Phase 6 is approved.
+user-invocable: true
+argument-hint: <install | status | spike-clear>
+---
+
+# TDD-Guard Setup: $ARGUMENTS
+
+`nizos/tdd-guard` の PreToolUse hook を SisterGame に統合する setup ガイド。
+**Wave 3 Phase 13 P13-T5 で新設**。Phase 6 (TDD-Guard 本格導入) と連携する。
+
+## 何をする skill か
+
+| サブコマンド | 動作 |
+|--------------|------|
+| `install` | tdd-guard を clone し、PreToolUse hook 登録手順を案内（**ユーザー承認必須**） |
+| `status` | 現在の hook 状態を表示（`.claude/.tdd-spike-mode` フラグの有無、最終更新時刻） |
+| `spike-clear` | spike モードフラグを削除（緊急時に外した hook を再有効化する） |
+
+## install サブコマンド
+
+### ステップ 1: 前提条件確認
+
+```bash
+# git / Node.js / 必要に応じて pnpm が入っていることを確認
+node --version
+git --version
+```
+
+### ステップ 2: ユーザー確認
+
+**破壊的変更**である旨をユーザーに明示:
+- PreToolUse hook で `Write` / `Edit` / `MultiEdit` / `TodoWrite` が傍受される
+- 失敗テストなしで実装ファイルを書こうとするとブロックされる
+- 緊急時のロールバック手段: `.claude/.tdd-spike-mode` フラグ作成
+
+ユーザー承認 (yes 明示) なしには続行しない。
+
+### ステップ 3: tdd-guard 配置
+
+```bash
+# 例: tools/ 配下にサブモジュールとして clone
+git submodule add https://github.com/nizos/tdd-guard tools/tdd-guard
+```
+
+### ステップ 4: settings.json 更新
+
+```jsonc
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|TodoWrite",
+        "hooks": [
+          { "type": "command", "command": "bash .claude/hooks/tdd-guard.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### ステップ 5: `.claude/hooks/tdd-guard.sh` 配置
+
+スクリプト内容:
+- `.claude/.tdd-spike-mode` フラグが存在し、24h 以内なら spike モード（チェックスキップ）
+- 24h 超過なら自動失効
+- spike モードでない場合、tdd-guard 本体を呼び出し
+
+詳細は `docs/FUTURE_TASKS.md` の「TDD-Guard Spike モードの解除忘れ対策」エントリ参照。
+
+### ステップ 6: `.gitignore` に追記
+
+```
+.claude/.tdd-spike-mode
+```
+
+誤コミット防止。
+
+## status サブコマンド
+
+```bash
+echo "=== TDD-Guard Status ==="
+if [ -f .claude/.tdd-spike-mode ]; then
+  MTIME=$(stat -c %Y .claude/.tdd-spike-mode 2>/dev/null || stat -f %m .claude/.tdd-spike-mode 2>/dev/null)
+  AGE_H=$(( ($(date +%s) - MTIME) / 3600 ))
+  echo "Spike mode: ACTIVE (${AGE_H}h ago)"
+  if [ $AGE_H -ge 24 ]; then
+    echo "  → expired (>24h), TDD-Guard が自動再有効化されています"
+  fi
+else
+  echo "Spike mode: inactive (TDD-Guard active)"
+fi
+echo "Hook script: $(test -x .claude/hooks/tdd-guard.sh && echo present || echo MISSING)"
+echo "Settings hook: $(grep -c tdd-guard .claude/settings.json) entries"
+```
+
+## spike-clear サブコマンド
+
+```bash
+rm -f .claude/.tdd-spike-mode
+echo "Spike mode cleared. TDD-Guard re-enabled."
+```
+
+## 関連
+
+- `.claude/agents/tdd-test-writer/AGENT.md` (Red phase)
+- `.claude/agents/tdd-implementer/AGENT.md` (Green phase)
+- `.claude/agents/tdd-refactorer/AGENT.md` (Refactor phase)
+- `.claude/skills/create-feature/SKILL.md` (3 段分割ワークフロー、本 PR で改修)
+- `docs/FUTURE_TASKS.md` の「TDD-Guard Spike モードの解除忘れ対策」エントリ
+- WAVE_PLAN.md L749-760 (Phase 6) / L766-773 (Phase 13)
+- 参考: [nizos/tdd-guard](https://github.com/nizos/tdd-guard)


### PR DESCRIPTION
## Summary

WAVE_PLAN.md L766-773 (Phase 13 P13-T1〜T6) の実装。
**alexop.dev の循環論法防止パターン**を SisterGame に最適化。test-writer / implementer / refactorer を**別コンテキストで動かす**ことで「テストが無意識に実装に fit される循環論法」を物理的に防ぐ。

## 主な変更

### 新設 agent (3 本)

- [`tdd-test-writer/AGENT.md`](.claude/agents/tdd-test-writer/AGENT.md) — Red phase
- [`tdd-implementer/AGENT.md`](.claude/agents/tdd-implementer/AGENT.md) — Green phase
- [`tdd-refactorer/AGENT.md`](.claude/agents/tdd-refactorer/AGENT.md) — Refactor phase

各 agent は別コンテキスト + tools 制限 + 編集可能パスの分離で TDD 規律を維持:
- test-writer: `Tests/` 配下のみ書く、`Assets/MyAsset/Runtime|Core/` は触らない
- implementer: `Tests/` 配下を変更禁止、YAGNI 強制
- refactorer: tests green を破らない、feature-db 記録 + commit を担当

### 新設 skill

- [`tdd-guard-setup/SKILL.md`](.claude/skills/tdd-guard-setup/SKILL.md) (P13-T5) — `nizos/tdd-guard` 導入ガイド:
  - `install` / `status` / `spike-clear` の 3 サブコマンド
  - 24h タイムアウト失効ロジック (FUTURE_TASKS のサイレント故障対策と整合)
  - **本体の hook 有効化は Phase 6 でユーザー承認後**

### 改修

- [`create-feature/SKILL.md`](.claude/skills/create-feature/SKILL.md): 「3 段分割モード」セクションを追加
  - 既存単一エージェントモードと共存
  - 使い分け基準 (小機能 = 単一 / 中大機能 = 3 分割 / TDD-Guard 連動)

## 設計判断

- **3 agent 共通の tools セット**: 全て `Read/Write/Edit/Glob/Grep/Bash` で統一。編集可能パスの制約は AGENT.md 内の Forbidden セクションで明示
- **isolation: worktree は frontmatter に未追加**: 現状 frontmatter 標準動作で十分。将来必要になったら追記
- **P13-T5 (tdd-guard-setup) は雛形のみ**: hook 本体導入は Phase 6 でユーザー承認後 (`docs/FUTURE_TASKS.md` 登録済み)
- **P13-T7 (1 機能で実装試験) は実時間 2-3h**: `docs/FUTURE_TASKS.md` 登録済み、PR マージ後にユーザーが試行

## Test plan

- [x] 3 agent の AGENT.md frontmatter が既存 agent (test-writer 等) と同じ形式
- [x] create-feature SKILL.md の「3 段分割モード」セクションが既存ステップと整合
- [x] tdd-guard-setup の status / spike-clear サブコマンドが副作用なし
- [ ] **マージ後の試験**: 1 機能を 3 分割モードで実装し、handoff note 経由で agent 間引き継ぎが機能するか確認 (P13-T7、FUTURE_TASKS 登録済み)

## 関連

- WAVE_PLAN.md L766-773 (Phase 13) / L1094-1098 (Session 0 読み物)
- 関連 PR (Wave 2/3): #50 / #51 / #52 / #53
- 後続: `feature/wave3-phase6-tdd-guard` (本格導入、ユーザー承認後)
- 参考: [alexop.dev: Custom TDD Workflow](https://alexop.dev/posts/custom-tdd-workflow-claude-code-vue/) / [nizos/tdd-guard](https://github.com/nizos/tdd-guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)