### PR TITLE
chore(git): .claude/cost-log.jsonl を gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Thumbs.db
 # Claude Code
 .claude/settings.local.json
 .claude/plans/
+.claude/cost-log.jsonl
 
 # Build output
 TestResults.xml


### PR DESCRIPTION
セッション毎に hook が生成するローカルコスト記録ファイル
(tools/cost-report.py 用) をリポジトリから除外する。

https://claude.ai/code/session_01JbA1Fnhuy8tqDS4KRr4zTq