### PR TITLE
セッション終了 handoff note 配置 (2026-04-25)

### DIFF
--- a/docs/reports/_registry.md
+++ b/docs/reports/_registry.md
@@ -39,6 +39,7 @@
 
 <!-- 新規 handoff note を作成したら、ここに `- [YYYY-MM-DD タイトル](handoffs/YYYY-MM-DD_slug.md)` を最上部追加 -->
 
+- [2026-04-25 セッション終了 / ブロッカー対応 + 動作確認 + UniCli 実環境検証 完了](handoffs/2026-04-25_session-end-blockers-resolved.md) — resolved / branch: main
 - [2026-04-25 Wave 4 完了 / 最終 handoff](handoffs/2026-04-25_wave4-complete-final.md) — resolved / branch: feature/wave4-phase12-adversarial-review
 - [2026-04-25 Wave 3 完了 / Wave 4 着手前](handoffs/2026-04-25_wave3-complete-wave4-start.md) — in-progress / branch: main
 - [2026-04-25 Wave 2 Phase 17 implementation](handoffs/2026-04-25_wave2-phase17-handoff.md) — in-progress / branch: feature/wave2-phase17-handoff

--- a/docs/reports/handoffs/2026-04-25_session-end-blockers-resolved.md
+++ b/docs/reports/handoffs/2026-04-25_session-end-blockers-resolved.md
@@ -1,0 +1,83 @@
+---
+date: 2026-04-25
+session_topic: Wave 2-4 全 PR マージ + ブロッカー対応 + 動作確認 / UniCli 実環境検証 完了
+status: resolved
+branch: main
+related_pr: 58
+last_commit: 49e825c
+---
+
+## 現在地
+
+**全 9 PR マージ完了**:
+
+| PR | Wave | 内容 |
+|----|------|------|
+| #50 | 2 | Phase 10 Two-layer skill |
+| #51 | 2 | Phase 17 Registry-based handoff |
+| #52 | 2 | Phase 11 P11-T7 lint.md 成文化 |
+| #53 | 3 | Phase 5 skill lifecycle |
+| #54 | 3 | Phase 13 TDD 3 sub-agents |
+| #55 | 3 | Phase 22 Unity hooks (UniCli 最優先) |
+| #56 | 4 | Phase 15 cost / Advisor Strategy |
+| #57 | 4 | Phase 12 Adversarial Review |
+| #58 | - | ブロッカー対応（調査 + 仕様化 + 実装） |
+
+**動作確認結果（main で実施、本セッション末尾）**:
+- ✅ 9 hooks 全動作（Stop / SessionStart / lint / cost / Unity 4 種）
+- ✅ 5 Python tools 動作（skill-usage 改善版で誤検知 0、cost-aggregate で transcript→USD 換算成功）
+- ✅ 32 skills + 12 agents の frontmatter 整合
+- ✅ Advisor Strategy 反映（design-systems=opus / create-feature=sonnet）
+- ✅ UniCli backend **実環境動作確認** — `unicli exec Console.GetLog` / `Compile` 成功
+- ✅ `pre-build-validate.sh --dev` → 「compile OK, no console errors」を UniCli 経由で確認
+
+**ブロッカー対応の最終結果**:
+- Opus 利用可 → reviewer-skeptic は `model: opus` 維持
+- TDD-Guard 導入希望 → submodule 方式の手順書を `docs/reports/specs/` に配置
+- settings.json 変更（opusplan / 環境変数）→ 仕様化、コスト測定 1 週間後に反映
+- 外部 skill 輸入 → 6 候補再精査の結果、SisterGame アーキテクチャと衝突するため**全候補見送り**
+- /cost hook 仕様 → transcript_path 解析方式で実装完了
+- claude-mcp CLI → server 管理のみで unfit、UniCli 採用継続が確定
+- skill-usage.py 誤検知 → 3 段階判定に厳格化、誤検知 0
+
+## 次セッションでやること
+
+`docs/wave2-4-blockers.md` 「実時間タスク」セクションを参照。優先度順:
+
+1. **2026-05-02 以降**:
+   - **P11-T6**: lint hook 1 週間誤検知観察 → `lint-observation-log.md` に集計
+   - **P11-T8**: lint phase=error 昇格 PR
+   - **P15-T8**: 1 週間コスト計測 → `python tools/cost-report.py --period 7d`
+   - **P17-T9**: handoff registry 1 週間運用試験 → `docs/compound/` に効果測定エントリ
+2. **コスト測定後**:
+   - settings.json 変更（`/model opusplan` + 環境変数）→ `docs/reports/specs/2026-04-25_settings-cost-optimization.md` の手順で
+3. **任意**:
+   - **P13-T7**: TDD 3 分割で 1 機能実装試験（2-3h）
+   - **P12-T7**: 既存 PR で `/adversarial-review` 試行（2h）
+   - **Phase 6**: TDD-Guard 本格導入 → `docs/reports/specs/2026-04-25_tdd-guard-installation.md` の手順で別 PR
+4. **Wave 5 着手判定**:
+   - `docs/wave2-4-blockers.md` § 3 のチェックリストを通過したら Phase 7 から開始
+
+## 注意点・ブロッカー
+
+- **main 直 push は禁止**: 全変更は feature ブランチ + PR 経由
+- **UniCli は v1.2.2 + com.yucchiy.unicli-server インストール済**: Unity Editor 起動中なら即動作。CI / Editor 未起動時は Unity batch mode フォールバック設計済
+- **Opus 利用前提のコード**: reviewer-skeptic は `model: opus`。Anthropic plan が変わったら Sonnet にフォールバック検討
+- **skill registry**: 32 skills と多めだが、四半期棚卸し（`docs/SKILL_LIFECYCLE.md`、次回 2026-07-25）で剪定予定
+- **dream skill との Stop hook 競合**: 互いに別ファイル名空間（dream は `~/.claude/.../memory/`、handoff は `docs/reports/handoffs/`）で衝突なし
+
+## 関連ファイル
+
+- `docs/wave2-4-blockers.md` — 実時間タスク + Wave 5 着手前チェックリスト
+- `docs/WAVE_PLAN.md` — Wave 計画 source of truth
+- `docs/FUTURE_TASKS.md` — Wave 4 残タスクセクション + ブロッカー対応結論
+- `docs/reports/_registry.md` — 14 entries 索引
+- `docs/SKILL_LIFECYCLE.md` — 四半期棚卸しルーチン
+
+## 関連リソース
+
+- マージ済 PR: #50 〜 #58（全 9 本）
+- 本セッションで生成した skill: 9 本（handoff-note / resume-handoff / registry-check / writing-skills / tdd-guard-setup / cost-report / adversarial-review / review-parallel）
+- 本セッションで生成した agent: 5 本（tdd-test-writer / tdd-implementer / tdd-refactorer / reviewer-optimizer / reviewer-skeptic）
+- 本セッションで生成した tools: 2 本（skill-usage.py / cost-report.py / cost-aggregate.py）
+- handoff note 5 本（本ファイル含む）— 次セッションで `/registry-check` 起動時に直近 3 件が自動表示


### PR DESCRIPTION
## Summary

Phase 17 で導入した handoff-note 機能を活用したセッション終了スナップショット。
全 9 PR (#50-#58) マージ + ブロッカー対応 + UniCli 実環境検証 完了の状態を記録。

## 変更

- [`docs/reports/handoffs/2026-04-25_session-end-blockers-resolved.md`](docs/reports/handoffs/2026-04-25_session-end-blockers-resolved.md) — 新規 handoff entry
- [`docs/reports/_registry.md`](docs/reports/_registry.md) — 索引最上部に追記

## 効果

次セッション開始時、SessionStart hook (`session-start-registry.sh`) が直近 3 件の handoff note を frontmatter から自動抽出 → 本 entry が筆頭表示。
ユーザーは `/resume-handoff` でそのまま次のアクション（実時間タスク消化 or Wave 5 着手判定）に着手可能。

## マージ判断

軽量 doc PR。レビュー不要レベル。マージで OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)