### PR TITLE
fix(save): SaveManager.Load のスロット切替で前 state 引きずりを修正 (Issue #80 L2)

### DIFF
--- a/Assets/MyAsset/Core/Common/Interfaces.cs
+++ b/Assets/MyAsset/Core/Common/Interfaces.cs
@@ -35,6 +35,13 @@ namespace Game.Core
     {
         string SaveId { get; }
         object Serialize();
+
+        /// <summary>
+        /// セーブデータからインスタンス状態を復元する。
+        /// 契約 (Issue #80 L2): <paramref name="data"/> が null の場合は「対象スロットに entry が無い」を意味し、
+        /// 内部状態を**初期状態にリセット**しなければならない。これにより SaveManager.Load 時にスロット切替で
+        /// 前 state を引きずらないことを保証する。
+        /// </summary>
         void Deserialize(object data);
     }
 

--- a/Assets/MyAsset/Core/Economy/CurrencyManager.cs
+++ b/Assets/MyAsset/Core/Economy/CurrencyManager.cs
@@ -85,6 +85,13 @@ namespace Game.Core
 
         void ISaveable.Deserialize(object data)
         {
+            // Issue #80 L2: data == null はスロットに entry 無し → 初期状態 (残高 0) にリセット。
+            if (data == null)
+            {
+                DeserializeBalance(0);
+                return;
+            }
+
             int balance = Convert.ToInt32(data);
             DeserializeBalance(balance);
         }

--- a/Assets/MyAsset/Core/LevelUp/LevelUpLogic.cs
+++ b/Assets/MyAsset/Core/LevelUp/LevelUpLogic.cs
@@ -333,6 +333,17 @@ namespace Game.Core
 
         void ISaveable.Deserialize(object data)
         {
+            // Issue #80 L2: data == null はスロットに entry 無し → 初期状態にリセット。
+            // (コンストラクタの初期値: level=1, exp=0, points=0, stats=default)
+            if (data == null)
+            {
+                _level = 1;
+                _currentExp = 0;
+                _availablePoints = 0;
+                _allocatedStats = default;
+                return;
+            }
+
             LevelUpSaveData saveData;
             if (data is LevelUpSaveData direct)
             {

--- a/Assets/MyAsset/Core/Save/FlagManager.cs
+++ b/Assets/MyAsset/Core/Save/FlagManager.cs
@@ -129,6 +129,15 @@ namespace Game.Core
 
         void ISaveable.Deserialize(object data)
         {
+            // Issue #80 L2: data == null はスロットに entry 無し → 初期状態にリセット。
+            if (data == null)
+            {
+                _globalFlags.Clear();
+                _mapLocalFlags.Clear();
+                _currentMapId = null;
+                return;
+            }
+
             FlagSaveData saveData;
             if (data is FlagSaveData direct)
             {

--- a/Assets/MyAsset/Core/Save/SaveManager.cs
+++ b/Assets/MyAsset/Core/Save/SaveManager.cs
@@ -108,10 +108,13 @@ namespace Game.Core
             for (int i = 0; i < _saveables.Count; i++)
             {
                 ISaveable saveable = _saveables[i];
-                if (slotData.entries.TryGetValue(saveable.SaveId, out object data))
+                // Issue #80 L2: entry が無い場合も Deserialize(null) を呼んで初期状態にリセットさせる。
+                // ISaveable コントラクトにより data == null は「reset to default」を意味する。
+                if (!slotData.entries.TryGetValue(saveable.SaveId, out object data))
                 {
-                    saveable.Deserialize(data);
+                    data = null;
                 }
+                saveable.Deserialize(data);
             }
 
             _activeSlotIndex = slotIndex;

--- a/Assets/MyAsset/Core/World/Backtrack/BacktrackRewardManager.cs
+++ b/Assets/MyAsset/Core/World/Backtrack/BacktrackRewardManager.cs
@@ -192,6 +192,13 @@ namespace Game.Core
 
         void ISaveable.Deserialize(object data)
         {
+            // Issue #80 L2: data == null はスロットに entry 無し → 初期状態にリセット。
+            if (data == null)
+            {
+                _collectedRewards.Clear();
+                return;
+            }
+
             if (data is string[] ids)
             {
                 LoadCollectedIds(ids);

--- a/Assets/MyAsset/Core/World/Gate/GateRegistry.cs
+++ b/Assets/MyAsset/Core/World/Gate/GateRegistry.cs
@@ -73,6 +73,13 @@ namespace Game.Core
 
         void ISaveable.Deserialize(object data)
         {
+            // Issue #80 L2: data == null はスロットに entry 無し → 初期状態にリセット。
+            if (data == null)
+            {
+                _gateStates.Clear();
+                return;
+            }
+
             if (data is Dictionary<string, bool> gateData)
             {
                 DeserializeAll(gateData);

--- a/Assets/Tests/EditMode/Integration_SaveManagerLoadResetTests.cs
+++ b/Assets/Tests/EditMode/Integration_SaveManagerLoadResetTests.cs
@@ -1,0 +1,259 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Game.Core;
+
+namespace Game.Tests.EditMode
+{
+    /// <summary>
+    /// Issue #80 L2: SaveManager.Load 前 state 引きずり対策の結合テスト。
+    ///
+    /// 観点:
+    /// 1. 既存ロジック呼び出し検証 — SaveManager.Load が、ロード対象スロットに entry が無い ISaveable に対して
+    ///    Deserialize(null) を呼び出し、各実装が初期状態にリセットすることを保証する。
+    /// 2. 状態シーケンス検証 — スロット A → スロット B 切替で、A の state が B にリークしないこと。
+    /// 3. 境界値・不変条件 — 各 ISaveable 実装は Deserialize(null) を呼ばれてもエラーを投げず、
+    ///    内部コレクションが空 / 数値がデフォルト値にリセットされること。
+    /// </summary>
+    public class Integration_SaveManagerLoadResetTests
+    {
+        // ===== SaveManager: Deserialize(null) ディスパッチ =====
+
+        [Test]
+        public void SaveManager_Load_WhenSaveableHasNoEntry_CallsDeserializeWithNull()
+        {
+            SaveManager manager = new SaveManager();
+            ResetTrackingSaveable saveable = new ResetTrackingSaveable { SaveId = "tracker" };
+            manager.Register(saveable);
+
+            // 空のスロットを作成 (entries 内に "tracker" は存在しない)
+            SaveSlotData emptySlot = new SaveSlotData(0);
+            manager.SetSlotData(0, emptySlot);
+
+            manager.Load(0);
+
+            Assert.IsTrue(saveable.DeserializeCalled, "entry が無い ISaveable にも Deserialize が呼ばれること");
+            Assert.IsNull(saveable.LastReceivedData, "entry が無いとき Deserialize に null が渡されること");
+        }
+
+        [Test]
+        public void SaveManager_Load_AfterPriorLoad_ResetsMissingEntries()
+        {
+            // Slot 0 で値を持ち、Slot 1 では entry なし → Slot 0 → Slot 1 切替で reset されること
+            SaveManager manager = new SaveManager();
+            ResetTrackingSaveable saveable = new ResetTrackingSaveable { SaveId = "tracker" };
+            manager.Register(saveable);
+
+            SaveSlotData slot0 = new SaveSlotData(0);
+            slot0.entries["tracker"] = "PERSISTED_VALUE";
+            manager.SetSlotData(0, slot0);
+
+            SaveSlotData slot1 = new SaveSlotData(1);
+            manager.SetSlotData(1, slot1);
+
+            manager.Load(0);
+            Assert.AreEqual("PERSISTED_VALUE", saveable.LastReceivedData);
+
+            manager.Load(1);
+            Assert.IsNull(saveable.LastReceivedData,
+                "別スロット読み込み時、entry が無い saveable は前 state を引きずらず Deserialize(null) で reset");
+        }
+
+        [Test]
+        public void SaveManager_Load_WhenEntryExists_StillPassesActualData()
+        {
+            SaveManager manager = new SaveManager();
+            ResetTrackingSaveable saveable = new ResetTrackingSaveable { SaveId = "tracker" };
+            manager.Register(saveable);
+
+            SaveSlotData slot = new SaveSlotData(0);
+            slot.entries["tracker"] = "ACTUAL_DATA";
+            manager.SetSlotData(0, slot);
+
+            manager.Load(0);
+
+            Assert.AreEqual("ACTUAL_DATA", saveable.LastReceivedData);
+        }
+
+        // ===== 各 ISaveable 実装の Deserialize(null) リセット契約 =====
+
+        [Test]
+        public void CurrencyManager_DeserializeNull_ResetsBalanceToZero()
+        {
+            CurrencyManager currency = new CurrencyManager(500);
+            currency.Add(200);
+            ISaveable saveable = currency;
+
+            saveable.Deserialize(null);
+
+            Assert.AreEqual(0, currency.Balance);
+        }
+
+        [Test]
+        public void FlagManager_DeserializeNull_ClearsAllFlags()
+        {
+            FlagManager flags = new FlagManager();
+            flags.SetGlobalFlag("story_chapter1_done", true);
+            flags.SwitchMap("dungeon_a");
+            flags.SetLocalFlag("chest_opened", true);
+            ISaveable saveable = flags;
+
+            saveable.Deserialize(null);
+
+            Assert.IsFalse(flags.GetGlobalFlag("story_chapter1_done"));
+            Assert.IsNull(flags.CurrentMapId, "CurrentMapId も reset されること");
+            Assert.IsFalse(flags.GetLocalFlag("chest_opened"));
+        }
+
+        [Test]
+        public void GateRegistry_DeserializeNull_ClearsAllGates()
+        {
+            GateRegistry gates = new GateRegistry();
+            gates.Register("gate_a", true);
+            gates.Register("gate_b", true);
+            ISaveable saveable = gates;
+
+            saveable.Deserialize(null);
+
+            Assert.AreEqual(0, gates.Count, "Deserialize(null) で gate 状態が空になること");
+        }
+
+        [Test]
+        public void BacktrackRewardManager_DeserializeNull_ClearsCollectedRewards()
+        {
+            BacktrackRewardManager rewards = new BacktrackRewardManager();
+            rewards.MarkCollected("reward_a");
+            rewards.MarkCollected("reward_b");
+            ISaveable saveable = rewards;
+
+            saveable.Deserialize(null);
+
+            Assert.IsFalse(rewards.IsCollected("reward_a"));
+            Assert.IsFalse(rewards.IsCollected("reward_b"));
+        }
+
+        [Test]
+        public void LevelUpLogic_DeserializeNull_ResetsToInitialState()
+        {
+            LevelUpLogic logic = new LevelUpLogic(initialLevel: 5);
+            logic.AddExp(1000);
+            ISaveable saveable = logic;
+
+            saveable.Deserialize(null);
+
+            Assert.AreEqual(1, logic.Level, "level は 1 に reset");
+            Assert.AreEqual(0, logic.CurrentExp, "currentExp は 0 に reset");
+            Assert.AreEqual(0, logic.AvailablePoints, "availablePoints は 0 に reset");
+            Assert.AreEqual(default(StatModifier), logic.AllocatedStats, "allocatedStats は default に reset");
+        }
+
+        // ===== 既に正しく動作する実装の回帰ガード =====
+
+        [Test]
+        public void InventoryManager_DeserializeNull_ClearsItems()
+        {
+            InventoryManager inventory = new InventoryManager();
+            inventory.Add(1, ItemCategory.Consumable, 5, 10);
+            inventory.Add(2, ItemCategory.Material, 3, 99);
+            ISaveable saveable = inventory;
+
+            saveable.Deserialize(null);
+
+            Assert.AreEqual(0, inventory.ItemCount);
+        }
+
+        [Test]
+        public void ChallengeManager_DeserializeNull_ClearsUnlocks()
+        {
+            ChallengeManager challenges = new ChallengeManager();
+            challenges.UnlockChallenge("ch1");
+            challenges.UnlockChallenge("ch2");
+            ISaveable saveable = challenges;
+
+            saveable.Deserialize(null);
+
+            Assert.IsFalse(challenges.IsUnlocked("ch1"));
+            Assert.IsFalse(challenges.IsUnlocked("ch2"));
+        }
+
+        [Test]
+        public void LeaderboardManager_DeserializeNull_ClearsRecords()
+        {
+            LeaderboardManager board = new LeaderboardManager();
+            ChallengeResult result = new ChallengeResult
+            {
+                challengeId = "ch1",
+                state = ChallengeState.Completed,
+                score = 100,
+                clearTime = 60f,
+                rank = ChallengeRank.S,
+            };
+            board.UpdateRecord(result);
+            ISaveable saveable = board;
+
+            saveable.Deserialize(null);
+
+            LeaderboardEntry[] all = board.GetAllRecords();
+            Assert.AreEqual(0, all.Length);
+        }
+
+        [Test]
+        public void AITemplateManager_DeserializeNull_ClearsTemplates()
+        {
+            AITemplateManager templates = new AITemplateManager();
+            AITemplateData template = new AITemplateData
+            {
+                templateId = "t1",
+                templateName = "Aggressive",
+            };
+            templates.SaveTemplate(template);
+            ISaveable saveable = templates;
+
+            saveable.Deserialize(null);
+
+            Assert.IsNull(templates.GetTemplate("t1"));
+        }
+
+        // ===== 不変条件: Deserialize(null) は例外を投げない =====
+
+        [Test]
+        public void AllSaveables_DeserializeNull_DoesNotThrow()
+        {
+            ISaveable[] all = new ISaveable[]
+            {
+                new CurrencyManager(),
+                new FlagManager(),
+                new GateRegistry(),
+                new BacktrackRewardManager(),
+                new LevelUpLogic(),
+                new InventoryManager(),
+                new ChallengeManager(),
+                new LeaderboardManager(),
+                new AITemplateManager(),
+            };
+
+            for (int i = 0; i < all.Length; i++)
+            {
+                ISaveable target = all[i];
+                Assert.DoesNotThrow(() => target.Deserialize(null),
+                    $"{target.GetType().Name}.Deserialize(null) が例外を投げないこと");
+            }
+        }
+
+        // ===== test helpers =====
+
+        private class ResetTrackingSaveable : ISaveable
+        {
+            public string SaveId { get; set; }
+            public bool DeserializeCalled { get; private set; }
+            public object LastReceivedData { get; private set; }
+
+            public object Serialize() => LastReceivedData;
+
+            public void Deserialize(object data)
+            {
+                DeserializeCalled = true;
+                LastReceivedData = data;
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Integration_SaveManagerLoadResetTests.cs.meta
+++ b/Assets/Tests/EditMode/Integration_SaveManagerLoadResetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 086357f8d2ef46668bbba336effe80c3


### PR DESCRIPTION
## Summary

Issue #80 L2 への対応。SaveManager.Load でスロット切替時に前 state を引きずる問題を **`ISaveable.Deserialize(null)` = 初期状態リセット契約** で修正。

## 背景

`SaveManager.Load(slotIndex)` は `slotData.entries.TryGetValue` でデータが存在しない場合 `Deserialize` を呼ばず、既存 in-memory 状態がそのまま残っていた。スロット切替で前スロットの state を引きずる挙動。

例: スロット 0 (CurrencyManager 残高 500) → スロット 1 (CurrencyManager 未保存) を Load すると、残高 500 のままになる。

## 変更

### コントラクト追加
- `ISaveable.Deserialize(object data)` に **「`data == null` → 初期状態にリセット」** の契約を XML doc で明文化

### SaveManager
- `Load()` 内で entry が無い saveable に対しても `Deserialize(null)` を呼ぶ

### 4 実装に null ガード追加
- `FlagManager`: globalFlags / mapLocalFlags / currentMapId をクリア
- `GateRegistry`: gateStates をクリア
- `BacktrackRewardManager`: collectedRewards をクリア
- `LevelUpLogic`: level=1 / exp=0 / points=0 / stats=default に reset

### 1 実装は明示化
- `CurrencyManager`: 暗黙の `Convert.ToInt32(null) == 0` 依存を `if (data == null) return reset` で明示

### 既に正しい 4 実装は変更なし
`InventoryManager` / `ChallengeManager` / `LeaderboardManager` / `AITemplateManager` は「先に Clear → 型不一致なら no-op」パターンで既に reset 動作するため変更なし。

## Test plan

`Assets/Tests/EditMode/Integration_SaveManagerLoadResetTests.cs` (13 tests)

- [x] SaveManager が entry 無しの saveable に Deserialize(null) を渡すこと
- [x] スロット切替シナリオ: Slot0 (data) → Slot1 (entry無) で reset されること
- [x] 各 9 実装が Deserialize(null) で初期状態に戻ること
- [x] 全 9 ISaveable 実装で Deserialize(null) が例外を投げないこと
- [x] 既存 SaveSystem テストが回帰しないこと (`SaveManager_Load_RestoresData` 等)

## 関連

- Issue #80 L2
- 既存 PR #90 で L1/L4/L6 完了、L2 はスコープ外として残置 → 本 PR で対応
- 規約: `.claude/rules/architecture.md` § Core はピュアロジック / `.claude/rules/test-driven.md` § 結合テスト 3 観点

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8gPoStVWQrCVPYCfhx6Yo)_