### PR TITLE
feat(camera): 動的カメラ Bounds 切替を ProCamera2DRoomsAdapter で実装

### DIFF
--- a/Assets/MyAsset/GameCode.asmdef
+++ b/Assets/MyAsset/GameCode.asmdef
@@ -9,7 +9,8 @@
         "LitMotion",
         "LitMotion.Extensions",
         "com.rainyrizzle.anyportrait",
-        "Micosmo.SensorToolkit"
+        "Micosmo.SensorToolkit",
+        "ProCamera2D.Runtime"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/MyAsset/Runtime/Camera/ProCamera2DRoomsAdapter.cs
+++ b/Assets/MyAsset/Runtime/Camera/ProCamera2DRoomsAdapter.cs
@@ -1,0 +1,89 @@
+using System;
+using Com.LuisPedroFonseca.ProCamera2D;
+using Game.Core;
+using R3;
+using UnityEngine;
+
+namespace Game.Runtime
+{
+    /// <summary>
+    /// <see cref="GameEvents.OnAreaTransition"/> を購読し、
+    /// 同シーン上の <see cref="ProCamera2DRooms"/> に対して toAreaId と一致する Room ID で
+    /// <c>EnterRoom</c> を呼び出す動的 Bounds 切替アダプタ。
+    /// </summary>
+    /// <remarks>
+    /// 配置先: ProCamera2DRooms と同じ GameObject (Inspector で <see cref="_rooms"/> をアサイン)。
+    ///
+    /// Room ID 命名規則:
+    /// <list type="bullet">
+    ///   <item>Room.ID = エリアシーン名 (例: <c>Stage1_1</c>) で <see cref="LevelStreamingOrchestrator"/> の sceneName と揃える</item>
+    ///   <item>該当 ID の Room が登録されていなければ no-op (LastAreaTransitionWasNoop=true)。
+    ///         <see cref="ProCamera2DRooms.EnterRoom(string,bool,bool)"/> は未登録 ID で例外を投げるため
+    ///         事前に <see cref="ProCamera2DRooms.GetRoom"/> で存在確認してから呼ぶ</item>
+    /// </list>
+    ///
+    /// 設計判断:
+    /// <list type="bullet">
+    ///   <item>ProCamera2DRooms 未割当でも例外を出さない (テスト・最小シーン用)</item>
+    ///   <item>R3 購読は <see cref="OnEnable"/> / <see cref="OnDisable"/> で対称管理</item>
+    /// </list>
+    /// </remarks>
+    public class ProCamera2DRoomsAdapter : MonoBehaviour
+    {
+        [SerializeField] private ProCamera2DRooms _rooms;
+
+        private IDisposable _subscription;
+
+        /// <summary>
+        /// 直近の <see cref="HandleAreaTransition"/> が ProCamera2DRooms 未割当 / 空 ID /
+        /// 未登録 ID で no-op に終わったか。テスト・デバッグ向けのフラグ。
+        /// </summary>
+        public bool LastAreaTransitionWasNoop { get; private set; }
+
+        private void OnEnable()
+        {
+            if (GameManager.Events != null)
+            {
+                _subscription = GameManager.Events.OnAreaTransition
+                    .Subscribe(transition => HandleAreaTransition(transition.toAreaId));
+            }
+        }
+
+        private void OnDisable()
+        {
+            _subscription?.Dispose();
+            _subscription = null;
+        }
+
+        /// <summary>テスト専用: <see cref="LastAreaTransitionWasNoop"/> を初期状態に戻す。</summary>
+        public void ResetLastTransitionFlagForTest()
+        {
+            LastAreaTransitionWasNoop = false;
+        }
+
+        private void HandleAreaTransition(string toAreaId)
+        {
+            if (_rooms == null)
+            {
+                LastAreaTransitionWasNoop = true;
+                return;
+            }
+
+            if (string.IsNullOrEmpty(toAreaId))
+            {
+                LastAreaTransitionWasNoop = true;
+                return;
+            }
+
+            Room found = _rooms.GetRoom(toAreaId);
+            if (found == null)
+            {
+                LastAreaTransitionWasNoop = true;
+                return;
+            }
+
+            _rooms.EnterRoom(toAreaId);
+            LastAreaTransitionWasNoop = false;
+        }
+    }
+}

--- a/Assets/MyAsset/Runtime/Camera/ProCamera2DRoomsAdapter.cs.meta
+++ b/Assets/MyAsset/Runtime/Camera/ProCamera2DRoomsAdapter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ea6dc08542c908b4c899e944dcfacb40

--- a/Assets/Tests/PlayMode/ProCamera2DRoomsAdapterTests.cs
+++ b/Assets/Tests/PlayMode/ProCamera2DRoomsAdapterTests.cs
@@ -1,0 +1,91 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Game.Core;
+using Game.Runtime;
+
+namespace Game.Tests.PlayMode
+{
+    /// <summary>
+    /// ProCamera2DRoomsAdapter のテスト。
+    /// GameEvents.OnAreaTransition を購読し、ProCamera2DRooms.EnterRoom(toAreaId) に転送する。
+    /// 配置先 ProCamera2DRooms 不在 / Room ID 未登録 / 空 ID は no-op で安全動作することを検証する。
+    /// </summary>
+    public class ProCamera2DRoomsAdapterTests
+    {
+        private GameObject _gmObj;
+        private GameObject _adapterObj;
+        private ProCamera2DRoomsAdapter _adapter;
+
+        [UnitySetUp]
+        public IEnumerator Setup()
+        {
+            _gmObj = TestSceneHelper.CreateGameManager();
+            yield return null;
+
+            _adapterObj = new GameObject("TestProCameraRoomsAdapter");
+            _adapter = _adapterObj.AddComponent<ProCamera2DRoomsAdapter>();
+            yield return null;
+        }
+
+        [UnityTearDown]
+        public IEnumerator TearDown()
+        {
+            if (_adapterObj != null)
+            {
+                Object.Destroy(_adapterObj);
+            }
+            if (_gmObj != null)
+            {
+                Object.Destroy(_gmObj);
+            }
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ProCamera2DRoomsAdapter_WhenAreaTransitionFiredAndRoomsNotAssigned_DoesNotThrowAndFlagsNoop()
+        {
+            // ProCamera2DRooms 未割当の環境では Adapter は no-op で動く必要がある
+            Assert.DoesNotThrow(() =>
+                GameManager.Events.FireAreaTransition("Persistent", "Stage1_1"),
+                "ProCamera2DRooms 未割当時でも Fire が例外を出さない");
+
+            yield return null;
+
+            Assert.IsTrue(_adapter.LastAreaTransitionWasNoop,
+                "ProCamera2DRooms 未割当時は LastAreaTransitionWasNoop=true で no-op 扱い");
+        }
+
+        [UnityTest]
+        public IEnumerator ProCamera2DRoomsAdapter_WhenToAreaIdEmpty_FlagsNoop()
+        {
+            // toAreaId 空文字も no-op (FlagManager と同じ防御)
+            GameManager.Events.FireAreaTransition("Persistent", "");
+            yield return null;
+
+            Assert.IsTrue(_adapter.LastAreaTransitionWasNoop,
+                "toAreaId 空のときは no-op");
+        }
+
+        [UnityTest]
+        public IEnumerator ProCamera2DRoomsAdapter_WhenDisabledAndReenabled_SubscriptionToggles()
+        {
+            // OnEnable / OnDisable で購読/解除が対称であることを、無効化中の Fire が adapter に届かないことで確認する
+            _adapterObj.SetActive(true);
+            yield return null;
+            GameManager.Events.FireAreaTransition("Persistent", "Stage1_1");
+            yield return null;
+            Assert.IsTrue(_adapter.LastAreaTransitionWasNoop,
+                "enable 中の発火は受信される (no-op だが受信)");
+
+            _adapterObj.SetActive(false);
+            yield return null;
+            _adapter.ResetLastTransitionFlagForTest();
+            GameManager.Events.FireAreaTransition("Persistent", "Stage1_2");
+            yield return null;
+            Assert.IsFalse(_adapter.LastAreaTransitionWasNoop,
+                "OnDisable 後の Fire は購読解除済みなので flag は false のまま");
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/ProCamera2DRoomsAdapterTests.cs.meta
+++ b/Assets/Tests/PlayMode/ProCamera2DRoomsAdapterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8b1533bbbb2cf9e4cab488f924fa5a64


### PR DESCRIPTION
## Summary

ProCamera2D 導入を受けて、エリア遷移時のカメラ範囲切替を `ProCamera2DRooms` ベースで実装。`GameEvents.OnAreaTransition` を購読し、toAreaId と一致する Room ID で `ProCamera2DRooms.EnterRoom` を呼ぶ。

- `ProCamera2DRoomsAdapter.cs` 新設
- Room ID 命名規則: エリアシーン名と揃える (例: `"Stage1_1"`)
- `ProCamera2DRooms` 未割当 / 空 ID / 未登録 ID は no-op (例外を出さない)
- `GameCode.asmdef` に `ProCamera2D.Runtime` 参照追加 (PR #86 と同じ依存。マージ順次第で重複変更になる場合あり)

## 残タスク (本 PR の scope 外)

- 各エリアの Room 設定 (Inspector で Dimensions / TransitionDuration 等を編集)
- Adapter の `_rooms` フィールドアサイン (Camera Prefab 上で)

実機調整が必要なため別タスクに残置 (FUTURE_TASKS L457 残)。

## Test plan

- [x] PlayMode `ProCamera2DRoomsAdapterTests` 3/3 pass:
  - `WhenAreaTransitionFiredAndRoomsNotAssigned_DoesNotThrowAndFlagsNoop`
  - `WhenToAreaIdEmpty_FlagsNoop`
  - `WhenDisabledAndReenabled_SubscriptionToggles`
- [ ] レビュー: PR #86 とのマージ順 (asmdef 参照追加が重複)

🤖 Generated with [Claude Code](https://claude.com/claude-code)