### PR TITLE
chore(unity): 既存 .cs ファイルの未追跡 .meta を一括追加

### DIFF
--- a/Assets/MyAsset/CLAUDE.md.meta
+++ b/Assets/MyAsset/CLAUDE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 32920c4a16f7c6d4c96e26da19583fc3
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Core/Movement/DropThroughLogic.cs.meta
+++ b/Assets/MyAsset/Core/Movement/DropThroughLogic.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8908408c6921fca45b8ac6cabdf1a3ab

--- a/Assets/MyAsset/Runtime/Collision/DropThroughPlatform.cs.meta
+++ b/Assets/MyAsset/Runtime/Collision/DropThroughPlatform.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8e10312bb64d0d74299993398af5d05c

--- a/Assets/Scenes/CLAUDE.md.meta
+++ b/Assets/Scenes/CLAUDE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d087e116393fe0f4b99b5c35976c04ee
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/CLAUDE.md.meta
+++ b/Assets/Tests/CLAUDE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 11071c03aa2b4884d8e11b5e2d5fd6e3
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/CoyoteTimeTests.cs.meta
+++ b/Assets/Tests/EditMode/CoyoteTimeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c53bc1dde53c3a44aa253f0f80ba9ac1

--- a/Assets/Tests/EditMode/DropThroughLogicTests.cs.meta
+++ b/Assets/Tests/EditMode/DropThroughLogicTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8ab34214211ed474f9eecb749b3377e1

--- a/Assets/Tests/EditMode/WallKickAlternationTests.cs.meta
+++ b/Assets/Tests/EditMode/WallKickAlternationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4e885dd8130e9924192a5b670e03ffc7


### PR DESCRIPTION
## Summary

- 実体 .cs / CLAUDE.md は tracked だが、対応する .meta が untracked のままになっていた不整合を解消
- git-workflow.md の「.meta セット管理」規約準拠 (アセット追加時は .meta も必ず一緒にコミット)
- Unity の GUID リンクをチーム間で安定させる

## 対象 .meta

- Assets/MyAsset/CLAUDE.md.meta
- Assets/MyAsset/Core/Movement/DropThroughLogic.cs.meta
- Assets/MyAsset/Runtime/Collision/DropThroughPlatform.cs.meta
- Assets/Scenes/CLAUDE.md.meta
- Assets/Tests/CLAUDE.md.meta
- Assets/Tests/EditMode/CoyoteTimeTests.cs.meta
- Assets/Tests/EditMode/DropThroughLogicTests.cs.meta
- Assets/Tests/EditMode/WallKickAlternationTests.cs.meta

## Test plan

- [x] git ls-files で対応する .cs / CLAUDE.md がすでに tracked であることを確認済み
- [ ] レビュー: 8 ファイルの .meta が GUID 重複なく追加されているか
- [ ] Unity で開いて GUID リンク再生成が走らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)